### PR TITLE
BOS surgery improvements & surgery tweaks

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -246,6 +246,7 @@
 #define TRAIT_PRACTITIONER		"Practitioner" //Has access to FoA surguries
 #define TRAIT_PRACTITIONER_EXPERT	"Practitioner Expert" //Lead follower works on par of other factions
 #define TRAIT_UNETHICAL_PRACTITIONER	"Unethical Practitioner" //Can do harmful experimental surguries
+#define TRAIT_SCRIBE_TRAINED	"scribe_trained" //BOS practitioner
 #define TRAIT_CYBERNETICIST		"Cyberneticist" //Utilizes powerful cybernetics
 #define TRAIT_CYBERNETICIST_EXPERT	"Cyberneticist Expert" //Can augument people into robots directly
 #define TRAIT_MACHINE_SPIRITS	"machine_spirits" //for tribe unique functions.

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -518,7 +518,7 @@ Proctor
 	if(visualsOnly)
 		return
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
-	ADD_TRAIT(H, TRAIT_SURGERY_MID, src)
+	ADD_TRAIT(H, TRAIT_SURGERY_HIGH, src)
 	ADD_TRAIT(H, TRAIT_CYBERNETICIST, src)
 	ADD_TRAIT(H, TRAIT_MASTER_GUNSMITH, src)
 
@@ -594,6 +594,7 @@ Scribe
 	if(visualsOnly)
 		return
 	ADD_TRAIT(H, TRAIT_SURGERY_MID, src)
+	ADD_TRAIT(H, TRAIT_SCRIBE_TRAINED, src)
 
 /datum/outfit/loadout/scribea
 	name = "Junior Scribe"

--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -246,7 +246,7 @@ Follower Volunteer
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = "Followers having no strict command structure, don't report to anyone- though they will look to the Administrator for guidance and the other Doctors as well."
-	description = "You are a Follower Volunteer. As a Volunteer, you make sure they get connected to the right people to find treatment, assist in the functions of the hospital, and stepping in for the Doctors when they are not present. Your reason for being here is to provide education and medical services, as well to learn from other Doctors as to better provide medical care for the wastes."
+	description = "You are a Follower Volunteer. As a Volunteer, you make sure they get connected to the right people to find treatment, assist in the functions of the hospital, learn from senior Followers, and utilize first aid to the best of your capacity when Doctors are not present."
 	forbids = "Causing harm to others except in times of self-defense."
 	enforces = "Followers are not fond of the NCR due to their corruption, but they will help them. They dislike the Brotherhood for hoarding tech, but will make deals to work with them if it furthers the spreading of knowledge. Legion is our mistake and its our job to correct the mistake by speaking of the truth, but recognize that the best way to fight the legion is to teach them and sometimes that can mean helping them. Preaching humanitarianism and valuing human life. Assist and provide medical services to any who require it, regardless of faction. Provide free education for all those who are willing to learn."
 	selection_color = "#FFDDFF"

--- a/code/modules/surgery/advanced/toxichealing.dm
+++ b/code/modules/surgery/advanced/toxichealing.dm
@@ -1,5 +1,5 @@
 /datum/surgery/advanced/toxichealing
-	name = "Body Rejuvenation"
+	name = "Surgically assisted rejuvenation (oxygen deprivation & toxicity)"
 	desc = "A surgical procedure that helps deal with oxygen  deprivation, and treats parts damaged due to toxic compounds. Works on corpses and alive alike without chemicals."
 	steps = list(/datum/surgery_step/incise,
 				/datum/surgery_step/incise,
@@ -16,6 +16,8 @@
 	requires_bodypart_type = 0
 	requires_trait = 2
 	requires_trait = "PRACTITIONER_1"
+	requires_trait = "SCRIBE_TRAINED"
+
 /datum/surgery_step/toxichealing
 	name = "rejuvenate body"
 	implements = list(TOOL_HEMOSTAT  = 100, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)

--- a/code/modules/surgery/bone_mending.dm
+++ b/code/modules/surgery/bone_mending.dm
@@ -27,6 +27,7 @@
 	targetable_wound = /datum/wound/blunt/critical
 	requires_trait= 2
 	requires_trait = "PRACTITIONER_1"
+	requires_trait = "SCRIBE_TRAINED"
 
 /datum/surgery/repair_bone_compound/can_start(mob/living/user, mob/living/carbon/target)
 	if(..())

--- a/code/modules/surgery/coronary_bypass.dm
+++ b/code/modules/surgery/coronary_bypass.dm
@@ -6,6 +6,7 @@
 	requires_bodypart_type = BODYPART_ORGANIC
 	requires_trait = 2
 	requires_trait = "PRACTITIONER_1"
+	requires_trait = "SCRIBE_TRAINED"
 
 /datum/surgery/coronary_bypass/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	var/obj/item/organ/heart/H = target.getorganslot(ORGAN_SLOT_HEART)

--- a/code/modules/surgery/emergency_cardioversion_recovery.dm
+++ b/code/modules/surgery/emergency_cardioversion_recovery.dm
@@ -6,6 +6,7 @@
 	requires_bodypart_type = BODYPART_ORGANIC
 	requires_trait = 2
 	requires_trait = "PRACTITIONER_1"
+	requires_trait = "SCRIBE_TRAINED"
 
 /datum/surgery_step/ventricular_electrotherapy
 	name = "ventricular electrotherapy"

--- a/code/modules/surgery/eye_surgery.dm
+++ b/code/modules/surgery/eye_surgery.dm
@@ -6,6 +6,7 @@
 	requires_bodypart_type = BODYPART_ORGANIC
 	requires_trait = 2
 	requires_trait = "PRACTITIONER_1"
+	requires_trait = "SCRIBE_TRAINED"
 
 //fix eyes
 /datum/surgery_step/fix_eyes

--- a/code/modules/surgery/graft_synthtissue.dm
+++ b/code/modules/surgery/graft_synthtissue.dm
@@ -17,6 +17,7 @@
 	)
 	requires_trait = 2
 	requires_trait = "PRACTITIONER_1"
