### PR TITLE
Several changes to the NCR Citizen loadout

### DIFF
--- a/code/modules/clothing/under/f13.dm
+++ b/code/modules/clothing/under/f13.dm
@@ -90,9 +90,9 @@
 	item_state = "ncr_shorts"
 	item_color = "ncr_shorts"
 
-/obj/item/clothing/under/f13/caravaneer
-	name = "caravaneer outfit"
-	desc = "A soft outfit used by NCR caravaneers."
+/obj/item/clothing/under/f13/ncrcaravan
+	name = "NCR caravaneer outfit"
+	desc = "A soft outfit commonly worn by NCR caravaneers."
 	icon_state = "caravaneer"
 	item_state = "caravaneer"
 	item_color = "caravaneer"

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -521,13 +521,13 @@ Raider
 	access = list()		//we can expand on this and make alterations as people suggest different loadouts
 	minimal_access = list()
 	loadout_options = list(
-	/datum/outfit/loadout/vault_refugee, 
-	/datum/outfit/loadout/salvager, 
-	/datum/outfit/loadout/medic, 
-	/datum/outfit/loadout/merchant, 
-	/datum/outfit/loadout/scavenger, 
-	/datum/outfit/loadout/citizen, 
-	/datum/outfit/loadout/slave)
+	/datum/outfit/loadout/vault_refugee,
+	/datum/outfit/loadout/salvager,
+	/datum/outfit/loadout/medic,
+	/datum/outfit/loadout/merchant,
+	/datum/outfit/loadout/scavenger,
+	/datum/outfit/loadout/citizen,
+	/datum/outfit/loadout/ncrcitizen)
 
 /datum/outfit/job/wasteland/f13wastelander
 	name = "Wastelander"
@@ -644,13 +644,12 @@ Raider
 	backpack_contents = list(
 		/obj/item/claymore/machete/spatha=1)
 
-/datum/outfit/loadout/slave
+/datum/outfit/loadout/ncrcitizen
 	name = "NCR Citizen"
-	uniform = /obj/item/clothing/under/f13/caravaneer
+	uniform = /obj/item/clothing/under/f13/ncrcaravan
 	shoes = /obj/item/clothing/shoes/f13/tan
 	head = /obj/item/clothing/head/f13/cowboy
 	gloves = /obj/item/clothing/gloves/color/brown
-	glasses = /obj/item/clothing/glasses/orange
 	l_hand = /obj/item/gun/ballistic/automatic/varmint
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m556/rifle=2)


### PR DESCRIPTION
## About The Pull Request
Changes the internal name for the NCR Citizen loadout from "/datum/outfit/loadout/slave" to "/datum/outfit/loadout/ncrcitizen", changes the internal name for the NCR variant of the caravaneer outfit from "/obj/item/clothing/under/f13/caravaneer" to "/obj/item/clothing/under/f13/ncrcaravan", makes the NCR citizen loadout spawn that variant, changes the description of it, changes the in-game name of it (from "caravaneer outfit" to "NCR caravaneer outfit"), and removes orange glasses from the NCR citizen loadout.
## Why It's Good For The Game
The NCR and non-NCR variants of the caravaneer outfit currently both have the exact same internal name and the NCR citizen loadout spawns the non-NCR one.

Renaming the outfit "NCR caravaneer outfit" makes it more obvious that people wearing it are supposed to be NCR citizens, right now the NCR Citizen loadout doesn't really give you anything that indicates you're from the NCR.

I think removing orange glasses from the loadout is good for the game because it doesn't really fit the rest of the loadout. People can still get them from the character setup loadout.
## Changelog
:cl:
del: The NCR Citizen Loadout no longer gives you orange glasses.
tweak: The NCR Citizen loadout now gives you a "NCR Caravaneer outfit" instead of just a "Caravaneer outfit".
/:cl: