### PR TITLE
Ranger loadout improvements & NCR Bloat role removal

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -657,9 +657,9 @@ Veteran Ranger
 	backpack_contents = list(
 		/obj/item/kitchen/knife/bowie=1, \
 		/obj/item/storage/survivalkit_aid_adv=1, \
-		/obj/item/storage/bag/money/small/ncr)
-		/obj/item/gun/ballistic/revolver/sequoia=1
-		/obj/item/ammo_box/c4570=3
+		/obj/item/storage/bag/money/small/ncr=1,
+		/obj/item/gun/ballistic/revolver/sequoia=1,
+		/obj/item/ammo_box/c4570=3)
 
 /datum/outfit/loadout/vrclassic
 	name = "Classic Veteran Ranger"
@@ -677,7 +677,8 @@ Veteran Ranger
 	name = "Brush Veteran Ranger"
 	suit_store = /obj/item/gun/ballistic/shotgun/automatic/hunting/brush
 	backpack_contents = list(
-		/obj/item/ammo_box/tube/c4570=3)
+		/obj/item/ammo_box/tube/c4570=3,
+		/obj/item/attachments/scope = 1)
 
 
 //NCR Ranger
@@ -738,8 +739,8 @@ Veteran Ranger
 	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/w308 = 3,
-		/obj/item/storage/survivalkit_aid=1
-		/obj/item/gun/ballistic/revolver/revolver45=1
+		/obj/item/storage/survivalkit_aid=1,
+		/obj/item/gun/ballistic/revolver/revolver45=1,
 		/obj/item/ammo_box/c45rev=3
 
 	)
@@ -752,9 +753,9 @@ Veteran Ranger
 	backpack_contents = list(
 		/obj/item/ammo_box/tube/m44 = 3,
 		/obj/item/melee/classic_baton/telescopic = 1,
-		/obj/item/storage/survivalkit_aid=1
-		/obj/item/attachments/scope=1
-		/obj/item/gun/ballistic/revolver/colt357=1
+		/obj/item/storage/survivalkit_aid=1,
+		/obj/item/attachments/scope=1,
+		/obj/item/gun/ballistic/revolver/colt357=1,
 		/obj/item/ammo_box/a357=3
 	)
 
@@ -768,9 +769,9 @@ Veteran Ranger
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m556/rifle/assault = 3,
 		/obj/item/clothing/head/helmet/f13/combat/ncr_patrol = 1,
-		/obj/item/storage/survivalkit_aid = 1
-		/obj/item/attachments/scope = 1
-		/obj/item/gun/ballistic/revolver/revolver44 = 1
+		/obj/item/storage/survivalkit_aid = 1,
+		/obj/item/attachments/scope = 1,
+		/obj/item/gun/ballistic/revolver/revolver44 = 1,
 		/obj/item/ammo_box/m44=3
 	)
 
@@ -785,8 +786,8 @@ Veteran Ranger
 		/obj/item/storage/fancy/ammobox/lethalshot = 1,
 		/obj/item/storage/fancy/ammobox/slugshot = 1,
 		/obj/item/clothing/head/helmet/f13/combat/ncr_patrol = 1,
-		/obj/item/storage/survivalkit_aid = 1
-		/obj/item/gun/ballistic/revolver/m29/snub=1
+		/obj/item/storage/survivalkit_aid = 1,
+		/obj/item/gun/ballistic/revolver/m29/snub=1,
 		/obj/item/ammo_box/a357=3
 	)
 
@@ -803,7 +804,7 @@ Veteran Ranger
 		/obj/item/clothing/accessory/armband/med/ncr = 1,
 		/obj/item/clothing/head/helmet/f13/combat/ncr_patrol = 1,
 		/obj/item/storage/survivalkit_aid_adv = 1,
-		/obj/item/book/granter/trait/chemistry = 1
-		/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1
+		/obj/item/book/granter/trait/chemistry = 1,
+		/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1,
 		/obj/item/ammo_box/magazine/m45=3
 	)

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -284,7 +284,7 @@ Sergeant First Class
 	neck 			= /obj/item/storage/belt/holster
 	ears 			= /obj/item/radio/headset/headset_ncr_com
 	suit 			= /obj/item/clothing/suit/armor/f13/ncrarmor/mantle/reinforced