+	requires_trait = "SCRIBE_TRAINED"
 
 //repair organs
 /datum/surgery_step/graft_synthtissue

--- a/code/modules/surgery/hepatectomy.dm
+++ b/code/modules/surgery/hepatectomy.dm
@@ -13,6 +13,7 @@
 		)
 	requires_trait = 2
 	requires_trait = "PRACTITIONER_1"
+	requires_trait = "SCRIBE_TRAINED"
 
 /datum/surgery/hepatectomy/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/liver/L = target.getorganslot(ORGAN_SLOT_LIVER)

--- a/code/modules/surgery/lobectomy.dm
+++ b/code/modules/surgery/lobectomy.dm
@@ -6,6 +6,7 @@
 	requires_bodypart_type = BODYPART_ORGANIC
 	requires_trait = 2
 	requires_trait = "PRACTITIONER_1"
+	requires_trait = "SCRIBE_TRAINED"
 
 /datum/surgery/lobectomy/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	var/obj/item/organ/lungs/L = target.getorganslot(ORGAN_SLOT_LUNGS)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -24,7 +24,7 @@
 	//	0 = low, 1 = mid, 2 = high
 	//	(CMO biological/prewar knoweldge expert) MEDICALEXPERT
 	//	(Follower) Practitioner (Follower Admin) Practitioner_expert
-	//	(Senior BOS scribe) cyberneticist,(BOS Head Scribe) cyberneticist_expert
+	//	(Scribe) scribe trained (Senior BOS scribe) cyberneticist, scribe trained (BOS Head Scribe) cyberneticist_expert
 	//	(Enclave Scientist) unethical practitioner
 	//	(Zetans?) abductor= "ABDUCTOR"
 
@@ -71,25 +71,31 @@
 		else
 			return FALSE
 
-	if(requires_trait== "CYBERNETICIST_2") //robotic brain surgery, augumentation,
+	if(requires_trait== "CYBERNETICIST_2") //robotic brain surgery, augumentation, robotic repairs.
 		if(HAS_TRAIT(user,TRAIT_CYBERNETICIST_EXPERT)|| HAS_TRAIT(user,TRAIT_ABDUCTOR_SCIENTIST_TRAINING))
 			return TRUE
 		else
 			return FALSE
 
-	if(requires_trait== "CYBERNETICIST_1") //follower
+	if(requires_trait== "CYBERNETICIST_1") //allows robotic limb repairs.
 		if(HAS_TRAIT(user,TRAIT_CYBERNETICIST)|| HAS_TRAIT(user,TRAIT_ABDUCTOR_SCIENTIST_TRAINING))
 			return TRUE
 		else
 			return FALSE
 
-	if(requires_trait== "PRACTITIONER_2") //robotic brain surgery, implants
+	if(requires_trait== "PRACTITIONER_2") //robotic brain surgery.
 		if(HAS_TRAIT(user,TRAIT_PRACTITIONER_EXPERT)|| HAS_TRAIT(user,TRAIT_ABDUCTOR_SCIENTIST_TRAINING))
 			return TRUE
 		else
 			return FALSE
 
-	if(requires_trait== "PRACTITIONER_1") //robotic repairs
+	if(requires_trait== "SCRIBE_TRAINED") //same as practitioner with BoS flavor.
+		if(HAS_TRAIT(user,TRAIT_SCRIBE_TRAINED)|| HAS_TRAIT(user,TRAIT_ABDUCTOR_SCIENTIST_TRAINING))
+			return TRUE
+		else
+			return FALSE
+
+	if(requires_trait== "PRACTITIONER_1") //doctoring trait for followers, allows high surgeries on medium skill level.
 		if(HAS_TRAIT(user,TRAIT_PRACTITIONER)|| HAS_TRAIT(user,TRAIT_ABDUCTOR_SCIENTIST_TRAINING))
 			return TRUE
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Normal & Junior scribes are now allocated the "Scribe Trained" trait meant to represent a formal education from within the Brotherhood, initeks are omitted. Functionally scribe training is the same as a Practitioner trait on a follower-doctor in allowing them to bypass a skill-check on most surgeries beside brain surgery.

* Senior scribe surgical intelligence has been raised to high as to render medium surgery level scribe training obsolete.

* Follower volunteers have had some updated context to their job description that makes them non-egible to replace doctors in full in case of a emergency, but prompted to assist in first aid. Volunteer Followers are still mainly students and service workers after all.

* Body Revival has been renamed to ``Surgically assisted rejuvenation (oxygen deprivation & toxicity)`` as a last resort option since it only vaguely mirrors a broad amount of surgeries in real life, and was being confusing to its purpose.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

~~BOS mains can stop shouting at me in developer chat that they can do less than followers~~

BOS mains can competently follow through with procedures more broadly without the nessecary dependency of more timelocked senior & headscribe roles. Follower volunteers are little bit more unburdoned with responsibility for ERPing doctors, and hopefully people can understand what the anti-oxy+toxin surgery is meant to do.
