### PR TITLE
Slims down the personal crafting menu + Tweaks & Fixes

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_assemblies.dm
+++ b/code/datums/components/crafting/recipes/recipes_assemblies.dm
@@ -143,39 +143,17 @@
 /datum/crafting_recipe/dryingrack
 	name = "Drying Rack"
 	result = /obj/machinery/smartfridge/drying_rack
-	reqs = 	list(/obj/item/stack/sheet/mineral/wood = 10)
-	time = 15
-	subcategory = CAT_FARMING
-	category = CAT_MISC
-
-/datum/crafting_recipe/growbin
-	name = "Grow Bin"
-	result = /obj/machinery/smartfridge/bottlerack/grownbin
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 20)
-	time = 40
-	subcategory = CAT_FARMING
-	category = CAT_MISC
-
-/datum/crafting_recipe/seedbin
-	name = "Seed Bin"
-	result = /obj/machinery/smartfridge/bottlerack/seedbin
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 20)
-	time = 40
-	subcategory = CAT_FARMING
-	category = CAT_MISC
-
-/datum/crafting_recipe/compost
-	name = "Compost Bin"
-	result = /obj/structure/reagent_dispensers/compostbin
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 25)
-	time = 40
+	reqs = list(/obj/item/stack/sheet/mineral/wood = 10,
+				/obj/item/stack/sheet/metal = 3)
+	time = 30
 	subcategory = CAT_FARMING
 	category = CAT_MISC
 
 /datum/crafting_recipe/seedextractor
 	name = "Seed Extractor"
 	result = /obj/structure/legion_extractor
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 25)
+	reqs = list(/obj/item/stack/sheet/mineral/wood = 20,
+				/obj/item/stack/sheet/metal = 5)
 	time = 40
 	subcategory = CAT_FARMING
 	category = CAT_MISC
@@ -223,53 +201,5 @@
 	reqs = list(/obj/item/stack/sheet/metal = 3,
 				/obj/item/stack/sheet/cloth = 3)
 	tools = list(TOOL_WORKBENCH)
-	subcategory = CAT_FARMING
-	category = CAT_MISC
-
-/datum/crafting_recipe/rollingpin
-	name = "Rolling Pin"
-	result = /obj/item/kitchen/rollingpin
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 2)
-	time = 30
-	subcategory = CAT_FARMING
-	category = CAT_MISC
-
-/datum/crafting_recipe/choppingblock
-	name = "Chopping Block"
-	result = /obj/item/chopping_block
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 2)
-	time = 30
-	subcategory = CAT_FARMING
-	category = CAT_MISC
-
-/datum/crafting_recipe/meatspikeframe
-	name = "Meatspike Frame"
-	result = /obj/structure/kitchenspike_frame
-	reqs = list(/obj/item/stack/sheet/metal = 1)
-	time = 25
-	subcategory = CAT_FARMING
-	category = CAT_MISC
-
-/datum/crafting_recipe/loom
-	name = "Weaving Loom"
-	result = /obj/structure/loom
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 10)
-	time = 15
-	subcategory = CAT_FARMING
-	category = CAT_MISC
-
-/datum/crafting_recipe/honeyapiary
-	name = "Apiary"
-	result = /obj/structure/beebox
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 40)
-	time = 50
-	subcategory = CAT_FARMING
-	category = CAT_MISC
-
-/datum/crafting_recipe/honeyframe
-	name = "Honey Frame"
-	result = /obj/item/honey_frame
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 5)
-	time = 10
 	subcategory = CAT_FARMING
 	category = CAT_MISC

--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -19,12 +19,6 @@
 				/obj/item/stack/sheet/cloth = 5)
 	tools = list(TOOL_FORGE)
 
-/datum/crafting_recipe/tribalwar/bonearmor
-	name = "Bone Armor"
-	result = /obj/item/clothing/suit/armor/bone
-	time = 30
-	reqs = list(/obj/item/stack/sheet/bone = 6)
-
 /datum/crafting_recipe/tribalwar/chitinarmor
 	name = "Insect Chitin Armor"
 	result = /obj/item/clothing/suit/armor/f13/chitinarmor
@@ -63,12 +57,6 @@
 	reqs = list(/obj/item/stack/sheet/bone = 2,
 				/obj/item/stack/sheet/sinew = 1)
 
-/datum/crafting_recipe/tribalwar/skullhelm
-	name = "Skull Helmet"
-	result = /obj/item/clothing/head/helmet/skull
-	time = 30
-	reqs = list(/obj/item/stack/sheet/bone = 4)
-
 /datum/crafting_recipe/tribalwar/tribe_armor
 	name = "Tribal Hide Armor"
 	result = /obj/item/clothing/suit/armor/f13/tribe_armor
@@ -77,12 +65,6 @@
 	tools = list(TOOL_WORKBENCH)
 
 //WEAPONS//
-
-/datum/crafting_recipe/tribalwar/bonedagger
-	name = "Bone Dagger"
-	result = /obj/item/kitchen/knife/combat/bone
-	time = 20
-	reqs = list(/obj/item/stack/sheet/bone = 2)
 
 /datum/crafting_recipe/tribalwar/bonespear
 	name = "Bone Spear"