-	head 			= /obj/item/clothing/head/f13/ncr
+	head 			= /obj/item/clothing/head/f13/ncr_campaign
 	suit_store		= /obj/item/gun/ballistic/automatic/service
 	belt			= /obj/item/storage/belt/military/assault/ncr
 	backpack_contents = list(
@@ -474,8 +474,8 @@ Trooper
 /datum/job/ncr/f13trooper
 	title = "NCR Trooper"
 	flag = F13TROOPER
-	total_positions = 6
-	spawn_positions = 6
+	total_positions = 8
+	spawn_positions = 8
 	description = "You are considered the backbone and workforce strength of the NCR Army. You answer to everyone above you in the chain of command, taking orders from your Sergeant directly and obeying all commands given by the Lieutenant."
 	supervisors = "Corporals and above"
 	selection_color = "#fff5cc"
@@ -509,8 +509,8 @@ Rear Echelon
 /datum/job/ncr/f13rearechelon
 	title = "NCR Rear Echelon"
 	flag = F13REARECHELON
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the support element sent to assist the Camp Miller garrison. You are essential specialized support staff to help sustain the base via supply or your specialized skills. You are not allowed to leave base unless given an explicit order by the CO or the current acting CO."
 	supervisors = "Corporals and above"
 	selection_color = "#fff5cc"
@@ -584,8 +584,8 @@ Trooper
 /datum/job/ncr/f13ncroffduty
 	title = "NCR Off-Duty"
 	flag = F13NCROFFDUTY
-	total_positions = 8
-	spawn_positions = 8
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are off-duty NCR-A personnel in the Yuma Region. Despite being out of uniform and off-duty you are still expected to follow NCR COMJ and represent the uniform properly. Failure to abide by this will result in disciplinary action."
 	supervisors = "All NCOs and COs"
 	selection_color = "#fff5cc"
@@ -658,6 +658,8 @@ Veteran Ranger
 		/obj/item/kitchen/knife/bowie=1, \
 		/obj/item/storage/survivalkit_aid_adv=1, \
 		/obj/item/storage/bag/money/small/ncr)
+		/obj/item/gun/ballistic/revolver/sequoia=1
+		/obj/item/ammo_box/c4570=3
 
 /datum/outfit/loadout/vrclassic
 	name = "Classic Veteran Ranger"
@@ -732,22 +734,28 @@ Veteran Ranger
 	name = "Recon Ranger"
 	suit =	/obj/item/clothing/suit/toggle/armor/f13/rangerrecon
 	belt =	/obj/item/storage/belt/military/reconbandolier
-	head = /obj/item/clothing/head/helmet/f13/combat/swat
-	suit_store = /obj/item/gun/ballistic/automatic/service/carbine
+	head = /obj/item/clothing/head/beret/ncr_recon_ranger
+	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m556/rifle/assault = 3,
+		/obj/item/ammo_box/magazine/w308 = 3,
 		/obj/item/storage/survivalkit_aid=1
+		/obj/item/gun/ballistic/revolver/revolver45=1
+		/obj/item/ammo_box/c45rev=3
+
 	)
 
 /datum/outfit/loadout/rangertrail
 	name = "Trail Ranger"
 	suit =	/obj/item/clothing/suit/armor/f13/trailranger
 	belt =	/obj/item/storage/belt/military/NCR_Bandolier
-	suit_store = /obj/item/gun/ballistic/automatic/m1garand
+	suit_store = /obj/item/gun/ballistic/shotgun/automatic/hunting/trail
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/garand308=3,
+		/obj/item/ammo_box/tube/m44 = 3,
 		/obj/item/melee/classic_baton/telescopic = 1,
 		/obj/item/storage/survivalkit_aid=1
+		/obj/item/attachments/scope=1
+		/obj/item/gun/ballistic/revolver/colt357=1
+		/obj/item/ammo_box/a357=3
 	)
 
 /datum/outfit/loadout/rangerpatrol
