### PR TITLE
Smelling Spirits QoL & 2 charge smelling spirit craftable recipie.

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -58,6 +58,16 @@
 	time = 45
 	category = CAT_MEDICAL
 
+/datum/crafting_recipe/smell_salts
+	name = "Smelling salts"
+	result = /obj/item/smelling_salts/crafted
+	reqs = list(/datum/reagent/ammonia = 10,                                 //Ammonia forces a intake of respiratory breath reflex, which is the foundation of all good smelling salts.
+				/obj/item/reagent_containers/food/snacks/onion_slice = 4,    //Sliced onions, 2 total split into 4 slices.
+				/obj/item/reagent_containers/food/snacks/grown/garlic = 2,   //Pungent garlic.
+				/obj/item/reagent_containers/food/snacks/grown/bee_balm = 2) //Beebalm was a smelling salt utilized in the victorian era for vaporous herbal remedies to things like sore throats.
+	time = 50
+	category = CAT_MEDICAL
+
 /datum/crafting_recipe/stimpak
 	name = "Stimpak"
 	result = /obj/item/reagent_containers/hypospray/medipen/stimpak

--- a/code/modules/fallout/obj/smelling_salts.dm
+++ b/code/modules/fallout/obj/smelling_salts.dm
@@ -1,27 +1,36 @@
 //smelling salts
 /obj/item/smelling_salts
 	name = "large phial of smelling salts"
-	desc = "A large glass phial of pungent smelling salts, used to revive those who have fainted."
+	desc = "A large glass phial of pungent smelling salts, used to revive those who have fainted.<br>It is bound in cord marking the colors of Caesars Legion,"
 	w_class = WEIGHT_CLASS_NORMAL
 	icon = 'icons/obj/fallout/smelling_salts.dmi'
 	icon_state = "smelling_salts_legion"
-	var/time_limit = DEFIB_TIME_LIMIT * 5 // half compared to an actual defib
-	var/charges = 50 // a bit lower than a normal defib's 10
+	var/charges = 8 // a bit lower than a normal defib's 10
 	var/in_use = FALSE
 	var/time_to_use = 10 SECONDS // a defib is 5 seconds
 
+/obj/item/smelling_salts/examine(mob/user)
+	. = ..()
+	if(in_range(user, src) || isobserver(user))
+		. += "<span class='notice'>It currently has <b>[charges]</b> uses remaining.</span>"
+
 /obj/item/smelling_salts/wayfarer
 	icon_state = "smelling_salts_wayfarer"
+	desc = "A large glass phial of pungent smelling salts, used to revive those who have fainted.<br>It is bound in primitive cord with blue freyed tips of the Wayfarer tribe."
 
 /obj/item/smelling_salts/crafted
 	name = "small phial of smelling salts"
 	w_class = WEIGHT_CLASS_SMALL // unsure about this balance-wise, given that defibs are bulky
 	desc = "A stoppered glass phial of pungent smelling salts, used to revive those who have fainted."
 	icon_state = "smelling_salts_crafted"
-	charges = 4 // half of the premade smelling salts
+	charges = 2 // quarter of the premade smelling salts
 
 /obj/item/smelling_salts/attack(mob/target, mob/user)
-	if(in_use)
+	if(in_use == TRUE)
+		to_chat(user, "<span class='warning'>I can't do that right now, they are already recieving smelling salts.</span>")
+		return
+	if(world.time < time_to_use)
+		to_chat(user, "<span class='warning'>They are not ready smell something so pungent yet, I should wait a moment.</span>")
 		return
 	if(!user.IsAdvancedToolUser())
 		to_chat(user, SPAN_WARNING("You don't know how to use [src]!"))
@@ -33,17 +42,36 @@
 
 	if(user.zone_selected != BODY_ZONE_PRECISE_MOUTH && user.zone_selected != BODY_ZONE_HEAD)
 		to_chat(user, SPAN_WARNING("[target_carbon] has to smell [src] to be revived, hold it up to their face!"))
+		return
 
 	if((target_carbon.head?.flags_cover & HEADCOVERSMOUTH) || (target_carbon.wear_mask?.flags_cover & MASKCOVERSMOUTH))
 		to_chat(user, SPAN_NOTICE("You're going to need to remove that [(target_carbon.head?.flags_cover & HEADCOVERSMOUTH) ? "helmet" : "mask"] first."))
 		return
 
-	else if(target_carbon.can_revive_smellingsalts())
+	else if(can_revive(target_carbon))
 		target_carbon.notify_ghost_cloning("You're being revived with smelling salts. Re-enter your corpse if you want to be revived!", source = src)
 
 	do_revive(target_carbon, user)
-	if(--charges <= 0)
+	charges--
+	if(charges <= 0)
+		to_chat(user, SPAN_NOTICE("[src] is now empty and useless; you throw it away."))
 		qdel(src)