@@ -187,24 +169,6 @@
 	result = /obj/item/clothing/mask/gas/tiki_mask
 	time = 30
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 2)
-
-/datum/crafting_recipe/tribal/bonepestle
-	name = "Bone Pestle"
-	result = /obj/item/pestle
-	time = 20
-	reqs = list(/obj/item/stack/sheet/bone = 1)
-
-/datum/crafting_recipe/tribal/bonemortar
-	name = "Bone Mortar"
-	result = /obj/item/reagent_containers/glass/mortar
-	time = 20
-	reqs = list(/obj/item/stack/sheet/bone = 3)
-
-/datum/crafting_recipe/tribal/primitive_chem_isolator
-	name = "Bone Chemical Isolator"
-	result = /obj/item/reagent_containers/glass/primitive_chem_isolator
-	time = 20
-	reqs = list(/obj/item/stack/sheet/bone = 3)
 
 /datum/crafting_recipe/tribal/bonetalisman
 	name = "Bone Talisman"

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -203,7 +203,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 
 
 // Plasteel
- 
+
 GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	new/datum/stack_recipe("bomb assembly", /obj/machinery/syndicatebomb/empty, 10, time = 50), \
 	new/datum/stack_recipe("micro powered fan assembly", /obj/machinery/fan_assembly, 5, time = 50, one_per_turf = TRUE, on_floor = TRUE), \
@@ -258,7 +258,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	amount = 5
 
 //  Wood
- 
+
 GLOBAL_LIST_INIT(wood_recipes, list ( \
 	new/datum/stack_recipe("wood table frame", /obj/structure/table_frame/wood, 2, time = 10), \
 	new/datum/stack_recipe("wooden barricade", /obj/structure/barricade/wooden, 5, time = 50, one_per_turf = TRUE, on_floor = TRUE), \
@@ -268,27 +268,42 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	new/datum/stack_recipe("tiled wooden floor tile", /obj/item/stack/tile/wood/wood_tiled, 1, 4, 20), \
 	new/datum/stack_recipe("diagonal wooden floor tile", /obj/item/stack/tile/wood/wood_diagonal, 1, 4, 20), \
 	null, \
-	new/datum/stack_recipe_list("pews", list(
+	new/datum/stack_recipe_list("pews", list( \
 		new /datum/stack_recipe("pew (middle)", /obj/structure/chair/pew, 3, one_per_turf = TRUE, on_floor = TRUE),\
 		new /datum/stack_recipe("pew (left)", /obj/structure/chair/pew/left, 3, one_per_turf = TRUE, on_floor = TRUE),\
 		new /datum/stack_recipe("pew (right)", /obj/structure/chair/pew/right, 3, one_per_turf = TRUE, on_floor = TRUE),\
-		)),
+		)), \
 	null, \
 	new/datum/stack_recipe("wooden chair", /obj/structure/chair/wood/, 3, time = 10, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("winged wooden chair", /obj/structure/chair/wood/wings, 3, time = 10, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("plywood chair", /obj/structure/chair/comfy/plywood, 4, time = 10, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
+	new/datum/stack_recipe_list("primitive industry & agriculture", list( \
+		new /datum/stack_recipe("loom", /obj/structure/loom, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE),\
+		new /datum/stack_recipe("compost bin", /obj/structure/reagent_dispensers/compostbin, 25, time = 40, one_per_turf = TRUE, on_floor = TRUE), \
+		null, \
+		new /datum/stack_recipe("harvest bin", /obj/machinery/smartfridge/bottlerack/grownbin, 20, time = 40, one_per_turf = TRUE, on_floor = TRUE), \
+		new /datum/stack_recipe("seed bin", /obj/machinery/smartfridge/bottlerack/seedbin, 20, time = 40, one_per_turf = TRUE, on_floor = TRUE), \
+		null, \
+		new /datum/stack_recipe("apiary", /obj/structure/beebox, 40, time = 50, one_per_turf = TRUE, on_floor = TRUE),\
+		new /datum/stack_recipe("honey frame", /obj/item/honey_frame, 5, time = 10),\
+		)), \
+	new/datum/stack_recipe_list("cooking", list( \
+		new /datum/stack_recipe("rolling pin", /obj/item/kitchen/rollingpin, 2, time = 30, one_per_turf = TRUE, on_floor = TRUE),\
+		new /datum/stack_recipe("chopping block", /obj/item/chopping_block, 2, time = 30, one_per_turf = TRUE, on_floor = TRUE), \
+		)), \
+	null, \
 	new/datum/stack_recipe("wooden door", /obj/structure/simple_door/room, 10, time = 20, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("interior wooden door", /obj/structure/simple_door/interior, 10, time = 20, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("wooden house door", /obj/structure/simple_door/house, 10, time = 20, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
-	new/datum/stack_recipe("wooden bucket", /obj/item/reagent_containers/glass/bucket/wood, 2, time = 30), \
+	new /datum/stack_recipe("wooden bucket", /obj/item/reagent_containers/glass/bucket/wood, 2, time = 30), \
 	new/datum/stack_recipe("ore box", /obj/structure/ore_box, 4, time = 50, one_per_turf = TRUE, on_floor = TRUE),\
 	new/datum/stack_recipe("wooden crate", /obj/structure/closet/crate/wooden, 6, time = 50, one_per_turf = TRUE, on_floor = TRUE),\
 	null, \
 	new/datum/stack_recipe("book case", /obj/structure/bookcase, 4, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("dresser", /obj/structure/dresser, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
-	new/datum/stack_recipe("display case chassis", /obj/structure/displaycase_chassis, 5, one_per_turf = TRUE, on_floor = TRUE)
+	new/datum/stack_recipe("display case chassis", /obj/structure/displaycase_chassis, 5, one_per_turf = TRUE, on_floor = TRUE), \
 	))
 
 /obj/item/stack/sheet/mineral/wood
@@ -387,7 +402,7 @@ GLOBAL_LIST_INIT(bamboo_recipes, list ( \
 
 
 // Cloth
- 
+
 GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	new/datum/stack_recipe("backpack", /obj/item/storage/backpack, 4), \
 	new/datum/stack_recipe("duffel bag", /obj/item/storage/backpack/duffelbag, 6), \
@@ -727,9 +742,19 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/greatergem
 
 // Bones
- 
+
 GLOBAL_LIST_INIT(bone_recipes, list(
-	new /datum/stack_recipe("Tribal Satchel", /obj/item/storage/backpack/satchel/bone, 4, time = 40),
+	new /datum/stack_recipe("bone dagger", /obj/item/kitchen/knife/combat/bone, 2, time = 20),
+	null, \
+	new /datum/stack_recipe("bone armor", /obj/item/clothing/suit/armor/bone, 6, time = 30),
+	new /datum/stack_recipe("skull helmet", /obj/item/clothing/head/helmet/skull, 4, time = 30),
+	null, \
+	new/datum/stack_recipe_list("medicine", list( \
+		new /datum/stack_recipe("bone pestle", /obj/item/pestle, 1, time = 20),\
+		new /datum/stack_recipe("bone mortar", /obj/item/reagent_containers/glass/mortar, 3, time = 20),\
+		new /datum/stack_recipe("bone chemical isolator", /obj/item/reagent_containers/glass/primitive_chem_isolator, 3, time = 20),\
+	)), \
+	null, \
 ))
 
 /obj/item/stack/sheet/bone

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -235,7 +235,7 @@
 // ----------------------------
 /obj/machinery/smartfridge/drying_rack
 	name = "drying rack"
-	desc = "A wooden contraption, used to dry plant products, food and hide."
+	desc = "A wooden case atop a large electric hot-plate, used to dry plant products, food and hide."
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "drying_rack"
 	use_power = IDLE_POWER_USE

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -323,7 +323,7 @@
 	if(reagents.total_volume == tank_volume)
 		to_chat(user,"<span class='warning'>The [src] is filled to capacity!</span>")
 		return
-	if(istype(W, /obj/item/seeds || /obj/item/reagent_containers/food/snacks/grown))
+	if(istype(W, /obj/item/seeds) || istype(W, /obj/item/reagent_containers/food/snacks/grown))
 		if(user.transferItemToLoc(W, src))
 			to_chat(user, "<span class='notice'>You load the [W] into the [src].</span>")
 			playsound(loc, 'sound/effects/blobattack.ogg', 25, 1, -1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A number of assets which lacked any real reason to be in the personal crafting menu due to being incomplex single material basic-crafts have been sensibly moved into relevant stack-crafting and their own subcatgories. These include ``primitive industry and agriculture`` for buildings like the seed bin & ``cooking`` for rolling pins etc for wood.

All of the bone daggers, armor & skull helms are now contributing to bone-stacks, including the grouped bone pestle, mortar and primitive seperator under ``medicine``

* The drying rack now has a mention of a hot-plate, which accounts for the +3 metal sheets it takes to craft in the farming category. The seed extractor also requires 5 metal, and remains in the personal crafting screen, but costs less wood.

* Duplicates on either side have been removed, there are no 2 copies of tribal bag, only a singular personal-crafted version, similarly there is only 1 version of the 5 cost meatspike frame.

* The compost 'machinery' has now recieved a fix and can recieve grown foods to refill its internal liquid compost.

Thanks to ``@PvtStupidhead`` for making the <https://github.com/DesertRose2/desertrose/pull/535> pr of which the compost-fix is included.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Slightly less personal crafting spam, inoffensive stack-lists. 

Drying racks make a slight bit more amount of sense for what they actually do, as glorified apocalptic hot-plates as well as legion seed extractors, both are justified to be personal crafted by combined resources (wood and metal) that represent their descriptive & visual mechanical parts.

Composters being usable sets a precedent in the future they could probably start empty, but for now you can recoup your losses. 😈