@@ -761,6 +769,9 @@ Veteran Ranger
 		/obj/item/ammo_box/magazine/m556/rifle/assault = 3,
 		/obj/item/clothing/head/helmet/f13/combat/ncr_patrol = 1,
 		/obj/item/storage/survivalkit_aid = 1
+		/obj/item/attachments/scope = 1
+		/obj/item/gun/ballistic/revolver/revolver44 = 1
+		/obj/item/ammo_box/m44=3
 	)
 
 /datum/outfit/loadout/rangerpatrolcqb
@@ -775,6 +786,8 @@ Veteran Ranger
 		/obj/item/storage/fancy/ammobox/slugshot = 1,
 		/obj/item/clothing/head/helmet/f13/combat/ncr_patrol = 1,
 		/obj/item/storage/survivalkit_aid = 1
+		/obj/item/gun/ballistic/revolver/m29/snub=1
+		/obj/item/ammo_box/a357=3
 	)
 
 /datum/outfit/loadout/rangermedic
@@ -783,12 +796,14 @@ Veteran Ranger
 	head = /obj/item/clothing/head/f13/ranger
 	uniform = /obj/item/clothing/under/f13/ranger/patrol
 	belt =	/obj/item/storage/belt/military/assault/ncr
-	suit_store = /obj/item/gun/ballistic/automatic/m1carbine/compact
+	suit_store = /obj/item/gun/ballistic/automatic/smg10mm
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m10mm_adv/simple = 3,
+		/obj/item/ammo_box/magazine/m10mm_adv/ = 3,
 		/obj/item/storage/firstaid/ancient = 1,
 		/obj/item/clothing/accessory/armband/med/ncr = 1,
 		/obj/item/clothing/head/helmet/f13/combat/ncr_patrol = 1,
 		/obj/item/storage/survivalkit_aid_adv = 1,
 		/obj/item/book/granter/trait/chemistry = 1
+		/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1
+		/obj/item/ammo_box/magazine/m45=3
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Previously the NCR Ranger kits were in a sad state, armed with bad guns and unscoped weapons rangers couldn't do their jobs. and everyone I spoke too disliked the ranger kits so i took it upon myself to improve them. as well i removed roles that almost nobody played and served no purpose.
Detailed loadout edits
Veteran Ranger: Given the sequoia back as its an iconic weapon and vet ranger was lacking short or medium range weaponry
Brush Vet Ranger: Given a scope so they can snipe
Recon Ranger: Scout Carbine replaced with sniper rifle so you can now more effectively recon and snipe. given 45 Colt Revolver as sidearm
Trail Ranger: Given a Scoped trail carbine as it fits the loadout very well and gives improved sniping/recon ability. 357 Magnum Revolver as sidearm
Patrol Ranger: Scout carbine given a scope for sniping/recon and given a .44 Magnum Revolver as a sidearm
CQB Ranger: Given a Snub-nosed 44 Magnum as sidearm for close quarters fighting
Medic Ranger: I Couldn't think of what to give them as a primary so I settled on a 10mm Submachine gun so they can defend their patients in the field and themselves. Compact 1911 as sidearm
Off Duty NCR and Rear Echelon: these roles served no purpose in game and were played by very few.
Sargent First Class: Given a Campaign hat to differentiate them from the common grunt. and so you dont have to select it in loadout anymore

## Why It's Good For The Game
This allows rangers to do their jobs as Snipers & Scouts and better differentiate kits. bloat roles served no purpose and were only used by people respawn rushing after thier base was attacked and all other slots taken
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Tweak: Veteran Ranger given ranger sequoia and brush gun kit given scope
Tweak: All ranger kits given pistols
Balance: Rear echelon & off duty NCR roles disabled by setting slots to 0.
Balance: NCR Trooper Slots Increased by 2 to make up for loss of total NCR slots with bloat role removal
Tweak: Trail, Recon & Medic ranger primaries replaced
Tweak: Recon, Trail & Patrol Ranger kits given scopes
Tweak: SFC Given Campaign hat by default
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