+
+/obj/item/smelling_salts/proc/can_revive(mob/living/carbon/T)
+	var/obj/item/organ/brain/BR = T.getorgan(/obj/item/organ/brain)
+	var/obj/item/organ/heart = T.getorgan(/obj/item/organ/heart)
+	var/tlimit = DEFIB_TIME_LIMIT * 10
+	if(T.suiciding || T.hellbound || HAS_TRAIT(src, TRAIT_HUSK) || AmBloodsucker(T))
+		return
+	if ((world.time - T.timeofdeath) < tlimit)
+		return
+	if((T.getBruteLoss() >= 160) || (T.getFireLoss() >= 160))
+		return
+	if(!heart || (heart.organ_flags & ORGAN_FAILING))
+		return
+	if(QDELETED(BR) || BR.brain_death || (BR.organ_flags & ORGAN_FAILING))
+		return
+	return TRUE
 
 /obj/item/smelling_salts/proc/do_revive(mob/living/carbon/revived_mob, mob/living/user)
 	in_use = TRUE
@@ -71,7 +99,7 @@
 	total_brute	= revived_mob.getBruteLoss()
 	total_burn	= revived_mob.getFireLoss()
 
-	if (!revived_mob.can_revive_smellingsalts())
+	if (!can_revive(revived_mob))
 		revived_mob.visible_message(SPAN_WARNING("[revived_mob] doesn't respond..."))
 		in_use = FALSE
 		return
@@ -82,6 +110,7 @@
 		return
 	//If the body has been fixed so that they would not be in crit when revived, give them oxyloss to put them back into crit
 	var/const/threshold = ((HEALTH_THRESHOLD_CRIT + HEALTH_THRESHOLD_DEAD) * 0.5)
+	var/tlimit = DEFIB_TIME_LIMIT * 10
 	if (revived_mob.health > threshold)
 		revived_mob.adjustOxyLoss(revived_mob.health - threshold, 0)
 	else
@@ -92,13 +121,13 @@
 		revived_mob.adjustFireLoss((mobhealth - threshold) * (total_burn / overall_damage), 0)
 		revived_mob.adjustBruteLoss((mobhealth - threshold) * (total_brute / overall_damage), 0)
 	revived_mob.updatehealth() // Previous "adjust" procs don't update health, so we do it manually.
-	revived_mob.visible_message(SPAN_NOTICE("[revived_mob] gasps and stirs!"))
+	revived_mob.visible_message(SPAN_NOTICE("[revived_mob] gasps and stirs!"), SPAN_NOTICE("You're alive!"))
 	revived_mob.set_heartattack(FALSE) // if you can safely be revived without this, then this should be removed; smelling salts aren't a defib
 	revived_mob.revive()
 	revived_mob.emote("gasp")
 	revived_mob.Jitter(20)
-	if(time_since_death > time_limit)
-		revived_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, max(0, min(99, ((time_limit - time_since_death) / time_limit * 100))), 150)
+	if(time_since_death > tlimit)
+		revived_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, max(0, min(99, ((tlimit - time_since_death) / tlimit * 100))), 150)
 	log_combat(revived_mob, revived_mob, "revived", src)
 	var/list/policies = CONFIG_GET(keyed_list/policyconfig)
 	var/memory_limit = CONFIG_GET(number/defib_cmd_time_limit)
@@ -107,4 +136,5 @@
 	if(policy)
 		to_chat(revived_mob, policy)
 	revived_mob.log_message("revived using strange reagent, [time_since_death / 10] seconds from time of death, considered [late? "late" : "memory-intact"] revival under configured policy limits.", LOG_GAME)
+	//add_logs(user, revived_mob, "revived (smelling salts)", src)
 	in_use = FALSE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -891,22 +891,6 @@
 		return
 	return TRUE
 
-/mob/living/carbon/proc/can_revive_smellingsalts()
-	var/tlimit = DEFIB_TIME_LIMIT * 10
-	var/obj/item/organ/heart = getorgan(/obj/item/organ/heart)
-	if(suiciding || hellbound || HAS_TRAIT(src, TRAIT_HUSK) || AmBloodsucker(src))
-		return
-	if((world.time - timeofdeath) > tlimit)
-		return
-	if((getBruteLoss() >= 160) || (getFireLoss() >= 160))
-		return
-	if(!heart || (heart.organ_flags & ORGAN_FAILING))
-		return
-	var/obj/item/organ/brain/BR = getorgan(/obj/item/organ/brain)
-	if(QDELETED(BR) || BR.brain_death || (BR.organ_flags & ORGAN_FAILING) || suiciding)
-		return
-	return TRUE
-
 /mob/living/carbon/fully_heal(admin_revive = FALSE)
 	if(reagents)
 		reagents.clear_reagents()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Thanks to ``@MarinaGryphon`` for providing a foundation in which to work on this PR with their dilligence in <judgex/desertrose#1114>. Adds more responsivity out of the object with a visible "uses" counter to let you know exactly how much you will get out of the given object ahead of time, and more contextual information such as whether the object is in use or is not ready to be used again.

* The recipie is detailed in the medical crafting menu, but comprises of a pungent mix of:
(**10 ammonia** + **4 chopped onion slices** + **2 grown garlic** + **2 beebalm**)
(Ammonia can be made out of Hydrogen, found in grass & Nitrogen found in agave leaves)

* Includes more detailed descriptions to tell the smelling salts in verbose often attributed to shape or the cord used.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

For those who need it, tribal factional players no longer have to bother admins as long as they have a stable supply of some odd ingredients to make their own. You still need a friend to use it on you in critical-condition, unless you just savor the smell of it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Special Notice

* Does not address the bug where the smelling salt cannot be unlocked if the person wielding, we recommend both parties might want to be buckled in to keep still. Its very much on radar but not in scope of this PR.