### PR TITLE
Pahrump Overhaul 

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -56,6 +56,12 @@
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/wood,
 /area/f13/vault)
+"aeW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/bunker)
 "agt" = (
 /obj/machinery/light{
 	dir = 1;
@@ -71,9 +77,28 @@
 	dir = 8
 	},
 /area/f13/vault)
+"agQ" = (
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"agV" = (
+/obj/structure/weightlifter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "ahh" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"aib" = (
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "aim" = (
 /turf/closed/indestructible/rock,
 /area/f13/tunnel)
@@ -109,6 +134,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"akI" = (
+/obj/structure/sign/poster/prewar/poster88,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "akP" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -121,6 +150,23 @@
 /obj/item/reagent_containers/food/snacks/doughslice,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
+"ami" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"anu" = (
+/obj/structure/closet/crate/secure/loot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"anx" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "anz" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -142,6 +188,29 @@
 	dir = 10
 	},
 /area/f13/vault)
+"apG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"aqG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/bunker)
+"asn" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "asT" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -182,10 +251,22 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"auJ" = (
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "avm" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"axd" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "ayq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/cell_charger,
@@ -264,6 +345,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"ayW" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "azm" = (
 /mob/living/simple_animal/hostile/cazador,
 /obj/effect/decal/cleanable/dirt{
@@ -289,6 +376,10 @@
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
+/area/f13/bunker)
+"aCx" = (
+/obj/machinery/chem_master,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "aCK" = (
 /obj/structure/chair/wood/fancy,
@@ -341,6 +432,17 @@
 	icon_state = "grass2"
 	},
 /area/f13/vault)
+"aGG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"aGH" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "aGJ" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -399,6 +501,18 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/vault)
+"aKv" = (
+/obj/structure/chair/bench,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"aKF" = (
+/obj/structure/closet/wardrobe,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "aKU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -436,12 +550,37 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"aOr" = (
+/obj/structure/closet/wardrobe,
+/obj/effect/spawner/lootdrop/crafts,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"aPN" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "aQB" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/shoes/galoshes,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
+	},
+/area/f13/bunker)
+"aSb" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"aSe" = (
+/obj/structure/wreck/trash/two_barrels,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "aSm" = (
@@ -480,6 +619,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
+"aVX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "aWc" = (
 /obj/machinery/conveyor/inverted{
 	dir = 6;
@@ -498,6 +641,14 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"aWL" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "aXE" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -526,6 +677,22 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/bunker)
+"bal" = (
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"bbf" = (
+/obj/structure/window/plastitanium{
+	desc = "A heavy duty window dirtied with dust and grime. Below, you see an expansive cave filled with ruined buildings, coated in glowing green sludge. Mulling around are ghouls. Thousands. Tens of thousands. An army, sealed and forgotten below the earth. They are trapped... for now.";
+	name = "viewport"
+	},
+/obj/structure/grille,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "bcr" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
@@ -578,11 +745,26 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"biC" = (
+/obj/structure/debris/v3,
+/turf/open/floor/plating/tunnel,
+/area/f13/underground/cave)
 "biF" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
+/area/f13/bunker)
+"biV" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"biX" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "bje" = (
 /obj/machinery/door/airlock/wood{
@@ -632,6 +814,17 @@
 	name = "temple wall"
 	},
 /area/f13/ruins)
+"blv" = (
+/obj/structure/chair/comfy/lime{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "blH" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
@@ -643,6 +836,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/vault)
+"bnF" = (
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "bnK" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -651,10 +854,34 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"bnW" = (
+/obj/structure/nest/ghoul,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"boi" = (
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "boj" = (
 /obj/machinery/vending/donksofttoyvendor,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"boR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"boZ" = (
+/obj/structure/table,
+/obj/item/holosign_creator/security,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "bpr" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
@@ -681,10 +908,47 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
+"bsH" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 16;
+	tag = "icon-sink (NORTH)"
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/bunker)
 "btc" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"bti" = (
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
+"btD" = (
+/obj/structure/closet/wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"bun" = (
+/obj/structure/sign/poster/prewar/vault_tec,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"buq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "buU" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -696,6 +960,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"bvB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "bwT" = (
 /obj/machinery/shower{
 	dir = 8
@@ -739,6 +1008,16 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
+	},
+/area/f13/bunker)
+"byz" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
 	},
 /area/f13/bunker)
 "byG" = (
@@ -818,6 +1097,17 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"bCx" = (
+/obj/structure/debris/v3,
+/turf/closed/wall/f13/tunnel,
+/area/f13/bunker)
+"bCK" = (
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "bCL" = (
 /obj/machinery/light{
 	dir = 4;
@@ -849,6 +1139,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"bDt" = (
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/f13/tunnel,
+/area/f13/bunker)
+"bEH" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "bEK" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -867,12 +1164,54 @@
 	icon_state = "verticalinnermain2bottom"
 	},
 /area/f13/wasteland)
+"bGo" = (
+/obj/machinery/workbench,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"bGR" = (
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"bGY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "bHb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
+"bHx" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"bHD" = (
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"bHL" = (
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "bIM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -881,6 +1220,10 @@
 	icon_state = "stagestairs"
 	},
 /area/f13/vault)
+"bJn" = (
+/obj/structure/debris/v3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/underground/cave)
 "bKv" = (
 /obj/structure/rack,
 /obj/item/storage/backpack/security,
@@ -920,6 +1263,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"bKJ" = (
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"bOP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/ripped,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "bPQ" = (
 /obj/structure/wreck/trash/three_barrels,
 /obj/effect/decal/cleanable/dirt{
@@ -955,12 +1308,29 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
+"bRL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"bRM" = (
+/obj/machinery/computer/med_data,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "bSB" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"bSG" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "bSU" = (
 /obj/structure/sink{
 	dir = 1;
@@ -990,6 +1360,23 @@
 /obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"bTF" = (
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"bTI" = (
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"bUM" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "bUN" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -1005,6 +1392,10 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
+/area/f13/bunker)
+"bYr" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "bYw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1043,6 +1434,17 @@
 /obj/structure/sign/warning,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"cbF" = (
+/obj/structure/punching_bag,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"ccu" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/obj/item/trash/can,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "ccw" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1066,6 +1468,13 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"cdD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "ceF" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/blood/radaway,
@@ -1078,6 +1487,21 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"ceY" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"cfH" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/f13/vault{
+	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "cfZ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1085,12 +1509,21 @@
 /obj/item/trash/f13/c_ration_3,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"chm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "chr" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
+/area/f13/bunker)
+"cht" = (
+/obj/structure/sign/poster/prewar/poster91,
+/turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "chI" = (
 /obj/item/storage/trash_stack,
@@ -1108,6 +1541,10 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"ciC" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "ciK" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
@@ -1129,6 +1566,13 @@
 	},
 /obj/item/trash/f13/rotten,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"ckH" = (
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "cmp" = (
 /obj/machinery/light{
@@ -1164,11 +1608,30 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"cmy" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"cmC" = (
+/obj/structure/table,
+/obj/item/defibrillator,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "cmM" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
+	},
+/area/f13/bunker)
+"cnm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button{
+	id = bonnie
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "cnA" = (
@@ -1196,6 +1659,17 @@
 /obj/item/bedsheet/yellow,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
+	},
+/area/f13/bunker)
+"con" = (
+/obj/structure/bed,
+/obj/item/trash/f13/bubblegum,
+/obj/machinery/light/broken,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"cph" = (
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "cpp" = (
@@ -1272,6 +1746,19 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"cxx" = (
+/mob/living/simple_animal/hostile/handy{
+	faction = list("bonnie")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"cyh" = (
+/obj/structure/table,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	faction = list("bonnie")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "cyk" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
@@ -1292,6 +1779,10 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
+/area/f13/bunker)
+"czt" = (
+/obj/structure/timeddoor,
+/turf/closed/wall/f13/tunnel,
 /area/f13/bunker)
 "cAz" = (
 /obj/structure/cable,
@@ -1317,6 +1808,12 @@
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"cBC" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "cCQ" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel/dark,
@@ -1326,6 +1823,11 @@
 /obj/item/clothing/head/collectable/tophat,
 /turf/open/floor/wood,
 /area/f13/vault)
+"cDm" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "cEv" = (
 /obj/structure/chair/stool/retro,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -1336,6 +1838,21 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"cGm" = (
+/obj/structure/debris/v3,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"cGG" = (
+/obj/item/trash/can,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"cGO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "cHe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -1383,6 +1900,23 @@
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland)
+"cKZ" = (
+/obj/item/clothing/under/rank/hydroponics,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"cLe" = (
+/obj/machinery/door/airlock/grunge/abandoned,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/bunker)
+"cMk" = (
+/obj/structure/window{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "cMr" = (
 /obj/structure/rack,
 /obj/item/crafting/abraxo,
@@ -1412,6 +1946,40 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"cNM" = (
+/obj/machinery/autolathe,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"cNN" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"cOb" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"cOF" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"cPT" = (
+/obj/item/trash/can,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"cQh" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "cQF" = (
 /obj/machinery/shower{
 	dir = 4
@@ -1468,6 +2036,13 @@
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
+"cXp" = (
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "cYq" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -1547,6 +2122,22 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"ddP" = (
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
+"dex" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "deM" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -1554,6 +2145,12 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/bunker)
+"deS" = (
+/obj/item/trash/f13/dandyapples,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/turf/open/floor/carpet/black,
 /area/f13/bunker)
 "deX" = (
 /turf/open/floor/plating/tunnel,
@@ -1573,6 +2170,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"dgI" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "dgM" = (
 /obj/structure/bookcase,
 /obj/item/book/codex_gigas,
@@ -1603,6 +2206,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"djC" = (
+/obj/structure/debris/v3,
+/turf/closed/indestructible/rock,
+/area/f13/underground/cave)
 "djI" = (
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/wasteland)
@@ -1675,6 +2282,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
+"dop" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/cans,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "doS" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1682,6 +2293,15 @@
 /obj/item/storage/toolbox/emergency/old,
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"dpB" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dqe" = (
 /obj/structure/table,
@@ -1705,6 +2325,10 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"dsT" = (
+/obj/structure/sign/departments/chemistry,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "dtD" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1714,10 +2338,46 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/bunker)
+"dtK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/rock,
+/area/f13/underground/cave)
+"dtO" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"duN" = (
+/obj/structure/table,
+/obj/item/crafting/fuse,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"dva" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "bonnief2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "dvm" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"dvE" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"dwp" = (
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	faction = list("bonnie")
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "dxB" = (
 /obj/machinery/door/airlock/mining{
 	name = "Casp Bay"
@@ -1737,6 +2397,11 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"dBR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "dBY" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
@@ -1798,6 +2463,25 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"dFh" = (
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"dGa" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"dGj" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/construction,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "dGy" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1822,6 +2506,11 @@
 /obj/item/circuitboard/machine/mechfab,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/vault)
+"dGV" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/diy,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "dHs" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -1873,6 +2562,25 @@
 	icon_state = "dirt"
 	},
 /area/f13/bunker)
+"dLZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"dMZ" = (
+/obj/structure/table,
+/obj/item/clothing/head/beret/black,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"dNv" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "dNC" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
@@ -1908,6 +2616,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"dQc" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "dQq" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -1932,6 +2646,17 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"dRI" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"dRJ" = (
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "dSc" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -1945,6 +2670,16 @@
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
 /area/f13/tcoms)
+"dTP" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/effect/turf_decal/loading_area,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "dTR" = (
 /obj/structure/curtain,
 /obj/structure/decoration/vent,
@@ -1958,6 +2693,17 @@
 /obj/structure/sign/departments/botany,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"dUV" = (
+/obj/item/ammo_box/c9mm,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"dVk" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "dVu" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -2016,6 +2762,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"dXG" = (
+/obj/machinery/rnd/server,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "dYh" = (
 /obj/structure/table/wood,
 /obj/item/clothing/accessory/lawyers_badge,
@@ -2036,6 +2789,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"dYF" = (
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"dYG" = (
+/obj/effect/turf_decal{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "dYV" = (
 /obj/machinery/light{
 	dir = 4;
@@ -2057,6 +2822,27 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/bunker)
+"eat" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/f13/vault{
+	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
+	},
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"ecz" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "edG" = (
 /obj/structure/table/wood,
@@ -2086,6 +2872,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"egB" = (
+/obj/structure/debris/v3,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "ehx" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -2116,6 +2908,13 @@
 /obj/item/flashlight/seclite,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"eje" = (
+/obj/structure/chair/comfy/lime{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "ejG" = (
 /obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/outside/dirt,
@@ -2126,6 +2925,13 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
+"ekM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "elo" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -2203,22 +3009,53 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"eqr" = (
+/obj/machinery/door/airlock/grunge/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "eqF" = (
 /obj/structure/decoration/hatch{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"erG" = (
+/obj/structure/debris/v4,
+/turf/open/floor/plating/tunnel,
+/area/f13/underground/cave)
+"erM" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "esm" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"etY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "euI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"euV" = (
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	name = "prewar lounge chair"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"evw" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "evR" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
@@ -2233,12 +3070,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
+"exa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "exl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
+"eyz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "eAJ" = (
 /obj/item/clothing/head/helmet/skull,
 /turf/open/indestructible/ground/outside/dirt,
@@ -2307,6 +3154,14 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/bunker)
+"eEz" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "eET" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -2329,6 +3184,11 @@
 /obj/item/trash/f13/mre,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"eFT" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "eHa" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/f13/canned/borscht,
@@ -2349,6 +3209,21 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"eHo" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"eHv" = (
+/obj/structure/debris/v3,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"eIp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "eJD" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -2360,6 +3235,9 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"eKa" = (
+/turf/closed/wall/f13/tunnel,
+/area/f13/bunker)
 "eKu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/popcorn,
@@ -2370,6 +3248,18 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"eMa" = (
+/obj/item/trash/can,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"eNK" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"eOy" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "eOH" = (
 /obj/item/am_shielding_container,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -2389,6 +3279,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"ePB" = (
+/obj/machinery/computer/card,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "ePY" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -2398,6 +3292,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"eQc" = (
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench";
+	tag = "icon-bench (WEST)"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "eQq" = (
 /obj/structure/vaultdoor{
 	name = "vault 113 door";
@@ -2409,6 +3313,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"eQV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "eRf" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2416,6 +3329,11 @@
 /obj/machinery/aug_manipulator,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"eSI" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "eUX" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
@@ -2450,6 +3368,10 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"eXs" = (
+/obj/structure/debris/v4,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "eYz" = (
 /obj/machinery/rnd/server/vault,
 /turf/open/floor/plasteel/dark,
@@ -2467,6 +3389,14 @@
 /obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/wood,
 /area/f13/vault)
+"eZH" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "eZM" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -2477,6 +3407,11 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"fax" = (
+/obj/structure/rack,
+/obj/item/stack/medical/gauze/cyborg,
+/turf/open/floor/carpet/black,
 /area/f13/bunker)
 "faZ" = (
 /obj/structure/cable{
@@ -2499,6 +3434,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"fcl" = (
+/obj/item/rack_parts,
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "fcq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2569,6 +3510,22 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/f13/vault)
+"fgw" = (
+/obj/machinery/light/fo13colored/Red,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"fgG" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/f13/vault{
+	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"fhx" = (
+/obj/machinery/door/airlock/grunge/abandoned,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "fhA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2577,6 +3534,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"fiA" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "fiJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -2648,6 +3612,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"fnX" = (
+/obj/structure/girder/reinforced,
+/obj/structure/sign/poster/ripped,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "fow" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/dandyapples,
@@ -2663,6 +3634,14 @@
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/wood,
 /area/f13/vault)
+"fpt" = (
+/obj/structure/chair/f13chair2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "fqu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -2678,6 +3657,17 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/bunker)
+"fsx" = (
+/obj/machinery/doorButtons/vaultButton,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"ftE" = (
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "fud" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2722,6 +3712,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"fwB" = (
+/obj/machinery/power/rtg,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"fwU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "fyg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2776,6 +3777,14 @@
 	icon_state = "grass2"
 	},
 /area/f13/vault)
+"fBu" = (
+/obj/structure/spider/stickyweb,
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "fDJ" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /obj/structure/cable{
@@ -2783,6 +3792,27 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"fDR" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"fDS" = (
+/obj/item/trash/chips,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"fDZ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"fEp" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "fEC" = (
 /obj/structure/rack,
 /obj/item/crafting/buzzer,
@@ -2792,6 +3822,16 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
+/area/f13/bunker)
+"fEM" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"fFe" = (
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fFr" = (
 /obj/structure/simple_door/bunker/glass,
@@ -2812,6 +3852,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"fHe" = (
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "fHg" = (
 /obj/structure/table,
 /obj/structure/cable{
@@ -2819,6 +3865,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
+"fHE" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/construction,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"fHJ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "fIu" = (
 /obj/machinery/light{
 	dir = 1;
@@ -2839,6 +3899,13 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
+/area/f13/bunker)
+"fIZ" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "fJp" = (
 /obj/structure/cable{
@@ -2868,11 +3935,34 @@
 /obj/structure/weightlifter,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"fKx" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"fMe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "fMk" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
+"fMu" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/bunker)
+"fMZ" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "fNo" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/lavendergrass{
@@ -2909,14 +3999,31 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/vault)
+"fPC" = (
+/obj/structure/table/abductor{
+	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
+	name = "advanced table"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "fPP" = (
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"fQD" = (
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "fRE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
+/area/f13/bunker)
+"fRO" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "fRP" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -2932,12 +4039,29 @@
 	},
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
+"fTJ" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "fTR" = (
 /obj/structure/chair/left{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
+"fUD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "fVF" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -2946,6 +4070,17 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
+	},
+/area/f13/bunker)
+"fWp" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/curtain,
+/obj/item/stock_parts/cell/ammo/mfc,
+/turf/open/floor/f13{
+	icon_state = "bar"
 	},
 /area/f13/bunker)
 "fWM" = (
@@ -2977,6 +4112,15 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
+"fYG" = (
+/obj/structure/sign/departments/medbay,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"fYJ" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "fYY" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -2992,6 +4136,16 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"gan" = (
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "gbZ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -3019,6 +4173,22 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
+/area/f13/bunker)
+"gdI" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"gdV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"gem" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "geI" = (
 /obj/machinery/computer/cargo,
@@ -3071,6 +4241,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"gis" = (
+/obj/structure/closet/crate/secure/loot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "giH" = (
 /obj/machinery/washing_machine,
 /obj/item/clothing/under/sundress,
@@ -3097,6 +4275,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"gjH" = (
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "gkf" = (
 /obj/machinery/door/window/brigdoor/security/cell/northleft{
 	dir = 4
@@ -3110,6 +4294,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"gla" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"glx" = (
+/obj/structure/table/reinforced,
+/obj/item/stock_parts/cell/ammo/mfc,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "glR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
@@ -3181,6 +4378,14 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/bunker)
+"gpd" = (
+/obj/structure/table/abductor{
+	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
+	name = "advanced table"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "grL" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner{
@@ -3211,6 +4416,21 @@
 /obj/item/storage/box/PDAs,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"gso" = (
+/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"gsR" = (
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "gsV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/reagent_containers/pill/radx,
@@ -3230,6 +4450,12 @@
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"guW" = (
+/obj/effect/turf_decal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "gvo" = (
 /obj/structure/closet/crate/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -3243,6 +4469,11 @@
 /obj/item/stamp/qm,
 /turf/open/floor/plasteel/neutral,
 /area/f13/vault)
+"gwg" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "gwo" = (
 /obj/structure/table/wood,
 /obj/item/crafting/timer,
@@ -3253,12 +4484,28 @@
 "gwy" = (
 /turf/closed/wall/rust,
 /area/f13/bunker)
+"gwK" = (
+/obj/machinery/door/airlock/grunge/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "gxS" = (
 /obj/structure/table/wood,
 /obj/item/trash/plate,
 /obj/item/trash/f13/steak,
 /turf/open/floor/f13{
 	icon_state = "bar"
+	},
+/area/f13/bunker)
+"gyx" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "gyP" = (
@@ -3334,6 +4581,10 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
+"gCH" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "gCQ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -3363,10 +4614,25 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"gDZ" = (
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "gEI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"gEV" = (
+/obj/structure/rack,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "gGd" = (
@@ -3377,6 +4643,15 @@
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"gGE" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"gGN" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "gHj" = (
 /obj/structure/table/wood/bar,
 /obj/machinery/chem_dispenser/drinks,
@@ -3410,6 +4685,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"gKm" = (
+/obj/structure/timeddoor,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "gKr" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/bunker)
@@ -3463,6 +4742,19 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
+"gOC" = (
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"gOP" = (
+/mob/living/simple_animal/hostile/handy{
+	faction = list("bonnie")
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "gOQ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
@@ -3521,10 +4813,25 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"gRP" = (
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "gSY" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"gTd" = (
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "gTQ" = (
 /obj/structure/chair{
 	dir = 8
@@ -3563,6 +4870,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"gWN" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "gXl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3614,6 +4925,15 @@
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
+/area/f13/bunker)
+"gZA" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/f13/vault{
+	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "hah" = (
 /obj/structure/closet/crate,
@@ -3698,6 +5018,16 @@
 	icon_state = "housebase"
 	},
 /area/f13/bunker)
+"hem" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"heI" = (
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "heT" = (
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
@@ -3727,12 +5057,20 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"hkw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "hkV" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/f13/bubblegum,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
+/area/f13/bunker)
+"hlA" = (
+/obj/item/rack_parts,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "hlY" = (
 /obj/structure/window/reinforced{
@@ -3766,6 +5104,10 @@
 /obj/item/clothing/suit/f13/hubologist,
 /turf/open/floor/holofloor/carpet,
 /area/f13/bunker)
+"hnF" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "hnN" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/grown/apple/gold{
@@ -3793,12 +5135,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"hoJ" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/cans,
+/obj/item/ammo_box/c10mm,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "hpf" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"hpE" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "hpM" = (
 /obj/machinery/light{
 	dir = 8;
@@ -3818,6 +5171,23 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"hrv" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"hrE" = (
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	name = "prewar lounge chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "hrW" = (
 /obj/effect/turf_decal/bot,
 /obj/item/gun/energy/laser/aer9,
@@ -3828,6 +5198,20 @@
 	dir = 1
 	},
 /area/f13/vault)
+"htR" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
+"huf" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "huM" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/shaker{
@@ -3840,6 +5224,18 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"hwn" = (
+/obj/structure/closet/wardrobe,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"hwz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "hwO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line,
@@ -3874,6 +5270,11 @@
 "hzJ" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
+"hzS" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "hBr" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -3911,6 +5312,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"hDJ" = (
+/obj/structure/debris/v4,
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "hEy" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/cram,
@@ -3960,6 +5366,10 @@
 /obj/item/bedsheet/hos,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"hJJ" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "hKl" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/vault/v113,
@@ -3994,6 +5404,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/bunker)
+"hOY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "hQl" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
@@ -4024,11 +5444,42 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"hRY" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/curtain,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/bunker)
+"hSM" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"hSP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "hTa" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
 	},
+/area/f13/bunker)
+"hUm" = (
+/obj/item/rack_parts,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/ammo_box/a762box,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "hUS" = (
 /obj/structure/urinal{
@@ -4046,11 +5497,33 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"hWl" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "bonnief3"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"hWD" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "hXi" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
+/area/f13/bunker)
+"hXL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/debris/v3,
+/turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "hYn" = (
 /obj/structure/flora/stump,
@@ -4071,11 +5544,34 @@
 /obj/item/reagent_containers/food/condiment/rice,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
+"hYr" = (
+/obj/machinery/vending/nukacolavend,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"hYt" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"hZq" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "hZN" = (
 /turf/open/floor/plasteel/caution{
 	dir = 5
 	},
 /area/f13/vault)
+"hZY" = (
+/obj/machinery/door/airlock/grunge/abandoned,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "iaE" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/mug/tea{
@@ -4109,6 +5605,10 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
+"icw" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "icB" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -4140,6 +5640,11 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"ifw" = (
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "igB" = (
 /turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
@@ -4186,12 +5691,74 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"ijS" = (
+/obj/structure/debris/v3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"ikx" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"ikQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"imh" = (
+/obj/structure/chair/bench,
+/obj/item/clothing/under/f13/vault{
+	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"imk" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "imP" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"imR" = (
+/obj/structure/sign/poster/prewar/poster92,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"inj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"inW" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "bonnief2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"iob" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"ipG" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "ipO" = (
 /obj/structure/toilet{
 	dir = 1
@@ -4202,6 +5769,16 @@
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/vault)
+"iqq" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"iqV" = (
+/obj/item/shovel/spade,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "irk" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt,
@@ -4294,6 +5871,21 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"izl" = (
+/turf/open/floor/plating/tunnel,
+/area/f13/underground/cave)
+"izq" = (
+/obj/structure/rack,
+/obj/item/storage/backpack/security,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"izK" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "izR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2"
@@ -4321,6 +5913,11 @@
 /obj/item/stack/sheet/animalhide/deathclaw,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
+"iCh" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "iCR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -4344,10 +5941,21 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/vault)
+"iFr" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "iFM" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/bunker)
+"iGb" = (
+/obj/effect/turf_decal/box,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "iGc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4360,6 +5968,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
+"iGp" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"iGD" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "iGW" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -4379,6 +5996,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"iHT" = (
+/obj/structure/mirror,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"iIm" = (
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "iJa" = (
 /obj/effect/turf_decal/arrows{
 	dir = 1
@@ -4423,13 +6049,53 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"iKb" = (
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"iKg" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"iKC" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "bonnief2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "iKK" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
+"iLx" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "iMf" = (
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/r_wall/f13/vault,
+/area/f13/bunker)
+"iMx" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"iNF" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "iOh" = (
 /obj/structure/chair,
@@ -4451,6 +6117,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"iPk" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/diy,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"iQg" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "iQt" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -4466,6 +6141,12 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
+/area/f13/bunker)
+"iRR" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/brews,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "iSF" = (
 /obj/machinery/status_display/supply{
@@ -4492,6 +6173,11 @@
 	dir = 1
 	},
 /area/f13/vault)
+"iVf" = (
+/turf/closed/indestructible/fakedoor{
+	name = "Impassable Airlock"
+	},
+/area/f13/bunker)
 "iVn" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = 6;
@@ -4512,11 +6198,22 @@
 	dir = 8
 	},
 /area/f13/vault)
+"iWi" = (
+/obj/structure/sign/poster/prewar/vault_tec,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "iWv" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/vault)
+"iWT" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "iXy" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -4558,6 +6255,12 @@
 /obj/machinery/light/sign,
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
+"jaA" = (
+/obj/effect/turf_decal/loading_area/white,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "jaY" = (
 /obj/machinery/smartfridge/food,
 /turf/open/floor/plasteel/cafeteria,
@@ -4572,6 +6275,14 @@
 	},
 /turf/open/floor/wood,
 /area/f13/vault)
+"jcW" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/f13/vault{
+	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "jcY" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -4579,6 +6290,21 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/radiation)
+"jdk" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"jdp" = (
+/obj/structure/debris/v3,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "jdx" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/steak,
@@ -4622,6 +6348,15 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"jge" = (
+/obj/machinery/door/poddoor/preopen{
+	id = bonnie
+	},
+/obj/effect/turf_decal/loading_area/white{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "jhe" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -4653,6 +6388,31 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/bunker)
+"jjT" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"jks" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/bunker)
+"jkO" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"jkS" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "jkZ" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste,
@@ -4676,6 +6436,11 @@
 	icon_state = "verticalrightborderlefttop"
 	},
 /area/f13/wasteland)
+"jmn" = (
+/obj/structure/chair/bench,
+/obj/item/soap,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "joZ" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -4697,6 +6462,14 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"jqD" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "jru" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -4704,6 +6477,24 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
+/area/f13/bunker)
+"jrw" = (
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"jrV" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/f13/vault{
+	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
+	},
+/obj/item/clothing/under/f13/vault{
+	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "jsf" = (
 /obj/structure/table,
@@ -4723,6 +6514,11 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
+/area/f13/bunker)
+"juh" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jvp" = (
 /obj/machinery/conveyor{
@@ -4763,6 +6559,12 @@
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/f13/vault)
+"jyE" = (
+/obj/machinery/door/airlock/grunge/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "jAa" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -4825,6 +6627,11 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"jFH" = (
+/obj/structure/spider/stickyweb,
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "jFN" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4833,6 +6640,11 @@
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"jGU" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "jIZ" = (
 /obj/structure/table,
 /obj/item/kitchen/knife/butcher,
@@ -4852,6 +6664,14 @@
 /obj/machinery/vending/sovietsoda,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"jMI" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "jNI" = (
 /obj/structure/window/reinforced{
 	color = "#000000";
@@ -4930,10 +6750,24 @@
 	dir = 4
 	},
 /area/f13/vault)
+"jQm" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/bunker)
 "jQF" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/neutral,
 /area/f13/vault)
+"jQX" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/bunker)
 "jRj" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/bubblegum/large,
@@ -4953,6 +6787,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"jUo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "jUG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -4988,6 +6830,14 @@
 /obj/item/storage/fancy/cigarettes/cigpack_cannabis,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"jWJ" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"jXR" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "jZk" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -4996,6 +6846,13 @@
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"jZC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "kaB" = (
 /obj/machinery/computer/security{
 	network = list("vault")
@@ -5038,6 +6895,11 @@
 "kcN" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"kez" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "keC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -5085,6 +6947,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"kkm" = (
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"kku" = (
+/obj/structure/debris/v4,
+/obj/structure/debris/v3,
+/turf/closed/indestructible/rock,
+/area/f13/underground/cave)
+"kkB" = (
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench";
+	tag = "icon-bench (EAST)"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "kkC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5149,6 +7028,10 @@
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"kqW" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "krK" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -5187,6 +7070,11 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
+/area/f13/bunker)
+"ktr" = (
+/obj/structure/chair/bench,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "ktL" = (
 /obj/machinery/light{
@@ -5234,6 +7122,13 @@
 	dir = 10
 	},
 /area/f13/vault)
+"kvY" = (
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "kws" = (
 /obj/structure/table/wood,
 /obj/item/grenade/empgrenade,
@@ -5245,6 +7140,35 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
+/area/f13/bunker)
+"kxU" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"kzb" = (
+/obj/structure/table/abductor{
+	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
+	name = "advanced table"
+	},
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"kzq" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"kBe" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "kBU" = (
 /obj/structure/flora/ausbushes/stalkybush,
@@ -5260,6 +7184,15 @@
 	icon_state = "grass2"
 	},
 /area/f13/vault)
+"kCm" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	faction = list("bonnie")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "kCt" = (
 /obj/structure/table,
 /obj/machinery/camera/autoname{
@@ -5272,6 +7205,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"kCz" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "kCB" = (
 /obj/item/detective_scanner,
 /obj/structure/closet,
@@ -5300,6 +7238,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"kEx" = (
+/obj/structure/table/abductor{
+	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
+	name = "advanced table"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "kEV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5323,6 +7269,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"kFt" = (
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"kFA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "kFE" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief of Security's Quarters";
@@ -5351,6 +7309,12 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"kGc" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "kGC" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -5361,6 +7325,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"kIl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"kIu" = (
+/obj/structure/debris/v3,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "kKj" = (
 /obj/machinery/computer/robotics{
 	dir = 1
@@ -5370,6 +7348,34 @@
 "kLr" = (
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
+"kLM" = (
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"kMy" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"kMA" = (
+/obj/structure/timeddoor,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"kMP" = (
+/obj/structure/table/abductor{
+	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
+	name = "advanced table"
+	},
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "kMR" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -5412,6 +7418,13 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"kNE" = (
+/obj/structure/chair/f13chair2,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "kNH" = (
 /obj/effect/landmark/start/cyborg,
 /obj/structure/cable{
@@ -5424,6 +7437,9 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
+/area/f13/bunker)
+"kPi" = (
+/turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "kPN" = (
 /obj/structure/bed,
@@ -5454,6 +7470,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"kSB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "kTb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/mechanic,
@@ -5476,10 +7496,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"kTz" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "kTA" = (
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
+"kTV" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/diy,
+/obj/item/ammo_box/m44box,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "kUP" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks,
@@ -5504,6 +7534,15 @@
 /obj/item/t_scanner/adv_mining_scanner/lesser,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
+"kXd" = (
+/obj/structure/table/abductor{
+	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
+	name = "advanced table"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "kYb" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light{
@@ -5511,6 +7550,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault)
+"kYJ" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "kZg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5538,6 +7583,23 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/holofloor/carpet,
 /area/f13/bunker)
+"ldj" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/f13/vault{
+	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"ldu" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/hooded/wintercoat/security,
+/obj/item/storage/backpack/security,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "led" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -5545,6 +7607,11 @@
 /obj/effect/landmark/start/f13/vaultdoctor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
+"lei" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "leD" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -5554,6 +7621,12 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
+/area/f13/bunker)
+"lfp" = (
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "lfA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5661,6 +7734,13 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"lmk" = (
+/obj/machinery/vending/hydronutrients,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "loi" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -5727,6 +7807,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"lwe" = (
+/obj/structure/sign/departments/security,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "lwj" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green,
@@ -5749,6 +7833,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"lyw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "lyx" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating/tunnel{
@@ -5760,10 +7850,37 @@
 /obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
+"lzg" = (
+/obj/structure/sign/departments/examroom,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "lBB" = (
 /turf/open/floor/f13{
 	icon_state = "stagestairs"
 	},
+/area/f13/bunker)
+"lBC" = (
+/obj/structure/table,
+/obj/item/pen/fourcolor,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"lCe" = (
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/obj/structure/curtain,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/bunker)
+"lDI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "lDQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5772,6 +7889,9 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
+"lEy" = (
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "lFA" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/gloves/f13/leather,
@@ -5779,6 +7899,9 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/bunker)
+"lGc" = (
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "lGv" = (
 /turf/open/floor/plasteel/showroomfloor,
@@ -5797,6 +7920,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"lJT" = (
+/obj/effect/turf_decal{
+	dir = 5
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"lKF" = (
+/obj/item/soap,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "lKO" = (
 /obj/structure/table/wood,
 /obj/item/crafting/capacitor,
@@ -5804,6 +7938,16 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
+/area/f13/bunker)
+"lLb" = (
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	name = "prewar lounge chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "lLW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -5864,11 +8008,33 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
+"lPS" = (
+/obj/structure/table/abductor{
+	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
+	name = "advanced table"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"lQf" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "lQh" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
+/area/f13/bunker)
+"lQW" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "lQZ" = (
 /obj/structure/cable{
@@ -5898,6 +8064,20 @@
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"lST" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"lTT" = (
+/obj/item/soap/deluxe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/bunker)
 "lVf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/broken{
@@ -5906,6 +8086,16 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
+/area/f13/bunker)
+"lVz" = (
+/obj/structure/nest/ghoul,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"lXR" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "lYs" = (
 /obj/structure/rack,
@@ -5942,6 +8132,14 @@
 	color = "000000"
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"mab" = (
+/obj/structure/table/abductor{
+	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
+	name = "advanced table"
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "mas" = (
 /obj/structure/timeddoor,
@@ -5999,10 +8197,23 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
+"mdw" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "mdB" = (
 /obj/effect/landmark/start/f13/vaultscientist,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"mdH" = (
+/obj/structure/closet/wardrobe,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "mei" = (
 /obj/machinery/computer/cargo/request{
 	dir = 8
@@ -6018,12 +8229,21 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"mfg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "mfA" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/f13/power_armor/excavator,
 /obj/item/clothing/head/helmet/f13/power_armor/excavator,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"mfE" = (
+/obj/machinery/door/airlock/grunge/abandoned,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "mgb" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/f13/wood{
@@ -6057,11 +8277,34 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
+"mhD" = (
+/obj/structure/chair/bench,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "mif" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"miI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"mkh" = (
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "mkT" = (
 /obj/structure/chair{
 	dir = 8
@@ -6076,6 +8319,13 @@
 /obj/item/crafting/abraxo,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/vault)
+"mlq" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "mlI" = (
 /obj/machinery/door/airlock{
 	name = "Gym"
@@ -6124,6 +8374,11 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"mre" = (
+/obj/structure/closet/wardrobe,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "mrz" = (
 /obj/structure/rack,
 /obj/item/seeds/tomato,
@@ -6151,6 +8406,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"msq" = (
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/structure/table,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "msD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6203,6 +8466,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"mvd" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "mvi" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
@@ -6230,6 +8497,17 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"mwk" = (
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/suit/f13/lonesome{
+	name = "bonnie's duster"
+	},
+/obj/effect/decal/remains/human{
+	name = "bonnie day"
+	},
+/obj/effect/decal/waste,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "mwr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6238,6 +8516,11 @@
 	dir = 8
 	},
 /area/f13/vault)
+"mwF" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "mwO" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -6280,6 +8563,21 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
+"myz" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "myJ" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -6300,12 +8598,20 @@
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"mzx" = (
+/obj/item/trash/f13/cram,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "mzC" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck/cas/black,
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
+/area/f13/bunker)
+"mzK" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "mAs" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6423,6 +8729,12 @@
 /obj/item/tank/internals/anesthetic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"mKP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "mKW" = (
 /turf/open/floor/wood,
 /area/f13/vault)
@@ -6435,6 +8747,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"mMh" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "mML" = (
 /obj/machinery/conveyor{
 	dir = 5;
@@ -6449,6 +8766,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"mMQ" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "mNt" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -6464,6 +8790,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"mOe" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/obj/structure/curtain{
+	color = "red"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
+"mOp" = (
+/obj/item/gun/energy/laser/aer9,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "mOt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6488,6 +8831,16 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"mQj" = (
+/obj/structure/timeddoor,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"mQM" = (
+/obj/item/crafting/fuse,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "mRj" = (
 /obj/machinery/light{
 	dir = 4
@@ -6553,11 +8906,27 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"mVO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "mWs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
+"mXe" = (
+/obj/structure/table,
+/obj/machinery/door/window/brigdoor/eastright{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "mXh" = (
 /obj/structure/closet/bus,
 /obj/structure/ladder/unbreakable{
@@ -6572,6 +8941,17 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
+"mXx" = (
+/obj/item/storage/trash_stack,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"mXO" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "mYm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -6588,6 +8968,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/vault)
+"nbU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "nbW" = (
 /obj/structure/rack,
 /obj/item/pen,
@@ -6608,18 +8992,43 @@
 /obj/structure/mirror,
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
+"ncH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "ndi" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"nea" = (
+/obj/structure/mirror,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "neE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/f13/steak,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"nfg" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "nfs" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
+"ngP" = (
+/obj/structure/closet/wardrobe,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"ngV" = (
+/obj/item/trash/f13/cram,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "nhA" = (
 /obj/machinery/door/airlock/science/glass{
 	name = "Research Storage";
@@ -6703,6 +9112,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"nqy" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "nqG" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -6717,6 +9137,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/timeddoor,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"nqW" = (
+/obj/structure/stacklifter,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"nqY" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy{
+	faction = list("bonnie")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "nre" = (
 /obj/structure/table,
@@ -6761,6 +9192,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"nuF" = (
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench";
+	tag = "icon-bench (EAST)"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "nvz" = (
 /obj/structure/flora/ausbushes,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -6803,10 +9246,31 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"nzg" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "nzV" = (
 /obj/machinery/vr_sleeper,
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
+	},
+/area/f13/bunker)
+"nAk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/bunker)
+"nAW" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "nBk" = (
@@ -6826,6 +9290,11 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker)
+"nCO" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "nDB" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -6844,12 +9313,23 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"nEh" = (
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "nEt" = (
 /obj/structure/rack,
 /obj/item/soap,
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
+/area/f13/bunker)
+"nER" = (
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "nFb" = (
 /obj/structure/chair/wood/modern,
@@ -6939,6 +9419,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"nMa" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/bunker)
+"nMe" = (
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "nMP" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
 /obj/effect/decal/cleanable/dirt{
@@ -7010,6 +9506,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/vault)
+"nQx" = (
+/obj/structure/nest/ghoul,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"nQM" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "nRJ" = (
 /obj/structure/fence{
 	icon_state = "metal_fence3"
@@ -7032,6 +9537,10 @@
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"nTD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "nTV" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = 7;
@@ -7040,6 +9549,10 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"nTX" = (
+/obj/item/soap/homemade,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "nVp" = (
 /obj/structure/stacklifter,
 /turf/open/floor/plasteel/dark,
@@ -7056,6 +9569,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"nXd" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "nXh" = (
 /turf/open/floor/holofloor/carpet,
 /area/f13/bunker)
@@ -7081,6 +9599,12 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
+/area/f13/bunker)
+"nYP" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "nZb" = (
 /obj/structure/wreck/trash/secway,
@@ -7109,6 +9633,15 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
+	},
+/area/f13/bunker)
+"oaO" = (
+/obj/structure/wreck/trash/three_barrels,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "obv" = (
@@ -7142,6 +9675,18 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
+"ocQ" = (
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"ocT" = (
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "ocW" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -7169,10 +9714,22 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"oeE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "oeJ" = (
 /mob/living/simple_animal/hostile/cazador/young,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ofe" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
+/obj/item/ammo_box/c45,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "ofx" = (
 /obj/machinery/workbench,
 /obj/effect/spawner/lootdrop/f13/blueprintVHigh,
@@ -7230,6 +9787,11 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
+"ojg" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "ojG" = (
 /obj/structure/sign/directions/science{
 	dir = 4;
@@ -7240,11 +9802,24 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"oks" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "oky" = (
 /obj/structure/simple_door/wood,
 /obj/structure/barricade/wooden/planks,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
+"omg" = (
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "omC" = (
 /obj/structure/table,
 /obj/item/assembly/flash/handheld,
@@ -7262,6 +9837,14 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"onR" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"orE" = (
+/obj/structure/debris/v3,
+/turf/closed/indestructible/rock,
+/area/f13/bunker)
 "orV" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -7315,6 +9898,27 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/vault)
+"ovb" = (
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	name = "prewar lounge chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"ovs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"ovx" = (
+/obj/structure/table/glass,
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "owz" = (
 /obj/structure/rack,
 /obj/machinery/button/door{
@@ -7325,6 +9929,21 @@
 	},
 /turf/open/floor/wood,
 /area/f13/vault)
+"owA" = (
+/obj/item/storage/trash_stack,
+/obj/structure/spider/stickyweb,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"oxh" = (
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "oxp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7360,6 +9979,12 @@
 	icon_state = "grass2"
 	},
 /area/f13/bunker)
+"ozN" = (
+/obj/structure/table,
+/obj/machinery/door/window/brigdoor/eastright,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "ozS" = (
 /obj/structure/chair,
 /obj/structure/cable{
@@ -7367,11 +9992,38 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
+"oAb" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"oBP" = (
+/obj/effect/turf_decal/delivery,
+/obj/item/soap/deluxe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/bunker)
 "oCN" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
+"oDm" = (
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"oDy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"oDX" = (
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "oFd" = (
 /mob/living/simple_animal/hostile/cazador,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7385,6 +10037,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"oHw" = (
+/obj/structure/table,
+/obj/item/trash/chips,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "oHA" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -7406,6 +10067,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"oHK" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "oIm" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -7414,6 +10079,10 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/bunker)
+"oIu" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "oJF" = (
 /obj/item/candle/tribal_torch,
@@ -7441,12 +10110,22 @@
 	icon_state = "housebase"
 	},
 /area/f13/bunker)
+"oNG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "oNI" = (
 /obj/structure/closet/crate/wooden,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"oNJ" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "oNM" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -7472,6 +10151,12 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"oPB" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "oPO" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottomright"
@@ -7504,11 +10189,27 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"oUF" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "oUH" = (
 /obj/structure/table,
 /obj/item/integrated_circuit_printer,
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
+"oUO" = (
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"oVe" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "oVD" = (
 /obj/structure/table/wood,
 /obj/item/crafting/board,
@@ -7533,6 +10234,17 @@
 /obj/item/coin/iron,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"oXE" = (
+/obj/structure/chair{
+	dir = 8;
+	tag = "icon-chair (WEST)"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "oXI" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1
@@ -7580,6 +10292,13 @@
 /obj/effect/decal/waste,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"pbh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "pcc" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Generator Room";
@@ -7591,6 +10310,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"pdY" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
+"peh" = (
+/obj/structure/table,
+/obj/item/ship_in_a_bottle,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "pet" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/fifty,
@@ -7613,6 +10348,14 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
+"pfx" = (
+/obj/structure/table,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	faction = list("bonnie")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "phj" = (
 /obj/structure/window/spawner/east,
 /obj/structure/window/spawner/north,
@@ -7646,6 +10389,18 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"pii" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain,
+/obj/structure/decoration/vent,
+/obj/item/soap,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/bunker)
 "pix" = (
 /obj/effect/turf_decal/box,
@@ -7698,6 +10453,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"pkF" = (
+/obj/structure/table/abductor{
+	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
+	name = "advanced table"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"plg" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "plk" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
@@ -7753,6 +10522,9 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"ppD" = (
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "ppF" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
@@ -7797,6 +10569,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"psT" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "psY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7850,6 +10628,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
+"pxn" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "pxp" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -7866,6 +10653,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"pze" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/f13/vault{
+	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "pzq" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -7900,6 +10695,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"pBW" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "pCj" = (
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt,
@@ -7908,6 +10707,20 @@
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
+"pCP" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"pDr" = (
+/mob/living/simple_animal/hostile/handy{
+	faction = list("bonnie")
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "pEA" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/caution,
@@ -7915,6 +10728,10 @@
 "pFL" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"pGv" = (
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "pHv" = (
 /obj/machinery/light{
@@ -7937,6 +10754,24 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
+"pJq" = (
+/obj/item/stock_parts/cell/ammo/mfc,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"pJE" = (
+/obj/structure/chalkboard,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"pKB" = (
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "pKG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7945,12 +10780,25 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"pLJ" = (
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "pMg" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"pMG" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "pML" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -7962,6 +10810,25 @@
 /obj/item/stock_parts/cell/ammo/mfc,
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/vault)
+"pOA" = (
+/obj/effect/turf_decal/loading_area/white{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"pOE" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/curtain,
+/obj/item/soap/homemade,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/bunker)
 "pOK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7998,6 +10865,11 @@
 /obj/item/reagent_containers/food/snacks/benedict,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"pRK" = (
+/obj/structure/closet/crate/bin,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "pSo" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -8020,6 +10892,38 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"pSZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	faction = list("bonnie")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"pTm" = (
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
+"pTw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"pUC" = (
+/obj/structure/debris/v4,
+/turf/closed/indestructible/rock,
+/area/f13/underground/cave)
 "pVj" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8031,6 +10935,27 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
+"pVK" = (
+/obj/item/storage/belt/security,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"pVX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"pWa" = (
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "pWk" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -8062,12 +10987,34 @@
 	icon_state = "grass2"
 	},
 /area/f13/bunker)
+"pZB" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"pZM" = (
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "qan" = (
 /obj/structure/sign/poster/official/help_others,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
 /area/f13/vault)
+"qaE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"qaW" = (
+/obj/item/trash/f13/cram_large,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "qbf" = (
 /obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/plasteel/showroomfloor,
@@ -8137,6 +11084,12 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"qfC" = (
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	faction = list("bonnie")
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "qfH" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -8152,6 +11105,13 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"qgQ" = (
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "qhc" = (
 /obj/machinery/button/crematorium{
@@ -8247,6 +11207,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"qmC" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "qnc" = (
 /obj/effect/decal/remains/robot,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -8258,6 +11224,30 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
+"qoT" = (
+/obj/machinery/door/airlock/public/glass{
+	req_access_txt = "31"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"qps" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"qpv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"qpZ" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "qqt" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -8265,6 +11255,14 @@
 /obj/item/storage/fancy/cigarettes/cigars,
 /obj/item/lighter/greyscale,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"qrk" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/bunker)
 "qrP" = (
 /obj/structure/chair/comfy/beige{
@@ -8282,6 +11280,15 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"qtu" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "qtI" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/cable{
@@ -8304,12 +11311,52 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
+"qvJ" = (
+/obj/structure/table,
+/obj/item/trash/candy,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "qxa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
+"qxc" = (
+/obj/structure/sign/poster/ripped,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"qxd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"qxt" = (
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"qxz" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
+"qxA" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "qxK" = (
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8372,6 +11419,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"qCI" = (
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "qCP" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief of Security";
@@ -8399,6 +11453,15 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
+"qDm" = (
+/obj/structure/wreck/trash/two_barrels,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "qEC" = (
 /obj/machinery/light{
 	dir = 4
@@ -8411,11 +11474,49 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"qFp" = (
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench";
+	tag = "icon-bench (WEST)"
+	},
+/obj/item/storage/backpack/security,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"qFx" = (
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"qFI" = (
+/obj/structure/debris/v3,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"qFX" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "qGR" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/bunker)
+"qGV" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "qHi" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -8441,6 +11542,23 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"qJO" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"qKT" = (
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"qLm" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "qLG" = (
 /obj/structure/fence{
 	dir = 4
@@ -8474,6 +11592,12 @@
 	},
 /turf/open/floor/wood,
 /area/f13/vault)
+"qMm" = (
+/obj/structure/vault_door/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "qNg" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/knife,
@@ -8509,6 +11633,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"qRG" = (
+/obj/structure/table,
+/obj/item/pda/security,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "qRI" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -8539,6 +11671,13 @@
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
+"qVa" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "qVM" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall/r_wall/f13vault{
@@ -8592,13 +11731,45 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"qXc" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "qXt" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"qYa" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "qYk" = (
 /obj/structure/timeddoor,
 /turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
+"qYn" = (
+/obj/structure/debris/v3,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"qZt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"qZM" = (
+/obj/machinery/door/airlock/grunge/abandoned,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "rag" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8637,6 +11808,25 @@
 	},
 /obj/item/trash/f13/blamco_large,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"rdH" = (
+/obj/structure/closet/wardrobe,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"rdW" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"reH" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "reP" = (
 /obj/machinery/autolathe,
@@ -8718,6 +11908,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
+"rjy" = (
+/obj/effect/turf_decal{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "rkE" = (
 /obj/machinery/light{
 	dir = 8;
@@ -8746,20 +11943,44 @@
 "rog" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"roz" = (
+/obj/effect/turf_decal/arrows,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "rpl" = (
 /obj/structure/sign/poster/prewar/protectron,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
 /area/f13/vault)
+"rpu" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "rpx" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
+"rqo" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "rqq" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/vault)
+"rqs" = (
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"rqt" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "rrf" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/yellow/side{
@@ -8798,6 +12019,12 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
+/area/f13/bunker)
+"rsG" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "rsJ" = (
 /obj/structure/simple_door/bunker,
@@ -8928,6 +12155,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"rCs" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/item/stock_parts/cell/ammo/mfc,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "rCD" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -8935,6 +12167,11 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"rCF" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "rEj" = (
 /obj/machinery/door/airlock/science/glass{
@@ -8946,6 +12183,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"rEw" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"rEM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "rEO" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -9002,10 +12250,20 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"rGC" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "rGG" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"rIp" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "rIK" = (
 /turf/open/floor/plasteel/yellow/side{
@@ -9046,6 +12304,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"rMR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "rMV" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -9066,6 +12332,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"rNE" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "rOf" = (
 /obj/machinery/light,
 /turf/open/floor/f13{
@@ -9091,6 +12365,62 @@
 	},
 /turf/open/floor/plating/f13,
 /area/f13/vault)
+"rPS" = (
+/obj/structure/nest/ghoul,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"rQa" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"rRq" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"rRw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"rRW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"rSM" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "rTj" = (
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -9099,6 +12429,11 @@
 /obj/item/twohanded/spear/bonespear/deathclaw,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
+"rTP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "rUE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9131,10 +12466,38 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"rXC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	faction = list("bonnie")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "rYh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
+	},
+/area/f13/bunker)
+"sao" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"sax" = (
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"saJ" = (
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"sbi" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
 	},
 /area/f13/bunker)
 "sbq" = (
@@ -9168,11 +12531,38 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"sdx" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"sdO" = (
+/obj/structure/nest/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"sfl" = (
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"shu" = (
+/obj/structure/dresser,
+/obj/item/stack/medical/gauze/cyborg,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "shZ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
+"sis" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "sje" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -9204,6 +12594,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
+"skp" = (
+/obj/structure/closet/wardrobe,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "skQ" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/robot_debris/down,
@@ -9224,6 +12619,12 @@
 "soK" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
+"spp" = (
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "sqU" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -9243,6 +12644,12 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"suq" = (
+/obj/structure/bookcase/random,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/item/book/manual/random,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "suK" = (
 /obj/machinery/hydroponics/soil{
 	mutmod = 0;
@@ -9250,6 +12657,12 @@
 	yieldmod = 1.3
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"svz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/bunker)
 "svU" = (
 /obj/machinery/light/broken{
@@ -9302,6 +12715,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"sAp" = (
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "sAG" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -9325,6 +12745,12 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"sBi" = (
+/obj/structure/closet/wardrobe,
+/obj/effect/spawner/lootdrop/crafts,
+/obj/effect/spawner/lootdrop/crafts,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "sBA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/f13/mre,
@@ -9333,6 +12759,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"sCz" = (
+/mob/living/simple_animal/hostile/handy{
+	faction = list("bonnie")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "sCP" = (
 /obj/machinery/chem_heater,
@@ -9346,6 +12779,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
+"sDX" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "sDY" = (
 /obj/machinery/light{
 	dir = 1
@@ -9365,6 +12805,15 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"sFf" = (
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "sGi" = (
 /obj/structure/window/reinforced{
 	color = "#000000"
@@ -9378,6 +12827,14 @@
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
+/area/f13/bunker)
+"sIg" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "sJr" = (
 /obj/structure/table/wood,
@@ -9400,6 +12857,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
+"sLn" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "sLM" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "rampdowntop"
@@ -9410,6 +12874,17 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"sMQ" = (
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
+	dir = 8;
+	light_color = "#008000";
+	name = "light tube"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "sNj" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -9417,6 +12892,20 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
+	},
+/area/f13/bunker)
+"sNw" = (
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"sOE" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "sOK" = (
@@ -9432,11 +12921,21 @@
 	dir = 4
 	},
 /area/f13/vault)
+"sPl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "sPs" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"sQb" = (
+/obj/structure/chair/bench,
+/obj/item/soap,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "sQV" = (
 /obj/structure/table/reinforced,
 /obj/item/crafting/coffee_pot{
@@ -9459,6 +12958,18 @@
 /obj/item/stock_parts/cell/ammo/ec,
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/vault)
+"sRF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "sRQ" = (
 /turf/open/floor/plasteel/caution{
 	dir = 8
@@ -9466,6 +12977,21 @@
 /area/f13/vault)
 "sST" = (
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"sTk" = (
+/obj/structure/closet/wardrobe,
+/obj/item/clothing/under/f13/vault{
+	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"sTP" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "sVf" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -9481,6 +13007,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"sXV" = (
+/obj/item/storage/trash_stack,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"sZi" = (
+/obj/structure/closet/wardrobe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "tak" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/floor/f13{
@@ -9492,6 +13030,13 @@
 /obj/structure/barricade/wooden/planks,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"taU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "tcX" = (
@@ -9511,6 +13056,32 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"ten" = (
+/obj/structure/closet/wardrobe,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"teM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"tfE" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"tfR" = (
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "tfS" = (
 /obj/structure/table/wood,
 /obj/item/crafting/buzzer,
@@ -9526,21 +13097,55 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"tgG" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "thj" = (
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"thm" = (
+/obj/machinery/computer/robotics,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "thU" = (
 /obj/effect/landmark/map_load_mark/dungeons/oasisbunker,
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
+"tiq" = (
+/obj/structure/table/abductor{
+	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
+	name = "advanced table"
+	},
+/obj/item/toy/redbutton{
+	anchored = 1;
+	desc = "A large button which is connected to a mass of wires that snake across the room... can't be good. It was triggered long ago.";
+	name = "Used Detonator"
+	},
+/obj/item/clothing/glasses/hud/diagnostic/night,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"tjD" = (
+/obj/structure/table/abductor{
+	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
+	name = "advanced table"
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "tkj" = (
 /obj/machinery/chem_master/advanced,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"tlG" = (
+/obj/structure/vault_door/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "tlL" = (
 /obj/effect/turf_decal/box,
 /obj/structure/cable{
@@ -9552,6 +13157,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"tpm" = (
+/obj/structure/closet/wardrobe,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "tqm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9570,6 +13180,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
+"tqH" = (
+/obj/structure/closet/wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"tqU" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "bonnief3"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "trf" = (
 /obj/structure/chair{
 	dir = 1
@@ -9577,6 +13203,10 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
+/area/f13/bunker)
+"trg" = (
+/obj/structure/chair/bench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "tro" = (
 /turf/open/floor/plasteel/yellow/side{
@@ -9611,6 +13241,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"trQ" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "tsO" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood{
@@ -9684,6 +13318,15 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"txI" = (
+/obj/structure/table/abductor{
+	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
+	name = "advanced table"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "txK" = (
 /obj/structure/chair{
 	dir = 8
@@ -9693,6 +13336,13 @@
 "txX" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"tyj" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "tyy" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -9702,6 +13352,11 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
+"tyC" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "tyX" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal,
@@ -9714,6 +13369,10 @@
 	},
 /obj/structure/wreck/trash/brokenvendor,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"tzv" = (
+/obj/machinery/computer/upload/ai,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "tzA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9736,6 +13395,11 @@
 /obj/item/reagent_containers/food/drinks/soda_cans,
 /turf/open/floor/wood,
 /area/f13/vault)
+"tBs" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "tCc" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 1
@@ -9751,10 +13415,35 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"tDE" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"tEv" = (
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "tEQ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"tER" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"tES" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/effect/turf_decal/loading_area,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "tFW" = (
 /obj/structure/campfire/stove,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -9792,6 +13481,10 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"tJh" = (
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "tLi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -9824,6 +13517,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"tOa" = (
+/obj/effect/turf_decal/loading_area/white{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "tOo" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 3;
@@ -9845,6 +13545,20 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"tOX" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"tRe" = (
+/obj/structure/chair/stool{
+	icon_state = "bench_center";
+	tag = "icon-bench_center"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "tRn" = (
 /obj/machinery/light{
 	dir = 1
@@ -9853,6 +13567,14 @@
 	dir = 1
 	},
 /area/f13/vault)
+"tRp" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "tRT" = (
 /obj/structure/chair{
 	dir = 1
@@ -9863,6 +13585,14 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
+/area/f13/bunker)
+"tRV" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "bonnief3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "tSp" = (
 /obj/effect/landmark/map_load_mark/dungeons/north,
@@ -9898,6 +13628,25 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"tWw" = (
+/obj/machinery/door/airlock/grunge/abandoned,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"tXe" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"tYe" = (
+/obj/structure/ladder/unbreakable{
+	desc = "An extremely sturdy metal ladder that leads up to the surface, over 500 feet above. Don't fall...";
+	height = 1;
+	id = "digsite";
+	name = "ladder to the surface"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "tYu" = (
 /turf/open/floor/plasteel/darkred/side{
 	dir = 4
@@ -9907,6 +13656,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
+"tYY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "tZZ" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -9914,6 +13667,12 @@
 "uau" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"ubY" = (
+/obj/structure/closet/wardrobe,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "ucK" = (
 /obj/machinery/door/airlock/engineering{
@@ -10012,6 +13771,13 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"unt" = (
+/obj/structure/showcase/machinery/tv,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "uof" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -10033,6 +13799,21 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
+"uoM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"upS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"uqs" = (
+/obj/structure/sign/poster/prewar/poster82,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "ura" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -10049,6 +13830,9 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
+"use" = (
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "usf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10064,6 +13848,16 @@
 /obj/structure/toilet,
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
+	},
+/area/f13/bunker)
+"usU" = (
+/obj/structure/toilet{
+	dir = 1;
+	tag = "icon-toilet00 (NORTH)"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
 	},
 /area/f13/bunker)
 "utf" = (
@@ -10116,6 +13910,11 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
+"uxq" = (
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "uym" = (
 /obj/item/wirerod,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -10145,6 +13944,11 @@
 /obj/structure/window/reinforced/tinted,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"uAx" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "uAJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -10187,6 +13991,25 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
+"uDT" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"uGe" = (
+/mob/living/simple_animal/hostile/handy{
+	faction = list("bonnie")
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "uGH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_dispenser/drinks,
@@ -10217,6 +14040,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
+"uJJ" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "uKd" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -10230,6 +14059,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"uKZ" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "uLc" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -10261,6 +14099,17 @@
 /obj/item/flashlight/seclite,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"uLV" = (
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"uLW" = (
+/obj/structure/vault_door/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "uMj" = (
 /obj/structure/chair/left,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -10287,6 +14136,19 @@
 /obj/effect/spawner/lootdrop/minor/beret_or_rabbitears,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"uOt" = (
+/obj/structure/table/abductor{
+	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
+	name = "advanced table"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "uPo" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
@@ -10320,6 +14182,19 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"uTG" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/item/stock_parts/cell/ammo/ec,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"uUb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "uWi" = (
 /obj/machinery/light{
 	dir = 4
@@ -10423,6 +14298,33 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
+"vfl" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"vgw" = (
+/obj/machinery/status_display{
+	desc = "A large glass display, used to show various types of information.";
+	text = "REACTOR FAILURE"
+	},
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"vgB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"vgY" = (
+/obj/item/book/manual/hydroponics_pod_people,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "vhM" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 1
@@ -10468,6 +14370,10 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
+"vkv" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "vkw" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/f13/vaultdweller,
@@ -10480,11 +14386,34 @@
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"vlg" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"vlx" = (
+/obj/machinery/status_display{
+	desc = "A large glass display, used to show various types of information.";
+	text = "REACTOR FAILURE"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"vlz" = (
+/obj/structure/weightlifter,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "vlG" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"vlX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "vnb" = (
 /obj/structure/rack,
 /obj/item/stock_parts/cell/high,
@@ -10511,6 +14440,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"vod" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "voz" = (
 /obj/structure/cable{
@@ -10560,6 +14493,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"vrn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "vrE" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/vault)
@@ -10619,6 +14558,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"vwN" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "vwT" = (
 /obj/structure/guncase/shotgun,
 /obj/effect/turf_decal/bot,
@@ -10629,6 +14575,11 @@
 	dir = 9
 	},
 /area/f13/vault)
+"vxP" = (
+/obj/item/crafting/fuse,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "vyw" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -10656,6 +14607,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"vBb" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "vBk" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -10688,6 +14645,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"vBU" = (
+/obj/structure/chair/comfy/lime{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "vCa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10702,6 +14665,17 @@
 /obj/item/clothing/shoes/wheelys,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"vCR" = (
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"vDp" = (
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	faction = list("bonnie")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "vDG" = (
 /obj/structure/sign/poster/prewar/poster80,
 /turf/closed/wall/f13/tentwall,
@@ -10723,6 +14697,10 @@
 "vGm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"vGI" = (
+/obj/structure/rack,
+/turf/open/floor/carpet/black,
 /area/f13/bunker)
 "vHC" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -10770,6 +14748,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"vLP" = (
+/obj/structure/sign/poster/prewar/poster90,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "vNb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -10835,6 +14817,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"vRQ" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "vSG" = (
 /obj/machinery/door/airlock,
 /obj/structure/cable{
@@ -10860,6 +14850,10 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
+"vUn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "vUz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/broken{
@@ -10887,6 +14881,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
+"vVK" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "vXb" = (
 /obj/machinery/rnd/production/protolathe,
 /turf/open/floor/plasteel/darkpurple/side{
@@ -10900,6 +14900,10 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
+"vYa" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "vYm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -10931,6 +14935,12 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"wbg" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "wbl" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
@@ -10942,6 +14952,25 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
+	},
+/area/f13/bunker)
+"wdn" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
+"wdu" = (
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "wdw" = (
@@ -11001,6 +15030,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/vault)
+"wfI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
+"wgs" = (
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "whC" = (
 /obj/structure/closet/toolcloset,
 /obj/structure/cable{
@@ -11037,6 +15081,21 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"wni" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"wnp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "wnY" = (
 /obj/structure/sign/poster/official/foam_force_ad,
 /turf/closed/wall/r_wall/f13vault{
@@ -11066,6 +15125,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"wqn" = (
+/obj/structure/sign/poster/prewar/poster83,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "wqW" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/lawyer/red,
@@ -11099,6 +15162,18 @@
 	icon_state = "carpetsymbol"
 	},
 /area/f13/bunker)
+"wrR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"wsd" = (
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "wsg" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -11106,6 +15181,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"wsN" = (
+/obj/structure/chair/bench,
+/obj/item/clothing/under/f13/vault{
+	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "wui" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
@@ -11282,6 +15365,13 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"wBc" = (
+/obj/machinery/status_display{
+	desc = "A large glass display, used to show various types of information.";
+	text = "E__RORORORoOOOoRRR"
+	},
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "wBi" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -11290,11 +15380,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"wBn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "wBx" = (
 /turf/open/floor/plasteel/darkpurple/corner{
 	dir = 1
 	},
 /area/f13/vault)
+"wBO" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "wBX" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/cable{
@@ -11305,6 +15407,15 @@
 "wCN" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
+"wDv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "wDy" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -11318,6 +15429,11 @@
 	icon_state = "horizontaltopbordertop2"
 	},
 /area/f13/wasteland)
+"wEY" = (
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "wFW" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/gutsy/nsb,
@@ -11394,11 +15510,37 @@
 	icon_state = "verticaloutermaintop"
 	},
 /area/f13/wasteland)
+"wKS" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
+"wLw" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"wMr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "wMC" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /obj/structure/window/reinforced/tinted,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"wNf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "wNg" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/vault)
@@ -11410,6 +15552,10 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
+"wOy" = (
+/obj/machinery/computer/crew,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "wOA" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase/lawyer,
@@ -11431,6 +15577,12 @@
 "wQi" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"wQl" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "wQM" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -11457,6 +15609,13 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
+"wSE" = (
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "wTv" = (
 /obj/machinery/light{
 	dir = 1;
@@ -11464,6 +15623,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"wUT" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/cans,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "wUX" = (
 /obj/machinery/light{
 	dir = 8;
@@ -11496,6 +15660,14 @@
 	dir = 1
 	},
 /area/f13/vault)
+"wWI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "wXu" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -11506,6 +15678,18 @@
 /area/f13/vault)
 "wYe" = (
 /turf/closed/wall/r_wall/f13/vault,
+/area/f13/bunker)
+"wYh" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"wYm" = (
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "wYZ" = (
 /obj/structure/rack,
@@ -11523,6 +15707,16 @@
 /obj/item/defibrillator,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
+"wZV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button{
+	id = bonnie
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "xaI" = (
 /obj/structure/window/reinforced{
 	color = "#000000";
@@ -11555,6 +15749,37 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"xbo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"xdm" = (
+/obj/structure/debris/v4,
+/obj/structure/debris/v3,
+/turf/open/floor/plating/tunnel,
+/area/f13/underground/cave)
+"xdG" = (
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	name = "prewar lounge chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"xes" = (
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "xeO" = (
 /obj/structure/girder/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -11577,9 +15802,21 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
+"xgd" = (
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "xhC" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"xhZ" = (
+/obj/structure/rack,
+/obj/item/holosign_creator/security,
+/obj/item/gun/energy/laser/wattz,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "xiS" = (
 /obj/machinery/newscaster/security_unit{
@@ -11599,11 +15836,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"xld" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "xly" = (
 /obj/structure/table/optable,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"xlP" = (
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "xmF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11625,6 +15870,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
+"xoO" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"xpp" = (
+/obj/machinery/door/airlock/grunge/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "xpD" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/caves)
@@ -11649,6 +15905,19 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"xqr" = (
+/obj/item/rack_parts,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/item/ammo_box/a357box,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "xrO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/departments/botany,
@@ -11661,6 +15930,11 @@
 /obj/item/ship_in_a_bottle,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"xsf" = (
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "xsv" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -11685,6 +15959,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
+"xuK" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"xuM" = (
+/obj/structure/closet/wardrobe,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "xuQ" = (
 /obj/machinery/door/airlock{
 	name = "Restrooms"
@@ -11702,6 +15985,15 @@
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"xvF" = (
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
+/obj/structure/curtain,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/bunker)
 "xwn" = (
 /obj/machinery/biogenerator,
 /obj/machinery/light{
@@ -11775,6 +16067,13 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"xAs" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "xBm" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/rollingpin,
@@ -11803,6 +16102,10 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"xCx" = (
+/obj/structure/chalkboard,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
 "xEJ" = (
 /obj/structure/cable,
 /obj/item/radio/intercom{
@@ -11812,6 +16115,19 @@
 	},
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
+"xFh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"xFO" = (
+/obj/effect/turf_decal{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "xHP" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -11841,6 +16157,12 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
+/area/f13/bunker)
+"xKq" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "xLW" = (
 /obj/structure/rack,
@@ -11910,12 +16232,28 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"xSa" = (
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	faction = list("bonnie")
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "xSr" = (
 /obj/machinery/workbench/advanced,
 /turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
 /area/f13/vault)
+"xSv" = (
+/obj/machinery/status_display{
+	desc = "A large glass display, used to show various types of information.";
+	text = "WARNING!!"
+	},
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "xSD" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/flora/ausbushes/fullgrass{
@@ -11946,9 +16284,41 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/bunker)
+"xTD" = (
+/obj/effect/turf_decal/arrows,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"xUv" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "xUK" = (
 /obj/structure/sign/departments/science,
 /turf/closed/wall/r_wall/f13/vault,
+/area/f13/bunker)
+"xVs" = (
+/obj/machinery/door/airlock/grunge/abandoned,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"xXu" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"xXx" = (
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "xXG" = (
 /obj/structure/table/wood,
@@ -11956,6 +16326,14 @@
 /obj/item/pen,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
+	},
+/area/f13/bunker)
+"xYn" = (
+/obj/structure/table,
+/obj/item/clothing/suit/hooded/wintercoat/security,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "xYC" = (
@@ -11978,6 +16356,13 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
+"xZp" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "yaD" = (
 /obj/structure/chair,
 /obj/machinery/light/broken{
@@ -11993,6 +16378,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"ybc" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "ybF" = (
 /obj/structure/sink{
 	dir = 8;
@@ -12031,6 +16420,14 @@
 "yeh" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/radiation)
+"yek" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/item/stock_parts/cell/ammo/mfc,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/bunker)
 "yeV" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -12054,11 +16451,35 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"yfG" = (
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"yfW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "ygg" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
+/area/f13/bunker)
+"yhm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "yhp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12066,6 +16487,24 @@
 	icon_state = "outermaincornerouter"
 	},
 /area/f13/wasteland)
+"yhs" = (
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/mentats{
+	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
+	name = "Pre-War Medicine"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"yiB" = (
+/obj/structure/table/abductor{
+	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
+	name = "advanced table"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "yjg" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -12079,6 +16518,10 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
+"yko" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/brews,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "yks" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -20966,11 +25409,11 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
+djC
+kku
+djC
+djC
+pUC
 heT
 heT
 heT
@@ -21223,11 +25666,11 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
+erG
+izl
+biC
+xdm
+biC
 heT
 heT
 heT
@@ -21477,47 +25920,47 @@ bsh
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+eKa
+bCx
+eKa
+vod
+vod
+vod
+eKa
+vod
+czt
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
 heT
 heT
 heT
@@ -21734,47 +26177,47 @@ bsh
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+egB
+cGm
+kRy
+ulM
+kRy
+eZH
+kRy
+kRy
+gKm
+nmg
+hYt
+kRy
+xKq
+kRy
+cGm
+kRy
+kRy
+kRy
+kRy
+kRy
+eZH
+kRy
+kRy
+kRy
+vod
+ulM
+vod
+kRy
+kRy
+eZH
+nmg
+kRy
+kRy
+uXT
+kRy
+hYt
+kRy
+qYn
+uXT
+kRy
+eKa
 heT
 heT
 heT
@@ -21991,47 +26434,47 @@ bsh
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+egB
+qFI
+kRy
+kRy
+uXT
+kRy
+nmg
+nmg
+mQj
+kRy
+uXT
+aSb
+kRy
+nmg
+ulM
+kRy
+uXT
+nmg
+kRy
+rPS
+ulM
+kRy
+uXT
+qFI
+kRy
+hYt
+kRy
+kRy
+kRy
+ulM
+kRy
+uXT
+kRy
+kRy
+kRy
+vod
+kRy
+uXT
+nQx
+ulM
+eKa
 heT
 heT
 heT
@@ -22248,47 +26691,47 @@ bsh
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+cGm
+cGm
+nmg
+uXT
+tYe
+kRy
+kRy
+kRy
+kMA
+kRy
+kRy
+kRy
+vod
+kRy
+kRy
+vod
+kRy
+kRy
+kRy
+kRy
+kRy
+kRy
+nmg
+kRy
+uXT
+kRy
+nmg
+lVz
+ulM
+kRy
+kRy
+cGm
+uXT
+bnW
+kRy
+vod
+kRy
+ulM
+kRy
+kRy
+eKa
 heT
 heT
 heT
@@ -22505,47 +26948,47 @@ bsh
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+cGm
+egB
+kRy
+kRy
+nmg
+uXT
+ulM
+kRy
+gKm
+nmg
+uXT
+vod
+kRy
+ulM
+uXT
+kRy
+hYt
+nmg
+kRy
+kRy
+kRy
+ulM
+kRy
+vod
+kRy
+kRy
+ulM
+kRy
+kRy
+uXT
+kRy
+kRy
+nmg
+kRy
+kRy
+hYt
+nmg
+kRy
+kRy
+cGm
+eKa
 heT
 heT
 heT
@@ -22762,47 +27205,47 @@ bsh
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+qFI
+kRy
+kRy
+kRy
+kRy
+iMx
+nmg
+kRy
+gKm
+kRy
+hYt
+kRy
+kRy
+kRy
+kRy
+kRy
+kRy
+nmg
+cGm
+kRy
+iMx
+kRy
+kRy
+kRy
+vod
+kRy
+cGm
+kRy
+kRy
+hrv
+kRy
+kRy
+ulM
+kRy
+nmg
+vod
+kRy
+kRy
+kRy
+kRy
+eKa
 heT
 heT
 heT
@@ -23019,47 +27462,47 @@ bsh
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+czt
+eKa
+eKa
+eKa
+kRy
+egB
+qFI
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+eKa
+hYt
+iqq
+iqq
+aSb
+vod
+eKa
 heT
 heT
 heT
@@ -23287,6 +27730,11 @@ heT
 heT
 heT
 heT
+eKa
+hrv
+uXT
+kRy
+eKa
 heT
 heT
 heT
@@ -23305,18 +27753,13 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+eKa
+rpu
+kRy
+jdp
+kRy
+mzK
+eKa
 heT
 heT
 heT
@@ -23544,6 +27987,11 @@ heT
 heT
 heT
 heT
+eKa
+eKa
+eKa
+eKa
+eKa
 heT
 heT
 heT
@@ -23562,18 +28010,13 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bDt
+kRy
+kRy
+ulM
+kRy
+uXT
+bDt
 heT
 heT
 heT
@@ -23823,15 +28266,15 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+cIT
+lEy
+kRy
+ulM
+nmg
+kRy
+iOE
+lEy
+cIT
 heT
 heT
 heT
@@ -24080,15 +28523,15 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+cIT
+lEy
+kRy
+gEI
+kRy
+kOH
+gEI
+lEy
+cIT
 heT
 heT
 heT
@@ -24314,6 +28757,17 @@ heT
 heT
 heT
 heT
+bTF
+bTF
+bTF
+bTF
+bTF
+heT
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -24325,28 +28779,17 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+cIT
+cIT
+lEy
+kRy
+iOE
+iOE
+iOE
+kRy
+lEy
+lEy
+cIT
 heT
 heT
 heT
@@ -24570,6 +29013,20 @@ heT
 heT
 heT
 heT
+bTF
+bTF
+dwp
+bTF
+dwp
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -24579,31 +29036,17 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+cIT
+lEy
+lEy
+kRy
+iOE
+iOE
+gEI
+kRy
+lEy
+lEy
+cIT
 heT
 heT
 heT
@@ -24827,6 +29270,21 @@ heT
 heT
 heT
 heT
+bTF
+fEM
+fEM
+kIl
+vrn
+fEM
+bTF
+bTF
+bTF
+fEM
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -24834,32 +29292,17 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+cIT
+cIT
+lEy
+lEy
+fRE
+iOE
+iOE
+iOE
+ulM
+lEy
+cIT
 heT
 heT
 heT
@@ -25084,39 +29527,39 @@ heT
 heT
 heT
 heT
+bTF
+fEM
+mkh
+vrn
+agQ
+vrn
+kYJ
+vrn
+vrn
+eIp
+fEM
+fEM
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+cIT
+lEy
+lEy
+lEy
+iOE
+fRE
+iOE
+iOE
+kRy
+lEy
+cIT
 heT
 heT
 heT
@@ -25341,40 +29784,40 @@ heT
 heT
 heT
 heT
+bTF
+vrn
+evw
+sOE
+pMG
+vrn
+bTF
+bTF
+bTF
+eIp
+wWI
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+cIT
+cIT
+lEy
+lEy
+lEy
+iOE
+kOH
+nmg
+iOE
+kRy
+lEy
+lEy
+cIT
 heT
 heT
 heT
@@ -25598,40 +30041,40 @@ heT
 heT
 heT
 heT
+bTF
+vrn
+vrn
+pJq
+vrn
+vrn
+tYY
+bTF
+bTF
+bTF
+vrn
+fEM
+vrn
+vrn
+pVK
+fEM
+ldu
+bTF
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+cIT
+cIT
+lEy
+lEy
+lEy
+iOE
+iOE
+kRy
+fRE
+kRy
+lEy
+lEy
+cIT
 heT
 heT
 heT
@@ -25855,39 +30298,39 @@ heT
 heT
 heT
 heT
+bTF
+pJq
+vrn
+vrn
+eIp
+fEM
+bTF
+tYY
+bTF
+bTF
+vrn
+vrn
+wWI
+fEM
+psT
+nEh
+izq
+bTF
 heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+cIT
+lEy
+lEy
+bDt
+fRE
+iOE
+fRE
+iOE
+iOE
+bDt
+cIT
 heT
 heT
 heT
@@ -26112,39 +30555,39 @@ heT
 heT
 heT
 heT
+bTF
+fEM
+vrn
+vrn
+vrn
+fEM
+bTF
+bTF
+bTF
+bTF
+fEM
+fEM
+boZ
+xYn
+fEM
+vrn
+gEV
+bTF
 heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+cIT
+lEy
+lEy
+eKa
+uoM
+kRy
+kOH
+iOE
+pbh
+eKa
+cIT
 heT
 heT
 heT
@@ -26369,38 +30812,38 @@ heT
 heT
 heT
 heT
+bTF
+lwe
+vkv
+bTF
+ami
+lwe
+bTF
+bTF
+tYY
+bTF
+kYJ
+bTF
+bTF
+bTF
+nuF
+fEM
+vVK
+bTF
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+cIT
+cIT
+lEy
+lEy
+lEy
+lEy
+kRy
+fRE
+iOE
+uXT
+iOE
+lEy
 heT
 heT
 heT
@@ -26627,37 +31070,37 @@ heT
 heT
 heT
 heT
+bTF
+tfE
+aVX
+aVX
+bTF
+bTF
+bTF
+qRG
+fEM
+pJq
+mOp
+evw
+bTF
+tRe
+vrn
+vVK
+bTF
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+cIT
+cIT
+lEy
+lEy
+lEy
+lEy
+lEy
+ulM
+iOE
+iOE
+kRy
+iOE
+lEy
 heT
 heT
 heT
@@ -26874,48 +31317,48 @@ bsh
 heT
 heT
 heT
+bTF
+bTF
+tYY
+tYY
+tYY
+tYY
+bTF
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+lGc
+lGc
+lGc
+bTF
+bTF
+bTF
+fEM
+vrn
+biV
+fEM
+msq
+bTF
+qFp
+vrn
+xhZ
+bTF
+cIT
+lEy
+lEy
+lEy
+lEy
+lEy
+lEy
+lEy
+kRy
+eyz
+fRE
+kRy
+iOE
+lEy
+cIT
 heT
 heT
 heT
@@ -27131,48 +31574,48 @@ bsh
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+nCO
+aVX
+sBi
+ubY
+mdH
+bTF
+bTF
+bTF
+bTF
+lwe
+vkv
+bTF
+vkv
+lwe
+bTF
+bTF
+evw
+vrn
+vrn
+biV
+fEM
+bTF
+bTF
+bTF
+bTF
+iWi
+vDp
+lEy
+lEy
+lEy
+lEy
+lEy
+lEy
+qfC
+kRy
+eyz
+kRy
+nmg
+iOE
+qfC
+cIT
 heT
 heT
 heT
@@ -27388,49 +31831,49 @@ bsh
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+gdI
+aVX
+tXe
+aVX
+lGc
+tYY
+tYY
+bTF
+iWi
+hYr
+lGc
+vDp
+lGc
+lGc
+iWi
+bTF
+bTF
+lST
+lST
+lST
+bTF
+bTF
+bTF
+bTF
+nzg
+eEz
+aVX
+hwz
+lEy
+lEy
+lEy
+lEy
+lEy
+bDt
+iOE
+jZC
+iOE
+kRy
+iOE
+bDt
+lEy
+cIT
 heT
 heT
 heT
@@ -27645,49 +32088,49 @@ bsh
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+trQ
+rqs
+pKB
+yhm
+lGc
+bTF
+pSZ
+aVX
+pGv
+lGc
+aVX
+lGc
+lGc
+pGv
+ciC
+tYY
+rXC
+aVX
+aVX
+aVX
+rXC
+bTF
+bTF
+vfl
+bGY
+aVX
+aVX
+aVX
+lGc
+lEy
+lEy
+lEy
+eKa
+eKa
+uoM
+kRy
+uXT
+kRy
+qZt
+eKa
+lEy
+cIT
 heT
 heT
 heT
@@ -27902,49 +32345,49 @@ bsh
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+tYY
+ozN
+oPB
+inj
+tWw
+bTF
+aVX
+bGY
+bGY
+aVX
+aVX
+tfE
+aVX
+aVX
+aVX
+inj
+wEY
+nER
+wEY
+nER
+nER
+bTF
+fsx
+bGY
+mKP
+dYF
+tfR
+wsd
+ocQ
+lGc
+nmg
+nmg
+xKq
+kOH
+kRy
+kRy
+iOE
+kRy
+iOE
+lEy
+lEy
+cIT
 heT
 heT
 heT
@@ -28159,6 +32602,48 @@ bsh
 heT
 heT
 heT
+bTF
+dva
+aVX
+aVX
+tfR
+lGc
+lGc
+lGc
+wsd
+tfR
+bGY
+bGY
+pGv
+ocQ
+aVX
+bGY
+qoT
+lGc
+gsR
+lGc
+aVX
+rjy
+lGc
+dYG
+aVX
+bGY
+aVX
+aVX
+bGY
+aVX
+pGv
+ocQ
+nmg
+nmg
+kOH
+nmg
+kRy
+iOE
+gEI
+ulM
+lEy
+cIT
 heT
 heT
 heT
@@ -28195,51 +32680,9 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bJn
+djC
+djC
 heT
 heT
 heT
@@ -28416,6 +32859,48 @@ bsh
 heT
 heT
 heT
+iWi
+wnp
+aVX
+aVX
+bGY
+aVX
+aVX
+lGc
+bGY
+aVX
+bGY
+bGY
+lGc
+lGc
+aVX
+aVX
+qoT
+lGc
+aVX
+aVX
+iGD
+xZp
+tlG
+guW
+wBO
+bGY
+bGY
+lGc
+aVX
+cdD
+aVX
+aVX
+lGc
+iOE
+nmg
+kRy
+iOE
+kRy
+iOE
+kRy
+lEy
+cIT
 heT
 heT
 heT
@@ -28448,55 +32933,13 @@ heT
 heT
 heT
 heT
+lEy
+eNK
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+lEy
+eNK
+ijS
+orE
 heT
 heT
 heT
@@ -28673,6 +33116,49 @@ bsh
 heT
 heT
 heT
+bTF
+iKC
+lGc
+lGc
+gsR
+lGc
+lGc
+aVX
+dYF
+tfR
+lGc
+mKP
+dYF
+ocQ
+bGY
+aVX
+qoT
+lGc
+ocQ
+aVX
+aVX
+lJT
+lGc
+xFO
+aVX
+aVX
+lGc
+aVX
+lGc
+cdD
+wsd
+gsR
+iOE
+taU
+kOH
+kOH
+kRy
+nmg
+kRy
+uXT
+lEy
+cIT
+koh
 heT
 heT
 heT
@@ -28702,58 +33188,15 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+eNK
+lEy
+lEy
+eNK
+pDr
+lEy
+lEy
+lEy
+ijS
 heT
 heT
 heT
@@ -28930,6 +33373,49 @@ bsh
 heT
 heT
 heT
+bTF
+bTF
+mXe
+uAx
+bTF
+xpp
+bTF
+lGc
+tfE
+aVX
+bGY
+bGY
+aVX
+aVX
+lGc
+lGc
+bTF
+nER
+nER
+nER
+nER
+nER
+bTF
+lGc
+lGc
+aVX
+dYF
+ocQ
+wsd
+dFh
+lGc
+nmg
+nmg
+pCP
+nmg
+kRy
+kRy
+uXT
+kRy
+mzK
+eKa
+lEy
+cIT
 heT
 heT
 heT
@@ -28960,57 +33446,14 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+lEy
+lEy
+lEy
+lEy
+koh
+eNK
+lEy
+koh
 heT
 heT
 heT
@@ -29187,84 +33630,84 @@ bsh
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+trQ
+aPN
+sLn
+nYP
+lGc
+bTF
+kCm
+lGc
+pGv
+lGc
+lfp
+aVX
+lGc
+pGv
+ciC
+bTF
+rXC
+aVX
+aVX
+aVX
+rXC
+bTF
+bTF
+ecz
+aVX
+aVX
+lGc
+aVX
+lGc
+lEy
+lEy
+lEy
+eKa
+eKa
+lEy
+lEy
+lEy
+lEy
+eKa
+eKa
+lEy
+cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+heT
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+lEy
+lEy
+lEy
+lEy
+dUV
 heT
 heT
 heT
@@ -29444,82 +33887,82 @@ bsh
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+gdI
+aVX
+bGY
+tXe
+aVX
+bTF
+bTF
+bTF
+iWi
+lGc
+lGc
+aVX
+aVX
+hYr
+iWi
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+nzg
+xUv
+aVX
+hwz
+hwz
+lEy
+lEy
+lEy
+lEy
+lEy
+lEy
+lEy
+lEy
+lEy
+lEy
+lEy
+cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+heT
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+lEy
+lEy
+lEy
+eNK
 heT
 heT
 heT
@@ -29701,81 +34144,81 @@ bsh
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+axd
+lGc
+mre
+aOr
+hwn
+tYY
+bTF
+bTF
+bTF
+bTF
+lGc
+vDp
+lGc
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+iWi
+vDp
+lEy
+cIT
+cIT
+cIT
+cIT
+cIT
+lEy
+lEy
+lEy
+lEy
+lEy
+lEy
+lEy
+cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+bTF
+bsH
+jQm
+aeW
+pii
+bTF
+heT
+bTF
+dsT
+rCF
+xXu
+aVX
+aVX
+duN
+trQ
+lzg
+bTF
+kzq
+lEy
+bTF
 heT
 heT
 heT
@@ -29958,9 +34401,21 @@ bsh
 heT
 heT
 heT
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
+bTF
+vkv
+bTF
+vkv
+bTF
 heT
 heT
 heT
@@ -29969,10 +34424,24 @@ heT
 heT
 heT
 heT
+bTF
+bTF
+bTF
+bTF
+cIT
+cIT
+cIT
 heT
 heT
 heT
 heT
+cIT
+lEy
+lEy
+lEy
+lEy
+lEy
+cIT
 heT
 heT
 heT
@@ -29986,63 +34455,37 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+aeW
+nMa
+jks
+usU
+tYY
+dtK
+bTF
+cht
+gWN
+cxx
+mQM
+lGc
+sCz
+bGY
+svz
+hwz
+kTz
+kTz
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -30225,7 +34668,11 @@ heT
 heT
 heT
 heT
+bTF
+kTz
+kTz
 heT
+bTF
 heT
 heT
 heT
@@ -30234,11 +34681,23 @@ heT
 heT
 heT
 heT
+lEy
+bTF
+bTF
+bTF
+cIT
+cIT
+cIT
 heT
 heT
 heT
 heT
 heT
+cIT
+cIT
+cIT
+cIT
+cIT
 heT
 heT
 heT
@@ -30252,54 +34711,38 @@ heT
 heT
 heT
 heT
+bTF
+bTF
+bTF
+cLe
+bTF
+bTF
+bTF
+bTF
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+fIZ
+mQM
+xlP
+iFr
+aVX
+lGc
+oDm
+gRP
+lEy
+kTz
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -30482,8 +34925,11 @@ heT
 heT
 heT
 heT
+bTF
+kTz
 heT
 heT
+bTF
 heT
 heT
 heT
@@ -30492,6 +34938,10 @@ heT
 heT
 heT
 heT
+cIT
+cIT
+bTF
+bTF
 heT
 heT
 heT
@@ -30518,46 +34968,39 @@ heT
 heT
 heT
 heT
+bTF
+bTF
+fax
+nTD
+rGC
+ifw
+bTF
+bTF
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+kqW
+aVX
+aVX
+aVX
+aVX
+lGc
+bTF
+wBn
+kTz
+kzq
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -30739,9 +35182,11 @@ heT
 heT
 heT
 heT
+bTF
 heT
 heT
 heT
+bTF
 heT
 heT
 heT
@@ -30780,41 +35225,39 @@ heT
 heT
 heT
 heT
+bTF
+bTF
+eMa
+vlg
+pZM
+ifw
+bTF
+bTF
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+dsT
+bSG
+rCF
+aVX
+aVX
+xXu
+tJh
+fnX
+svz
+kTz
+lGc
+vgY
+aVX
+aVX
+nYP
+cxx
+iqV
+tDE
+bKJ
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -31039,40 +35482,40 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+tBs
+deS
+hSP
+shu
+bTF
+bTF
+bTF
+bTF
+imR
+aCx
+sCz
+aVX
+vxP
+sCz
+lGc
+wqn
+svz
+bTF
+eOy
+lGc
+lGc
+fQD
+aVX
+aVX
+cKZ
+lGc
+rdW
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -31296,40 +35739,40 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+dMZ
+fiA
+nTD
+vlg
+ppD
+bTF
+bTF
+bTF
+bTF
+pRK
+lGc
+aVX
+aVX
+vxP
+ybc
+kzq
+kTz
+kTz
+aVX
+lGc
+bHD
+kez
+sCz
+kez
+cxx
+biX
+aVX
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -31553,40 +35996,40 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+peh
+myz
+vGI
+nTD
+con
+bTF
+bTF
+bTF
+bTF
+lGc
+aVX
+sfl
+aVX
+lGc
+lGc
+bTF
+kzq
+bTF
+qKT
+aVX
+lGc
+biX
+bGY
+biX
+lGc
+biX
+aVX
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -31779,73 +36222,73 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+inj
+bTF
+bTF
+bTF
+bTF
+bTF
+tYY
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+bTF
+bTF
+bTF
+mfE
+bTF
+bTF
+bTF
+bTF
+bTF
+lzg
+boi
+cBC
+lGc
+aVX
+bSG
+trQ
+dsT
+ayW
+bTF
+vYa
+gCH
+nqY
+biX
+aVX
+kez
+lGc
+biX
+cDm
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -32022,88 +36465,88 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+pZB
+dgI
+gwg
+upS
+upS
+use
+upS
+use
+upS
+gDZ
+boR
+gDZ
+boR
+boR
+boR
+gDZ
+upS
+gDZ
+upS
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+bTF
+bTF
+sax
+dGa
+sax
+iCh
+bTF
+bTF
+bTF
+akI
+dRJ
+sCz
+lGc
+aVX
+cxx
+gWN
+uqs
+bTF
+bTF
+iKb
+lGc
+aVX
+kez
+aVX
+biX
+sCz
+biX
+aVX
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -32279,89 +36722,89 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+tYY
+inj
+bTF
+bTF
+bTF
+bTF
+bTF
+upS
+qFX
+gwg
+upS
+qCI
+use
+use
+mvd
+upS
+upS
+aGG
+upS
+etY
+upS
+upS
+upS
+teM
+upS
+use
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+bTF
+nfg
+kxU
+hkw
+hkw
+cmy
+sax
+nfg
+bTF
+bTF
+fIZ
+lGc
+lGc
+mQM
+sfl
+lei
+bTF
+bTF
+bTF
+lmk
+lGc
+cKZ
+aVX
+bYr
+lGc
+aVX
+fQD
+wrR
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -32536,91 +36979,91 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+unt
+use
+xFh
+xbo
+qZM
+upS
+upS
+use
+xbo
+xbo
+upS
+oHK
+bTF
+use
+upS
+bTF
+upS
+iQg
+bTF
+tYY
+bTF
+bTF
+bEH
+bTF
+bEH
+bTF
+bTF
+bTF
+bEH
+tYY
+bEH
+bTF
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+qJO
+hkw
+sax
+sax
+dBR
+hkw
+sax
+kxU
+bTF
+bTF
+sfl
+aVX
+aVX
+aVX
+bGY
+xXx
+bTF
+bTF
+bTF
+rqt
+cxx
+bGY
+nqY
+sCz
+aVX
+aVX
+bHD
+cKZ
+bTF
+bTF
+bTF
+bTF
+bTF
+tDE
+tDE
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -32784,102 +37227,102 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+dtK
+heT
+heT
+heT
+heT
+heT
+heT
+dtK
+dtK
+bTF
+bTF
+nQM
+wYh
+tgG
+upS
+tYY
+nXd
+gOC
+upS
+wgs
+upS
+pLJ
+use
+bTF
+dtO
+use
+eqr
+use
+upS
+use
+use
+bTF
+ldj
+bEH
+aKv
+bEH
+fgG
+bTF
+tpm
+bEH
+bal
+vUn
+fgG
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+fDR
+hkw
+sax
+hkw
+hkw
+asn
+sax
+sax
+bTF
+fYG
+tRp
+tRp
+xpp
+tRp
+tRp
+fYG
+bTF
+bTF
+bTF
+tRp
+tRp
+tRp
+tRp
+tRp
+tRp
+tRp
+tRp
+htR
+bTF
+bTF
+bTF
+qxc
+rqo
+dvE
+tDE
+jFH
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -33040,103 +37483,103 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+tYY
+eHv
+bTF
+tYY
+bTF
+bTF
+bTF
+bTF
+tYY
+bTF
+bTF
+iWT
+rRq
+plg
+dpB
+fEp
+boR
+gOC
+use
+wgs
+upS
+pLJ
+use
+bTF
+rRq
+kBe
+bTF
+fMZ
+xTD
+upS
+qCI
+tYY
+ten
+vUn
+trg
+bEH
+fgG
+bTF
+skp
+ikQ
+trg
+bEH
+xuM
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+bRM
+hkw
+sax
+qps
+pfx
+hkw
+hkw
+ftE
+mOe
+jFH
+tDE
+lGc
+lGc
+aVX
+lGc
+bTF
+bTF
+bTF
+bTF
+owA
+xld
+aVX
+aVX
+aVX
+aVX
+bGY
+aVX
+kqW
+bTF
+bTF
+bTF
+buq
+aVX
+bGY
+aVX
+aVX
+vgB
+iWi
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -33297,103 +37740,103 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+tYY
+bTF
+eHv
+bTF
+aVX
+aVX
+aVX
+tXe
+aVX
+bvB
+tXe
+bTF
+tYY
+fEp
+gwg
+gwg
+tYY
+fUD
+bGR
+use
+wgs
+upS
+iGb
+oIu
+bTF
+fEp
+gwg
+bTF
+bTF
+bTF
+use
+upS
+bTF
+fgG
+vUn
+saJ
+vUn
+fgG
+bTF
+cfH
+bEH
+wsN
+ikQ
+skp
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+thm
+hkw
+sax
+hkw
+cmC
+eje
+sax
+sax
+mOe
+tDE
+lGc
+oxh
+aVX
+gsR
+ciC
+tDE
+bTF
+eHv
+eHv
+xgd
+vlX
+lGc
+lGc
+aVX
+lGc
+aVX
+lGc
+aVX
+bTI
+iWi
+mXO
+lGc
+aVX
+bGY
+lGc
+aVX
+aVX
+vlX
+rqo
+bTF
+bTF
 heT
 heT
 heT
@@ -33554,103 +37997,103 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+tYY
+tYY
+hXL
+xgd
+ocQ
+tfE
+xgd
+gsR
+aVX
+aVX
+gsR
+use
+kvY
+upS
+use
+kvY
+upS
+kvY
+xbo
+gDZ
+upS
+kvY
+boR
+kvY
+boR
+xbo
+kvY
+lKF
+pBW
+bTF
+use
+upS
+tYY
+pze
+vUn
+trg
+fDS
+fgG
+tYY
+tqH
+bEH
+trg
+vUn
+btD
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+sIg
+hkw
+sax
+hkw
+jjT
+vBU
+hkw
+wLw
+bTF
+mXO
+lGc
+aVX
+aVX
+aVX
+lGc
+lGc
+hDJ
+xgd
+hDJ
+lGc
+aVX
+lGc
+ocQ
+bRL
+aVX
+aVX
+bGY
+bGY
+rsG
+gsR
+oNJ
+aVX
+bGY
+aVX
+tDE
+gsR
+aVX
+inW
+aVX
+bTF
+bTF
 heT
 heT
 heT
@@ -33811,103 +38254,103 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+tYY
+tYY
+hXL
+qMm
+lGc
+tXe
+aVX
+lGc
+tXe
+tXe
+lGc
+uLW
+use
+upS
+qxd
+upS
+use
+use
+use
+boR
+use
+upS
+boR
+upS
+upS
+rTP
+use
+upS
+mvd
+bTF
+use
+upS
+bTF
+eat
+vUn
+jmn
+vUn
+rdH
+bTF
+skp
+vUn
+ktr
+vUn
+ten
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+suq
+sax
+kxU
+ovb
+hJJ
+sax
+dBR
+sax
+xpp
+aVX
+bGY
+lGc
+bGY
+lGc
+lGc
+lGc
+xgd
+xgd
+xgd
+kIu
+aVX
+lGc
+aVX
+aVX
+aVX
+lGc
+lGc
+oNJ
+aVX
+oNJ
+aVX
+bGY
+mKP
+bKJ
+tDE
+bKJ
+aVX
+lGc
+aVX
+qxc
+bTF
 heT
 heT
 heT
@@ -34068,103 +38511,103 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+tYY
+tYY
+eHv
+aVX
+gsR
+tXe
+tfE
+ocQ
+lGc
+reH
+gsR
+upS
+fHe
+use
+boR
+kvY
+use
+fHe
+use
+kvY
+upS
+kvY
+upS
+kvY
+use
+use
+fHe
+upS
+fwU
+bTF
+pVX
+upS
+bTF
+skp
+bEH
+gjH
+vUn
+fgG
+bTF
+eHo
+bEH
+trg
+bEH
+fgG
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vLP
+iKg
+hkw
+sax
+hkw
+hJJ
+blv
+dBR
+qpZ
+bTF
+mXO
+mKP
+ocT
+bGY
+oxh
+aVX
+tDE
+xgd
+eXs
+eXs
+lGc
+aVX
+lGc
+gsR
+lGc
+aVX
+lGc
+aVX
+bGY
+oNJ
+gsR
+oNJ
+aVX
+bRL
+aVX
+aVX
+ocQ
+aVX
+inW
+aVX
+bTF
+bTF
 heT
 heT
 heT
@@ -34325,103 +38768,103 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+tYY
+tYY
+hXL
+tYY
+tfE
+aVX
+aVX
+tXe
+aVX
+lGc
+tfE
+bTF
+bTF
+gwg
+gwg
+fEp
+bTF
+pVX
+wgs
+use
+pLJ
+upS
+gOC
+oIu
+bTF
+eqr
+bTF
+upS
+upS
+bTF
+use
+upS
+bTF
+fgG
+vUn
+imh
+vUn
+fgG
+bTF
+fgG
+ikQ
+trg
+vUn
+jrV
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+tzv
+hkw
+ftE
+hkw
+hJJ
+eje
+jUo
+hkw
+mOe
+aVX
+mKP
+lGc
+aVX
+aVX
+aVX
+lGc
+bTF
+bTF
+bTF
+tDE
+aVX
+lGc
+aVX
+aVX
+lGc
+aVX
+aVX
+aVX
+ciC
+iWi
+mXO
+lGc
+aVX
+aVX
+bKJ
+lGc
+aVX
+lGc
+rqo
+bTF
+bTF
 heT
 heT
 heT
@@ -34582,103 +39025,103 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+izK
+izK
+izK
+bTF
+bTF
+bTF
+xuK
+cOb
+jkO
+mlq
+gwg
+use
+wgs
+use
+gOC
+boR
+pLJ
+use
+bTF
+upS
+bTF
+upS
+upS
+tYY
+use
+nTX
+bTF
+jcW
+vUn
+ktr
+vUn
+fgG
+bTF
+tpm
+jGU
+saJ
+bEH
+xuM
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+ePB
+hkw
+sax
+jjT
+cyh
+hkw
+hkw
+sax
+mOe
+lQf
+aVX
+bGY
+aVX
+mKP
+ciC
+qxc
+bTF
+bTF
+bTF
+fBu
+bKJ
+aVX
+aVX
+lGc
+lGc
+lGc
+lGc
+xld
+bTF
+bTF
+bTF
+tDE
+tDE
+bGY
+aVX
+aVX
+bTI
+iWi
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -34842,98 +39285,98 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+bTF
+izK
+izK
+izK
+bTF
+bTF
+bTF
+wni
+oAb
+ikx
+fFe
+tYY
+upS
+wgs
+use
+wgs
+boR
+pLJ
+use
+bTF
+upS
+bTF
+lCe
+lCe
+tYY
+xvF
+xvF
+bTF
+sTk
+bEH
+saJ
+mMh
+xuM
+bTF
+fgG
+vUn
+saJ
+vUn
+aKF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+heT
+bTF
+wOy
+hkw
+hkw
+sax
+hkw
+sax
+hkw
+onR
+bTF
+bOP
+aVX
+mVO
+aVX
+aVX
+aVX
+bTF
+bTF
+bTF
+bTF
+tRp
+tRp
+htR
+htR
+tRp
+tRp
+tRp
+tRp
+tRp
+bTF
+bTF
+bTF
+qxc
+jFH
+aVX
+aVX
+sao
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -35099,97 +39542,97 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+vgw
+oDX
+oDX
+nbU
+nbU
+nbU
+vlx
+tYY
+unt
+wYh
+use
+tgG
+eqr
+use
+upS
+upS
+upS
+boR
+boR
+hzS
+bTF
+upS
+bTF
+lTT
+xbh
+aqG
+nAk
+xbh
+bTF
+gZA
+bEH
+saJ
+bEH
+sTk
+bTF
+xuM
+bEH
+saJ
+ikQ
+fgG
+bTF
+pJE
+rCs
+tyj
+oks
+tyC
+cOF
+icw
+oks
+bTF
+heT
+bTF
+nfg
+sax
+hkw
+hkw
+sax
+sax
+onR
+sax
+bTF
+bTF
+aVX
+aVX
+aVX
+aVX
+bvB
+bTF
+bTF
+bTF
+bTF
+iPk
+aVX
+lGc
+lGc
+aVX
+gOP
+aVX
+aVX
+aVX
+bTF
+bTF
+bTF
+bTF
+bTF
+vlX
+buq
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -35354,98 +39797,98 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+bTF
+auJ
+nbU
+oDy
+oDy
+nbU
+oDX
+bHL
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+use
+bTF
+fMu
+jQX
+oBP
+jQX
+jQX
+inj
+fgG
+bEH
+trg
+bEH
+fgG
+tYY
+fgG
+bEH
+sQb
+ikQ
+ngP
+tYY
+ncH
+sPl
+chm
+sPl
+sPl
+sPl
+sPl
+oks
+bTF
+heT
+bTF
+bTF
+nfg
+sax
+hkw
+hkw
+kxU
+sax
+nfg
+bTF
+bTF
+aVX
+aVX
+aVX
+aVX
+aVX
+bTF
+bTF
+bTF
+bTF
+fHE
+sCz
+dGj
+bGY
+iRR
+lGc
+hlA
+sCz
+dGj
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -35611,96 +40054,96 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+xSv
+oDX
+oDX
+kEx
+gpd
+oDX
+oDX
+tjD
+fPC
+oDX
+bTF
+dXG
+dQc
+qDm
+rIp
+bTF
+rSM
+apG
+gyx
+gla
+xAs
+gla
+tYY
+use
+bTF
+fWp
+pOE
+hRY
+hRY
+hRY
+bTF
+ldj
+bEH
+mhD
+bEH
+fgG
+bTF
+rdH
+vUn
+gan
+bEH
+sZi
+bTF
+xCx
+kkm
+kkm
+cXp
+cXp
+kkm
+kkm
+uTG
+bTF
+heT
+bTF
+bTF
+bTF
+sax
+sax
+sax
+iCh
+bTF
+bTF
+bTF
+bTF
+aVX
+bGY
+lGc
+aVX
+vlX
+bTF
+bTF
+bTF
+bTF
+iPk
+lGc
+hUm
+lGc
+fHE
+lGc
+fHE
+aVX
+kTV
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -35868,96 +40311,96 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+izK
+bbf
+nbU
+kzb
+nbU
+nbU
+oDX
+qxt
+oDX
+nbU
+kzb
+bTF
+aSe
+pTw
+nAW
+hZq
+bTF
+bTF
+wbg
+wZV
+qrk
+gla
+cph
+tYY
+use
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bEH
+bTF
+bEH
+bTF
+bTF
+bTF
+vUn
+bTF
+bEH
+bTF
+iWi
+sPl
+ngV
+ccu
+tOX
+tOX
+lBC
+sPl
+uTG
+bTF
+heT
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+iWi
+wnp
+jrw
+aVX
+oxh
+dLZ
+iWi
+bTF
+bTF
+bTF
+hoJ
+sCz
+dGj
+nqY
+wUT
+sCz
+fcl
+lGc
+jWJ
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -36125,94 +40568,94 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+izK
+bbf
+oDy
+kzb
+xdG
+nbU
+oDX
+nbU
+nbU
+hrE
+mab
+bTF
+tER
+gso
+mMQ
+dQc
+bTF
+bTF
+dRI
+tYY
+ipG
+tYY
+jyE
+bTF
+upS
+upS
+upS
+upS
+use
+use
+use
+eqr
+use
+bCK
+ceY
+bCK
+use
+wYh
+upS
+bCK
+ceY
+bCK
+use
+fHe
+sPl
+sPl
+kkm
+kkm
+sPl
+sPl
+kkm
+kkm
+bTF
+heT
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+aVX
+aVX
+lGc
+aVX
+aVX
+bTF
+bTF
+bTF
+bTF
+fHE
+lGc
+wUT
+lGc
+xqr
+aVX
+mwF
+lGc
+dop
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -36382,94 +40825,94 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+izK
+bbf
+hOY
+yiB
+nbU
+nbU
+rRw
+nbU
+nbU
+lDI
+txI
+tYY
+fwB
+uJJ
+rMR
+rIp
+bTF
+tYY
+gla
+gla
+pOA
+cph
+gla
+bTF
+tYY
+bTF
+jyE
+bTF
+bTF
+bTF
+bTF
+bTF
+use
+mzx
+use
+upS
+upS
+boR
+upS
+upS
+upS
+boR
+use
+upS
+ncH
+sPl
+sPl
+sPl
+gGE
+sPl
+ncH
+kkm
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+bTF
+aVX
+ovs
+lGc
+aVX
+aVX
+bTF
+bTF
+bTF
+bTF
+yko
+cNM
+dGV
+bKJ
+iPk
+bGo
+iPk
+uGe
+ofe
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -36639,94 +41082,94 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+wBc
+yhs
+oDy
+gpd
+lPS
+nbU
+nbU
+yiB
+txI
+nbU
+inj
+tYY
+bTF
+gwK
+bTF
+bTF
+bTF
+tOa
+bTF
+bTF
+cph
+apG
+gla
+cph
+cph
+apG
+cph
+bTF
+bTF
+bTF
+bTF
+oHK
+use
+use
+use
+use
+upS
+use
+use
+use
+use
+upS
+kvY
+sPl
+kkm
+ncH
+ncH
+wMr
+sPl
+ncH
+kkm
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+bTF
+aVX
+bGY
+lGc
+aVX
+aVX
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -36896,93 +41339,93 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+xSv
+yiB
+nbU
+cGO
+nbU
+nbU
+nbU
+nbU
+oDX
+nbU
+nbU
+sMQ
+kFt
+lyw
+lyw
+kFt
+qFx
+kFt
+exa
+huf
+bTF
+rRW
+gla
+qXc
+cph
+sdO
+apG
+gla
+bTF
+bTF
+bTF
+bTF
+bTF
+tRp
+tRp
+tRp
+htR
+tRp
+tRp
+tRp
+tRp
+tRp
+bTF
+bun
+ncH
+kkm
+eFT
+sPl
+tOX
+kkm
+kMy
+kkm
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+bTF
+aVX
+aVX
+lGc
+aVX
+xXx
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -37153,92 +41596,92 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+vgw
+tiq
+oNG
+mwk
+cGO
+nbU
+nbU
+sRF
+oDX
+oDX
+lDI
+oDy
+lyw
+kFt
+lyw
+bUM
+lyw
+kSB
+exa
+kSB
+tYY
+apG
+xAs
+cph
+wSE
+bTF
+eQV
+gla
+iVf
+spp
+oeE
+dVk
+bTF
+bti
+jMI
+sbi
+bti
+oHw
+sbi
+wKS
+vRQ
+bti
+bTF
+bTF
+fMe
+kkm
+jkS
+sPl
+jkS
+kkm
+xoO
+fRO
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+bTF
+lGc
+tRV
+lGc
+hWl
+lGc
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -37410,79 +41853,79 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+wBc
+yiB
+nbU
+oNG
+nbU
+nbU
+nbU
+nbU
+oDX
+qxt
+nbU
+pWa
+kFt
+kFt
+lyw
+ekM
+kFt
+kFt
+sdx
+qgQ
+bTF
+cph
+gla
+apG
+cph
+kFA
+gla
+cph
+bTF
+oeE
+spp
+dex
+oeE
+oeE
+spp
+spp
+spp
+hWD
+oeE
+hWD
+dex
+wfI
+ddP
+tRp
+kkm
+kkm
+iIm
+kkm
+gGN
+kkm
+ojg
+kkm
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+iWi
+rqo
+lGc
+xSa
+lGc
+rqo
+iWi
+bTF
+bTF
 heT
 heT
 heT
@@ -37667,78 +42110,78 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+xSv
+ckH
+nbU
+uOt
+kXd
+nbU
+rRw
+yiB
+yiB
+nbU
+bTF
+bTF
+bTF
+hZY
+tYY
+bTF
+bTF
+jge
+bTF
+bTF
+cph
+apG
+gla
+gla
+cph
+vBb
+qmC
+bTF
+oeE
+spp
+oeE
+spp
+oeE
+oeE
+oeE
+spp
+spp
+spp
+pTm
+oeE
+fpt
+wdn
+tRp
+kkm
+kkm
+xoO
+sPl
+jkS
+kkm
+xoO
+cPT
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -37924,77 +42367,77 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+izK
+bbf
+nbU
+lPS
+oDy
+nbU
+oDX
+nbU
+oDX
+oDX
+yiB
+bTF
+hpE
+jdk
+qaE
+tEv
+bTF
+bTF
+cph
+cph
+jaA
+cph
+apG
+bTF
+bTF
+bTF
+jyE
+bTF
+bTF
+oeE
+sDX
+tYY
+bTF
+qxz
+spp
+uKZ
+bTF
+bTF
+yek
+spp
+spp
+dex
+bti
+tRp
+kkm
+sPl
+ojg
+sPl
+tOX
+kkm
+ojg
+kkm
+bTF
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -38181,59 +42624,59 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+izK
+izK
+nbU
+gpd
+lLb
+oDX
+qxt
+nbU
+oDX
+euV
+mab
+vgw
+fHJ
+wDv
+uLV
+dQc
+bTF
+bTF
+dRI
+bTF
+dRI
+bTF
+xVs
+bTF
+bTF
+cNN
+upS
+erM
+bTF
+oeE
+spp
+inj
+inj
+nqy
+spp
+qxz
+bTF
+bTF
+pdY
+spp
+rNE
+dex
+qxz
+tRp
+kkm
+sPl
+xoO
+ncH
+uDT
+kkm
+xoO
+kkm
+bTF
 heT
 heT
 heT
@@ -38438,59 +42881,59 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+izK
+bbf
+nbU
+gpd
+oDy
+nbU
+oDX
+oDX
+oDX
+oDX
+yiB
+bTF
+tEv
+oaO
+jqD
+anx
+bTF
+bTF
+qxA
+cnm
+glx
+gla
+apG
+bTF
+bTF
+anu
+boR
+upS
+bTF
+spp
+oeE
+oeE
+spp
+oeE
+oeE
+oeE
+spp
+spp
+oeE
+oeE
+spp
+kNE
+bti
+tRp
+kkm
+sPl
+kGc
+sPl
+qYa
+sPl
+tOX
+kkm
+bTF
 heT
 heT
 heT
@@ -38695,59 +43138,59 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+nbU
+oDX
+pkF
+txI
+oDX
+oDX
+yiB
+kMP
+oDX
+bTF
+rQa
+lyw
+hSM
+gis
+bTF
+bHx
+gla
+oXE
+gla
+gla
+wdu
+bTF
+bTF
+iGp
+upS
+cNN
+bTF
+spp
+spp
+spp
+spp
+spp
+oeE
+xes
+dex
+rNE
+bnF
+omg
+spp
+spp
+jMI
+tRp
+kkm
+cGG
+xoO
+ncH
+xoO
+sPl
+jkS
+kkm
+bTF
 heT
 heT
 heT
@@ -38952,59 +43395,59 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+bTF
+auJ
+oDX
+oDX
+oDy
+oDX
+qxt
+fgw
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bti
+pxn
+wKS
+qtu
+imk
+byz
+bti
+qvJ
+qxz
+wKS
+imk
+wKS
+bti
+bTF
+bTF
+iNF
+kkm
+qVa
+sPl
+iIm
+sPl
+rEw
+fRO
+bTF
 heT
 heT
 heT
@@ -39209,59 +43652,59 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+bTF
+wBc
+oDX
+nbU
+nbU
+nbU
+nbU
+xSv
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+tRp
+tRp
+tRp
+tRp
+tRp
+tRp
+tRp
+tRp
+tRp
+tRp
+htR
+tRp
+tRp
+bTF
+bTF
+lXR
+ncH
+xoO
+sPl
+jkS
+kkm
+xoO
+kkm
+bTF
 heT
 heT
 heT
@@ -39466,59 +43909,59 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+bTF
+bTF
+oDX
+oDX
+oDX
+oDX
+nbU
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+oHK
+use
+use
+use
+use
+use
+use
+use
+use
+use
+use
+upS
+oUF
+upS
+upS
+use
+use
+use
+eSI
+bTF
+kkm
+kLM
+sPl
+sPl
+sPl
+kkm
+sPl
+kkm
+bTF
 heT
 heT
 heT
@@ -39723,59 +44166,59 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+bTF
+bTF
+uAx
+bTF
+fhx
+bTF
+uAx
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+tYY
+tYY
+bTF
+bTF
+bTF
+use
+nqW
+use
+vlz
+use
+nqW
+use
+agV
+upS
+nqW
+upS
+agV
+boR
+nqW
+use
+vlz
+wYh
+nqW
+mvd
+bTF
+aGH
+gdV
+kkm
+kkm
+kkm
+kkm
+fDZ
+aGH
+bTF
 heT
 heT
 heT
@@ -39980,59 +44423,59 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+hem
+lQW
+kPi
+mfg
+kPi
+kPi
+jXR
+lQW
+hem
+bTF
+bTF
+bTF
+bGR
+upS
+gTd
+xsf
+fTJ
+use
+use
+upS
+hzS
+bTF
+upS
+juh
+upS
+mdw
+use
+mdw
+use
+juh
+upS
+qGV
+upS
+mdw
+boR
+mdw
+use
+juh
+upS
+juh
+wYh
+bTF
+bTF
+iWi
+heI
+use
+use
+sNw
+iWi
+bTF
+bTF
 heT
 heT
 heT
@@ -40237,58 +44680,58 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+lQW
+hem
+kCz
+qpv
+sis
+uUb
+kPi
+lQW
+lQW
+bTF
+bTF
+bTF
+fFe
+upS
+cQh
+dTP
+vwN
+upS
+boR
+fYJ
+mXx
+bTF
+pVX
+nMe
+upS
+heI
+use
+heI
+use
+sNw
+upS
+wYm
+upS
+heI
+use
+heI
+upS
+sNw
+use
+wYm
+upS
+roz
+upS
+rEM
+upS
+upS
+upS
+ovx
+pBW
+bTF
 heT
 heT
 heT
@@ -40494,58 +44937,58 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+lQW
+lQW
+kCz
+kPi
+uUb
+qpv
+qpv
+hem
+lQW
+bTF
+bTF
+bTF
+use
+use
+cQh
+tES
+sTP
+xbo
+upS
+miI
+use
+bTF
+upS
+upS
+upS
+qaW
+use
+use
+upS
+upS
+upS
+use
+use
+boR
+boR
+upS
+use
+use
+use
+use
+upS
+use
+upS
+upS
+rEM
+upS
+upS
+xsf
+oVe
+bTF
 heT
 heT
 heT
@@ -40751,58 +45194,58 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+tYY
+wQl
+lQW
+kPi
+oUO
+kPi
+jXR
+kPi
+hem
+lQW
+bTF
+bTF
+bTF
+bGR
+upS
+bGR
+hnF
+fKx
+boR
+qCI
+upS
+aib
+bTF
+gem
+xsf
+upS
+use
+roz
+mdw
+upS
+use
+roz
+mdw
+upS
+upS
+xTD
+juh
+upS
+upS
+roz
+mdw
+use
+roz
+use
+upS
+upS
+iLx
+use
+use
+use
+bTF
 heT
 heT
 heT
@@ -41008,58 +45451,58 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+tYY
+wQl
+hem
+hem
+hem
+hem
+hem
+hem
+hem
+lQW
+bTF
+bTF
+bTF
+iLx
+rEM
+iLx
+bTF
+bTF
+wNf
+upS
+upS
+use
+bTF
+use
+vCR
+boR
+use
+use
+cbF
+use
+qLm
+use
+cbF
+yfW
+use
+use
+cbF
+upS
+aGG
+ikx
+cbF
+oHK
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -41265,50 +45708,50 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+hem
+dNv
+lQW
+hem
+iob
+hem
+lQW
+aWL
+wQl
+bTF
+bTF
+bTF
+pLJ
+boR
+bGR
+bTF
+kkB
+upS
+upS
+upS
+use
+bTF
+cMk
+cMk
+boR
+use
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
 heT
 heT
 heT
@@ -41522,35 +45965,35 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+bTF
+bTF
+tYY
+tYY
+tYY
+tYY
+tYY
+tYY
+tYY
+bTF
+bTF
+bTF
+upS
+boR
+upS
+bTF
+eQc
+upS
+upS
+upS
+use
+bTF
+upS
+upS
+heI
+use
+bTF
 heT
 heT
 heT
@@ -41779,35 +46222,35 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bTF
+bGR
+boR
+gTd
+bTF
+sAp
+use
+use
+upS
+use
+bTF
+use
+use
+upS
+use
+bTF
 heT
 heT
 heT
@@ -42049,22 +46492,22 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+upS
+upS
+upS
+bTF
+gem
+uxq
+qCI
+upS
+yfG
+bTF
+sFf
+upS
+upS
+heI
+bTF
 heT
 heT
 heT
@@ -42306,22 +46749,22 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+upS
+upS
+upS
+bTF
+use
+hnF
+upS
+upS
+use
+sXV
+use
+upS
+upS
+use
+bTF
 heT
 heT
 heT
@@ -42563,22 +47006,22 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+use
+tqU
+use
+bTF
+use
+upS
+upS
+upS
+use
+use
+use
+use
+upS
+upS
+bTF
 heT
 heT
 heT
@@ -42820,22 +47263,22 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+bTF
+bTF
+bTF
+bTF
+use
+upS
+use
+upS
+upS
+upS
+upS
+upS
+use
+use
+bTF
 heT
 heT
 heT
@@ -43081,18 +47524,18 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+mdw
+mdw
+juh
+juh
+juh
+juh
+qGV
+juh
+juh
+mdw
+bTF
 heT
 heT
 heT
@@ -43338,18 +47781,18 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bTF
+iHT
+iHT
+iHT
+iHT
+iHT
+iHT
+nea
+iHT
+iHT
+iHT
+bTF
 heT
 heT
 heT

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -342,7 +342,7 @@
 /obj/structure/simple_door/metal/ventilation,
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating,
-/area/f13/wasteland)
+/area/f13/building)
 "akm" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt,
@@ -389,7 +389,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plating,
-/area/f13/wasteland)
+/area/f13/building)
 "all" = (
 /obj/structure/closet/crate/wicker,
 /turf/open/indestructible/ground/outside/dirt{
@@ -646,13 +646,10 @@
 	},
 /area/f13/building)
 "aun" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks,
-/turf/open/floor/plating,
-/area/f13/wasteland)
+/obj/structure/window/fulltile/wood,
+/obj/structure/curtain,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aup" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating,
@@ -7493,6 +7490,10 @@
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"eSN" = (
+/obj/effect/landmark/start/f13/deputy,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "eST" = (
 /obj/structure/rack,
 /obj/item/claymore/machete/warclub,
@@ -8416,9 +8417,11 @@
 	},
 /area/f13/building)
 "fuN" = (
-/obj/structure/chair/f13chair2{
-	dir = 4
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "gatehouseladder"
 	},
+/obj/effect/landmark/start/f13/deputy,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "fuU" = (
@@ -9298,7 +9301,7 @@
 "fZm" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
-	name = "Sheriff Office";
+	name = "Gatehouse";
 	req_one_access_txt = "62"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -10320,7 +10323,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mineral/wasteland_vendor/mining,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
+/area/f13/wasteland)
 "gDl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil{
@@ -10328,8 +10331,11 @@
 	pixel_x = -28
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/trashcart{
+	name = "corpse cart"
+	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
+/area/f13/wasteland)
 "gDn" = (
 /obj/structure/fence{
 	dir = 8
@@ -10379,11 +10385,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/closet/crate/trashcart{
-	name = "corpse cart"
-	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
+/area/f13/wasteland)
 "gEY" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13{
@@ -11560,8 +11563,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "hpY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "hqr" = (
 /obj/machinery/vending/games,
@@ -15983,6 +15989,13 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13,
 /area/f13/building)
+"jUO" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0";
+	tag = "icon-verticalleftborderright0"
+	},
+/area/f13/wasteland)
 "jUR" = (
 /obj/structure/sign/poster/prewar/poster88,
 /turf/closed/wall/f13/supermart,
@@ -16660,9 +16673,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "kmQ" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "kmX" = (
 /turf/open/floor/plasteel/barber{
@@ -17169,7 +17182,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "kBs" = (
 /obj/structure/simple_door/house{
 	icon_state = "interior";
@@ -17180,10 +17193,11 @@
 	},
 /area/f13/city)
 "kBC" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	req_one_access_txt = "25"
 	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "kBG" = (
 /obj/effect/decal/marking{
@@ -17224,7 +17238,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "kCD" = (
 /obj/structure/simple_door/house{
 	icon_state = "interioropening";
@@ -17434,7 +17448,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
+/area/f13/wasteland)
 "kJj" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 4
@@ -17478,12 +17492,10 @@
 	},
 /area/f13/legion)
 "kKZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/building)
+/obj/structure/flora/wasteplant/wild_punga,
+/obj/effect/decal/riverbank,
+/turf/open/water,
+/area/f13/wasteland)
 "kLk" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -17559,7 +17571,7 @@
 	pixel_y = 32
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
+/area/f13/wasteland)
 "kNT" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/mortar{
@@ -21038,16 +21050,29 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mUU" = (
-/obj/structure/fence/wooden{
-	dir = 4;
-	icon_state = "post_wood"
+/obj/structure/destructible/tribal_torch{
+	pixel_y = 20
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outermaincornerinner"
+	},
+/area/f13/wasteland)
 "mVc" = (
-/obj/structure/fence/corner/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
+	},
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 5
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermaintop";
+	tag = "icon-verticaloutermaintop"
+	},
+/area/f13/wasteland)
 "mVh" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -21415,12 +21440,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "nfz" = (
-/obj/structure/chair/bench,
+/obj/structure/bed,
+/obj/item/bedsheet/random,
 /obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
-	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "nfH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
@@ -21965,6 +21989,9 @@
 /area/f13/tunnel)
 "nAI" = (
 /obj/structure/railing,
+/obj/structure/railing{
+	pixel_y = 4
+	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "nAR" = (
@@ -22010,6 +22037,9 @@
 /area/f13/legion)
 "nCx" = (
 /obj/structure/railing,
+/obj/structure/railing{
+	pixel_y = 4
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
@@ -22584,6 +22614,7 @@
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
 	},
+/obj/effect/decal/riverbank,
 /turf/open/water,
 /area/f13/wasteland)
 "nWu" = (
@@ -22720,8 +22751,10 @@
 	},
 /area/f13/bar)
 "odc" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/building)
 "odh" = (
@@ -23511,7 +23544,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "oBQ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0";
@@ -24152,11 +24185,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "oUy" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "oUI" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24180,6 +24214,16 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"oVe" = (
+/obj/structure/fence{
+	dir = 1;
+	pixel_x = -18
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "oVl" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -24308,7 +24352,7 @@
 /area/f13/city)
 "oXV" = (
 /obj/structure/destructible/tribal_torch,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/wood/f13/oakbroken4,
 /area/f13/building)
 "oYb" = (
 /turf/closed/indestructible/f13/matrix,
@@ -24316,7 +24360,7 @@
 "oYu" = (
 /obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/building)
 "oYI" = (
 /obj/structure/lamp_post/quadra,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25018,7 +25062,6 @@
 /turf/closed/wall/f13/wood,
 /area/f13/clinic)
 "puP" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/ladder/unbreakable{
 	height = 1;
 	id = "clinicoutsideladder"
@@ -25364,12 +25407,12 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
 "pHi" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
-	name = "Sheriff Office";
+	name = "Gatehouse";
 	req_one_access_txt = "62"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pHm" = (
@@ -25626,6 +25669,7 @@
 /area/f13/village)
 "pOe" = (
 /obj/structure/bed,
+/obj/item/bedsheet/random,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "pOo" = (
@@ -26523,10 +26567,6 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "qoj" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
 /obj/structure/fence{
 	dir = 1;
 	pixel_x = -18
@@ -26798,10 +26838,6 @@
 	icon_state = "horizontaltopbordertop2right"
 	},
 /area/f13/tunnel)
-"qyj" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
 "qyH" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood{
@@ -26822,7 +26858,7 @@
 /area/f13/wasteland)
 "qzr" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
 "qzt" = (
 /obj/structure/fence/corner,
@@ -26862,13 +26898,6 @@
 /obj/structure/sign/poster/official/twelve_gauge,
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
-"qAc" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
 "qAi" = (
 /obj/structure/table,
 /obj/machinery/light/small,
@@ -27231,11 +27260,11 @@
 	},
 /area/f13/village)
 "qKe" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "interiorgate2"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0";
+	tag = "icon-verticalleftborderright0"
+	},
 /area/f13/wasteland)
 "qKU" = (
 /obj/structure/chair/comfy/brown{
@@ -27281,7 +27310,9 @@
 /area/f13/village)
 "qMj" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
 /area/f13/wasteland)
 "qMn" = (
 /obj/structure/table,
@@ -27476,20 +27507,22 @@
 	},
 /area/f13/wasteland)
 "qPW" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/obj/item/taperecorder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "qQe" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/closet/cabinet,
+/obj/structure/curtain{
+	color = "#845f58"
 	},
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "house1ladder";
+	layer = 2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "qQf" = (
 /obj/structure/rack,
@@ -27571,6 +27604,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"qRt" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qRz" = (
 /obj/structure/chair/stool{
 	dir = 8;
@@ -27645,7 +27683,7 @@
 "qTa" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
-	name = "Gatehouse";
+	name = "Sheriff Office";
 	req_one_access_txt = "62"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -27806,6 +27844,8 @@
 "qZO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/taperecorder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "ram" = (
@@ -27850,12 +27890,12 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "rbF" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "gatehouseladder"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "rbJ" = (
 /obj/structure/flora/grass/wasteland{
@@ -27990,7 +28030,6 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rgI" = (
-/obj/effect/landmark/start/f13/deputy,
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/pinup_ride{
@@ -28197,7 +28236,6 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "rpa" = (
-/obj/effect/landmark/start/f13/deputy,
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -33455,8 +33493,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "uCT" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/structure/chair/stool/retro,
+/obj/effect/landmark/start/f13/settler,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "uCW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -33608,6 +33647,12 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"uGZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/building)
 "uHl" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/item/clothing/under/f13/shiny,
@@ -35717,6 +35762,13 @@
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vVc" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "vVt" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -39671,9 +39723,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "ykD" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
-	},
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "ykH" = (
 /obj/structure/table/wood/settler,
@@ -64054,7 +64106,7 @@ mPa
 xXh
 nNZ
 mvv
-mvv
+uRa
 onz
 wDc
 fyf
@@ -65336,7 +65388,7 @@ kiW
 dCV
 gts
 aka
-pMI
+dCV
 nWl
 tvr
 tvr
@@ -65345,7 +65397,7 @@ tvr
 pCf
 pMf
 mvv
-ofL
+vVc
 bpD
 uHT
 fyf
@@ -65593,8 +65645,8 @@ dCV
 dCV
 dCV
 akY
-pMI
-tvr
+dCV
+fQr
 tvr
 tvr
 tvr
@@ -65849,9 +65901,9 @@ liO
 cpK
 mdc
 dCV
-aun
-pMI
-nUj
+rEc
+dCV
+kKZ
 oqu
 tvr
 tvr
@@ -66117,7 +66169,7 @@ gts
 gts
 gts
 gts
-nGq
+gts
 bpD
 fyf
 fyf
@@ -66374,7 +66426,7 @@ dCV
 dCV
 dCV
 dCV
-nGq
+gts
 bpD
 fyf
 fyf
@@ -66631,7 +66683,7 @@ uqa
 pNk
 obr
 dCV
-nGq
+gts
 bpD
 fyf
 fyf
@@ -66888,7 +66940,7 @@ pDd
 lmw
 pNk
 dCV
-nGq
+gts
 bpD
 fyf
 fyf
@@ -67137,15 +67189,15 @@ dCV
 bfr
 oFP
 obr
-lmw
+grC
 lmw
 ovR
 oZC
 uqa
 lmw
-lmw
+ury
 dCV
-nGq
+gts
 bpD
 fyf
 fyf
@@ -67900,7 +67952,7 @@ oIQ
 lmw
 iMV
 jKV
-kmQ
+dkg
 dkg
 cpK
 cpK
@@ -67911,11 +67963,11 @@ oFP
 oFP
 gts
 oYu
-lPT
-lPT
-lPT
-lPT
-lPT
+uqa
+uqa
+uqa
+uqa
+uqa
 dCV
 gts
 fyf
@@ -68157,7 +68209,7 @@ lmw
 iiG
 uFK
 uqa
-ykD
+cam
 dkg
 cpK
 gdY
@@ -68676,7 +68728,7 @@ dkg
 cam
 cah
 ajD
-mUU
+jfx
 mvv
 mvv
 rjH
@@ -69447,7 +69499,7 @@ dkg
 xdD
 cam
 ajD
-lPT
+uqa
 nwh
 ovN
 mvv
@@ -69704,13 +69756,13 @@ cpK
 cpK
 mdM
 ajD
-mVc
+ntg
 nwp
 lKw
 oAS
 oAS
 oAS
-lKw
+gCh
 nwp
 ntg
 nwp
@@ -69963,15 +70015,15 @@ meU
 onk
 ybI
 nwu
-odc
+ybI
 oBu
 oBu
 oBu
-odc
+ybI
 ybI
 ybI
 qxN
-pMI
+dCV
 dCV
 gts
 fyf
@@ -70228,7 +70280,7 @@ tUb
 idu
 mfq
 xtl
-pMI
+dCV
 dCV
 gts
 igz
@@ -70484,7 +70536,7 @@ wGJ
 erY
 erY
 erY
-qyj
+pMI
 dCV
 dCV
 nGq
@@ -70741,11 +70793,11 @@ wGJ
 erY
 erY
 kjQ
-kjQ
+gfR
 qKe
 hBN
-rDT
-pGa
+cXB
+jUO
 pGa
 pGa
 pGa
@@ -71001,7 +71053,7 @@ erY
 qzr
 qMj
 hOl
-hOl
+cXB
 hOl
 hOl
 hOl
@@ -71250,15 +71302,15 @@ qac
 nxj
 wGJ
 erY
-oUy
+erY
 apk
 pcT
 pEs
 qcT
-qAc
+ghx
+qoS
+qoS
 cXB
-qoS
-qoS
 qoS
 btW
 fvz
@@ -72274,7 +72326,7 @@ wGJ
 cdc
 wGJ
 mEn
-nfz
+mgu
 nzq
 odS
 oIF
@@ -72798,8 +72850,8 @@ ubg
 dCV
 gZD
 dCV
-dCV
 pSk
+dCV
 gts
 fyf
 kGc
@@ -73054,9 +73106,9 @@ qoS
 qoS
 sYX
 qoj
-qoj
-uqa
-uqa
+oVe
+pSk
+eSN
 gts
 fyf
 kGc
@@ -73312,8 +73364,8 @@ ees
 pHi
 dza
 dza
-qQe
-rbF
+pSk
+pSk
 gts
 fyf
 kGc
@@ -73559,7 +73611,7 @@ dkg
 dkg
 dkg
 dkg
-cpK
+xdD
 nAI
 dkg
 dkg
@@ -74593,7 +74645,7 @@ dit
 lsC
 dit
 uCW
-uCW
+puP
 uqa
 qul
 qDY
@@ -74850,7 +74902,7 @@ ohx
 oOG
 dit
 uCW
-puP
+gdY
 uqa
 uqa
 uqa
@@ -75106,8 +75158,8 @@ nGh
 oiz
 dza
 dit
-dCV
-dCV
+oVF
+uaf
 dCV
 dCV
 dCV
@@ -75363,13 +75415,13 @@ dit
 dop
 dza
 dit
+xdD
+uaf
+aun
+rpu
+uGZ
+qRt
 dCV
-gts
-gts
-gts
-gts
-gts
-gts
 gts
 fyf
 kGc
@@ -75620,14 +75672,14 @@ dit
 pSk
 dza
 dit
+xdD
+uaf
+kBC
+rpu
+vcM
+rpu
 dCV
 gts
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 kGc
 unI
@@ -75877,15 +75929,15 @@ nHi
 pSk
 dza
 dit
+rRt
+cam
+aun
+uCT
+vcM
+vcM
 dCV
 gts
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+upX
 kGc
 unI
 hbW
@@ -76124,7 +76176,7 @@ cpK
 ish
 iXz
 cpK
-kmQ
+dkg
 dit
 dit
 moO
@@ -76134,14 +76186,14 @@ dit
 pSk
 dza
 dit
+gdY
+xdD
+dCV
+ykD
+vcM
+qkP
 dCV
 gts
-fyf
-fyf
-qTY
-fyf
-fyf
-fyf
 fyf
 kGc
 unI
@@ -76381,7 +76433,7 @@ xdD
 cam
 gdY
 dkg
-kBC
+cah
 dit
 lKV
 dit
@@ -76391,14 +76443,14 @@ dit
 ojL
 dza
 dit
+mUU
+cpK
+gfc
+dCV
+dCV
+dCV
 dCV
 gts
-fyf
-fyf
-upX
-fyf
-fyf
-fyf
 fyf
 kGc
 unI
@@ -76633,7 +76685,7 @@ eLJ
 fAP
 gne
 gCN
-hpY
+xdD
 xdD
 xdD
 dkg
@@ -76648,14 +76700,14 @@ nIj
 dza
 oON
 dit
+mVc
+cpK
+uCW
+uCW
+uCW
 dCV
 gts
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
+gts
 fyf
 kGc
 unI
@@ -76890,7 +76942,7 @@ giZ
 giZ
 gmZ
 gDl
-hpY
+xdD
 cpK
 isL
 jeX
@@ -76905,13 +76957,13 @@ mVn
 dza
 oOZ
 dit
-dCV
+uqa
+uqa
+uqa
+kBC
+aun
+uqa
 gts
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 kGc
@@ -77147,12 +77199,12 @@ dCV
 giZ
 giZ
 gET
-ids
-ids
+cpK
+cpK
 itI
 rRt
 cpK
-kKZ
+oVF
 dit
 dza
 mqy
@@ -77162,13 +77214,13 @@ pSk
 pSk
 pSk
 dit
+nfz
+qQe
+uqa
+rpu
+vcM
 dCV
 gts
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 kGc
@@ -77402,10 +77454,10 @@ fyf
 gts
 dCV
 dCV
+aun
+kBC
 dCV
 dCV
-dCV
-sYX
 iyo
 cpK
 cpK
@@ -77419,13 +77471,13 @@ nJc
 okc
 oQv
 dit
+odc
+rpu
+uqa
+vXh
+rkZ
 dCV
 gts
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 kGc
@@ -77658,15 +77710,15 @@ fyf
 fyf
 gts
 gts
-gts
-gts
-gts
-gts
 dCV
-dCV
-uCT
-ids
 hpY
+rpu
+csO
+dCV
+dCV
+lKG
+cpK
+xdD
 dit
 dit
 dit
@@ -77676,13 +77728,13 @@ dit
 dit
 dit
 dit
+oUy
+vcM
+rbF
+vcM
+rkZ
 dCV
 gts
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 kGc
@@ -77914,13 +77966,18 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-gts
 gts
 dCV
+bxl
+rpu
+rpu
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
 dCV
 dCV
 dCV
@@ -77936,11 +77993,6 @@ dCV
 dCV
 gts
 fyf
-fyf
-fyf
-fyf
-fyf
-lWZ
 fyf
 kGc
 unI
@@ -78171,11 +78223,12 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+dCV
+kmQ
+rpu
+qkP
+dCV
 gts
 gts
 gts
@@ -78192,11 +78245,10 @@ gts
 gts
 gts
 gts
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+gts
+gts
+gts
 fyf
 fyf
 kGc
@@ -78428,13 +78480,13 @@ fyf
 fyf
 fyf
 fyf
-trW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+dCV
+dCV
+dCV
+dCV
+dCV
+gts
 fyf
 fyf
 fyf
@@ -78685,13 +78737,13 @@ fyf
 fyf
 fyf
 fyf
-fyf
-qOV
-wDc
-fyf
-fyf
-fyf
-fyf
+gts
+gts
+gts
+gts
+gts
+gts
+gts
 fyf
 fyf
 fyf
@@ -78968,7 +79020,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+lWZ
 fyf
 kGc
 unI
@@ -81270,7 +81322,7 @@ qyR
 xNE
 fyf
 fyf
-fyf
+upX
 fyf
 fyf
 fyf

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -926,6 +926,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"aBO" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "aCn" = (
 /obj/structure/chair/wood/fancy{
 	dir = 8
@@ -1476,6 +1484,16 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
+"aVP" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = 25;
+	pixel_y = 18
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderrighttop"
+	},
+/area/f13/wasteland)
 "aVY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -1694,6 +1712,14 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/legion)
+"bcj" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "bcx" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -1887,6 +1913,15 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"bjj" = (
+/obj/structure/chair/wood/worn{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "bjs" = (
 /obj/structure/ladder/unbreakable{
@@ -2891,9 +2926,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "bOG" = (
-/obj/machinery/light/sign/oasis,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright3"
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_2"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "bOO" = (
@@ -4936,7 +4973,7 @@
 "doF" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/button/door{
-	id = "frontgateshu2t";
+	id = "frontgateshut2";
 	name = "gate shutters";
 	pixel_x = -5;
 	pixel_y = 32
@@ -5038,6 +5075,12 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"dsb" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft1"
+	},
+/area/f13/wasteland)
 "dsh" = (
 /obj/structure/rack,
 /obj/item/clothing/head/sombrero,
@@ -8259,7 +8302,7 @@
 	icon_state = "goo5"
 	},
 /obj/effect/decal/riverbank,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/wasteland)
 "fqL" = (
 /turf/open/floor/f13/wood{
@@ -9033,7 +9076,7 @@
 /area/f13/village)
 "fQr" = (
 /obj/effect/decal/riverbank,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/wasteland)
 "fQt" = (
 /obj/effect/landmark/start/f13/barkeep,
@@ -9109,6 +9152,15 @@
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2top"
+	},
+/area/f13/wasteland)
+"fSw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
 "fSz" = (
@@ -9429,7 +9481,7 @@
 /area/f13/village)
 "gfR" = (
 /obj/machinery/door/poddoor/gate/preopen{
-	id = "interiorgate2"
+	id = "interiorgate"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
@@ -10533,7 +10585,7 @@
 /area/f13/wasteland)
 "gKP" = (
 /obj/effect/decal/riverbankcorner,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/wasteland)
 "gLH" = (
 /obj/structure/window/fulltile/house,
@@ -11046,6 +11098,14 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"gZZ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland)
 "hab" = (
 /obj/structure/chair/left{
 	dir = 4
@@ -11174,6 +11234,13 @@
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblecorner"
+	},
+/area/f13/wasteland)
+"hfe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
 "hfh" = (
@@ -11854,6 +11921,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"hxJ" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland)
 "hxK" = (
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/f13/wood{
@@ -12373,6 +12447,9 @@
 "hNY" = (
 /obj/machinery/mineral/wasteland_vendor/attachments{
 	icon_state = "weapon_idle"
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
@@ -13097,6 +13174,7 @@
 	density = 0;
 	pixel_x = 17
 	},
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "ill" = (
@@ -13355,14 +13433,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "ish" = (
-/obj/structure/destructible/tribal_torch{
-	layer = 3.1;
-	pixel_y = 20
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "ism" = (
 /obj/structure/window/fulltile/house{
@@ -14062,7 +14135,7 @@
 /obj/effect/decal/riverbank{
 	dir = 5
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/wasteland)
 "iLD" = (
 /obj/item/seeds/cannabis,
@@ -14169,6 +14242,9 @@
 /obj/effect/decal/fakelattice{
 	pixel_x = -17
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
@@ -14211,6 +14287,9 @@
 /area/f13/village)
 "iOF" = (
 /obj/structure/wreck/trash/two_barrels,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "iOM" = (
@@ -14388,6 +14467,9 @@
 /obj/structure/wreck/trash/machinepile{
 	layer = 3
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "iTk" = (
@@ -14441,6 +14523,13 @@
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"iUP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flag/oasis,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "iVd" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -15276,6 +15365,13 @@
 	},
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"jwU" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "jwV" = (
 /obj/structure/table,
@@ -17176,7 +17272,7 @@
 /area/f13/legion)
 "kBr" = (
 /obj/structure/ladder/unbreakable{
-	height = 1;
+	height = 2;
 	id = "clinicoutsideladder"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17235,6 +17331,7 @@
 /area/f13/building)
 "kCA" = (
 /obj/structure/wreck/trash/five_tires,
+/obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
@@ -17494,7 +17591,7 @@
 "kKZ" = (
 /obj/structure/flora/wasteplant/wild_punga,
 /obj/effect/decal/riverbank,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/wasteland)
 "kLk" = (
 /obj/structure/bed,
@@ -18176,7 +18273,7 @@
 /area/f13/wasteland)
 "liO" = (
 /obj/structure/ladder/unbreakable{
-	height = 1;
+	height = 2;
 	id = "busladder"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18355,6 +18452,9 @@
 /obj/machinery/vending/cola/space_up,
 /obj/effect/decal/cleanable/glass{
 	pixel_x = 12
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
@@ -18572,10 +18672,10 @@
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "lun" = (
-/obj/structure/chair,
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_y = 32
 	},
+/obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -19703,6 +19803,9 @@
 "mbD" = (
 /obj/structure/closet,
 /obj/item/storage/backpack/satchel/leather,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
@@ -19761,6 +19864,7 @@
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
 	},
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "mdT" = (
@@ -20137,9 +20241,14 @@
 	},
 /area/f13/building)
 "moR" = (
-/obj/structure/curtain,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	layer = 2;
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "moV" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -20544,7 +20653,7 @@
 	},
 /area/f13/brotherhood)
 "mDr" = (
-/obj/structure/bonfire,
+/obj/structure/bonfire/prelit,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain3"
 	},
@@ -20900,7 +21009,7 @@
 /obj/effect/decal/riverbank{
 	dir = 9
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/wasteland)
 "mPk" = (
 /obj/structure/disposalpipe/segment{
@@ -21050,9 +21159,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mUU" = (
-/obj/structure/destructible/tribal_torch{
-	pixel_y = 20
-	},
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
 	icon_state = "outermaincornerinner"
@@ -21456,6 +21563,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"ngb" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
+	},
+/area/f13/wasteland)
 "ngg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -21561,12 +21677,14 @@
 	},
 /area/f13/wasteland)
 "nkq" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_2"
 	},
-/area/f13/building)
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "nla" = (
 /obj/machinery/workbench/forge,
 /turf/open/indestructible/ground/inside/dirt,
@@ -22039,6 +22157,9 @@
 /obj/structure/railing,
 /obj/structure/railing{
 	pixel_y = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
@@ -22539,7 +22660,7 @@
 /area/f13/wasteland)
 "nUj" = (
 /obj/structure/flora/wasteplant/wild_punga,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/wasteland)
 "nUm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22615,7 +22736,7 @@
 	icon_state = "tree_2"
 	},
 /obj/effect/decal/riverbank,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/wasteland)
 "nWu" = (
 /obj/machinery/deepfryer,
@@ -22752,6 +22873,9 @@
 /area/f13/bar)
 "odc" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
 	tag = "icon-housewood4-broken"
@@ -22788,6 +22912,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"odI" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland)
 "odJ" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical,
@@ -23262,7 +23394,7 @@
 /area/f13/brotherhood)
 "oqu" = (
 /obj/structure/reagent_dispensers/barrel/two,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/wasteland)
 "oqA" = (
 /turf/open/floor/f13/wood{
@@ -23294,6 +23426,14 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"osk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/building)
 "osm" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24045,6 +24185,10 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"oQz" = (
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "oQM" = (
 /obj/structure/table/booth,
 /turf/open/floor/carpet/black,
@@ -24093,7 +24237,7 @@
 /obj/effect/decal/riverbank{
 	dir = 4
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/wasteland)
 "oRS" = (
 /obj/structure/table/wood/fancy/black,
@@ -24215,10 +24359,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "oVe" = (
-/obj/structure/fence{
-	dir = 1;
-	pixel_x = -18
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -25063,8 +25203,8 @@
 /area/f13/clinic)
 "puP" = (
 /obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "clinicoutsideladder"
+	height = 2;
+	id = "church"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -25294,13 +25434,22 @@
 /obj/effect/decal/riverbank{
 	dir = 1
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/wasteland)
 "pCi" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"pCn" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	layer = 2;
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "pCy" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -26317,6 +26466,18 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"qhg" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland)
 "qhi" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -26566,13 +26727,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"qoj" = (
-/obj/structure/fence{
-	dir = 1;
-	pixel_x = -18
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "qop" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/dirt,
@@ -27261,6 +27415,9 @@
 /area/f13/village)
 "qKe" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0";
 	tag = "icon-verticalleftborderright0"
@@ -27288,6 +27445,12 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"qLJ" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "interiorgate2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland)
 "qLO" = (
 /obj/machinery/light{
 	dir = 4
@@ -30029,6 +30192,21 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"syC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
+"syG" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "syU" = (
 /obj/machinery/shower{
 	dir = 8
@@ -30163,6 +30341,9 @@
 "sCF" = (
 /obj/structure/decoration/clock{
 	pixel_y = 21
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2";
@@ -31106,6 +31287,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
+"thP" = (
+/obj/machinery/light/sign/oasis,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "thW" = (
 /obj/machinery/light{
 	dir = 4
@@ -31534,7 +31719,7 @@
 	},
 /area/f13/legion)
 "tvr" = (
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/wasteland)
 "tvA" = (
 /obj/structure/rack,
@@ -36174,6 +36359,14 @@
 /obj/item/clothing/under/f13/shiny,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wmo" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left"
+	},
+/area/f13/wasteland)
 "wmI" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -38301,6 +38494,12 @@
 	},
 /turf/open/water,
 /area/f13/caves)
+"xte" = (
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft1"
+	},
+/area/f13/wasteland)
 "xtl" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -39240,7 +39439,7 @@
 /obj/effect/decal/riverbank{
 	dir = 6
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/wasteland)
 "xXl" = (
 /obj/item/clothing/under/f13/police,
@@ -39725,6 +39924,9 @@
 "ykD" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ykH" = (
@@ -54118,7 +54320,7 @@ uok
 pim
 pim
 pim
-pim
+syG
 pim
 dit
 mhI
@@ -55661,7 +55863,7 @@ vyb
 vyb
 vyb
 xdG
-vYv
+lHK
 dit
 qxu
 qxu
@@ -61021,7 +61223,7 @@ fyf
 yjG
 rpu
 klA
-oqA
+qbL
 sYX
 fyf
 fyf
@@ -61033,7 +61235,7 @@ fyf
 fyf
 sYX
 seB
-rpu
+sew
 rpu
 sYX
 fyf
@@ -62563,7 +62765,7 @@ rpu
 sDp
 rpu
 rpu
-rpu
+plt
 sYX
 fyf
 fyf
@@ -62574,7 +62776,7 @@ bpD
 fyf
 fyf
 sYX
-rMz
+bjj
 aug
 rpu
 sYX
@@ -62836,7 +63038,7 @@ rpu
 jcl
 sYX
 sOD
-sKH
+aBO
 rpu
 tor
 sYX
@@ -65139,7 +65341,7 @@ gKP
 oRQ
 xXh
 mvv
-mvv
+bzm
 mvv
 bpD
 fyf
@@ -66668,7 +66870,7 @@ lmw
 iMc
 iMc
 dCV
-gdY
+wmo
 cpK
 cah
 gZD
@@ -66905,7 +67107,7 @@ boN
 azC
 fyf
 fyf
-sND
+bOG
 daU
 mvv
 mvv
@@ -67162,8 +67364,8 @@ fbq
 azC
 fyf
 fyf
-fyf
-mvv
+tBN
+pCn
 mvv
 bHr
 hCg
@@ -67419,7 +67621,7 @@ cGu
 azC
 fyf
 fyf
-fyf
+tBN
 mvv
 mvv
 bpD
@@ -67451,7 +67653,7 @@ lmw
 lmw
 pbr
 uqa
-pOe
+bcj
 lmw
 dCV
 gts
@@ -67676,7 +67878,7 @@ gjP
 gjP
 fyf
 fyf
-fyf
+oLT
 mfD
 mfD
 hCg
@@ -68733,7 +68935,7 @@ mvv
 mvv
 rjH
 rjH
-mvv
+rjH
 rjH
 rjH
 pSC
@@ -68965,7 +69167,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+bXG
 fyf
 fyf
 gts
@@ -68990,12 +69192,12 @@ mvv
 mvv
 rjH
 rjH
-mvv
+rjH
 rjH
 rjH
 pVp
 fyf
-fyf
+qIE
 dCV
 gts
 fyf
@@ -69247,12 +69449,12 @@ mvv
 mvv
 rjH
 rjH
-mvv
+rjH
 rjH
 rjH
 qbe
 fyf
-fyf
+qHZ
 dCV
 gts
 fyf
@@ -69732,7 +69934,7 @@ gjP
 gjP
 fyf
 fyf
-gSt
+fyf
 fyf
 gSt
 igz
@@ -69989,13 +70191,13 @@ sJw
 xgV
 fyf
 fyf
-wIK
+fyf
 fyf
 wIK
 hkW
 sTa
-ybI
 chX
+ybI
 gts
 dCV
 dpS
@@ -70015,11 +70217,11 @@ meU
 onk
 ybI
 nwu
-ybI
+odI
 oBu
 oBu
 oBu
-ybI
+odI
 ybI
 ybI
 qxN
@@ -70246,7 +70448,7 @@ aJb
 fJv
 fyf
 sZA
-hCs
+fyf
 fyf
 hCs
 rnx
@@ -70258,7 +70460,7 @@ cXB
 aJb
 hBN
 aJb
-gfR
+qLJ
 tUb
 pWN
 plq
@@ -70278,7 +70480,7 @@ rnx
 aJb
 tUb
 idu
-mfq
+ngb
 xtl
 dCV
 dCV
@@ -70503,7 +70705,7 @@ kjQ
 pWN
 uPP
 fyf
-mEL
+fyf
 fyf
 mEL
 wKo
@@ -70770,7 +70972,7 @@ kaM
 kaM
 cXB
 dsi
-etN
+qhg
 etN
 ghx
 etN
@@ -71019,11 +71221,11 @@ fyf
 fyf
 fyf
 fyf
-fyf
-ars
-bOG
-ees
+thP
+aVP
+fsm
 cjG
+ees
 gts
 gts
 dwx
@@ -71297,9 +71499,9 @@ hbW
 hOl
 wGJ
 mgo
+lKw
 qac
-qac
-nxj
+iUP
 wGJ
 erY
 erY
@@ -71554,7 +71756,7 @@ ktX
 hOl
 wGJ
 erY
-hOl
+gZZ
 neN
 cdc
 wGJ
@@ -71818,7 +72020,7 @@ wGJ
 wGJ
 oUR
 mgo
-pjQ
+hxJ
 dCV
 qhs
 dza
@@ -72072,7 +72274,7 @@ mDr
 cdc
 wGJ
 wGJ
-nxj
+hfe
 wGJ
 wGJ
 pnw
@@ -72302,7 +72504,7 @@ qmP
 gjP
 fyf
 fyf
-fyf
+moR
 fyf
 fyf
 fyf
@@ -73096,16 +73298,16 @@ xhJ
 kaM
 kaM
 kaM
-qoS
+dsb
 qoS
 qoS
 ofe
 oKy
 qoS
 qoS
-qoS
+xte
 sYX
-qoj
+pSk
 oVe
 pSk
 eSN
@@ -73358,8 +73560,8 @@ ees
 ees
 ees
 gQv
-jZE
 oYI
+jZE
 ees
 pHi
 dza
@@ -73590,7 +73792,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+nxY
 fyf
 gts
 gts
@@ -73617,7 +73819,7 @@ dkg
 dkg
 dkg
 cpK
-iIG
+uCW
 uqa
 uqa
 uqa
@@ -73864,7 +74066,7 @@ sYX
 iVd
 cpK
 xdD
-ipj
+fSw
 ipj
 ipj
 xdD
@@ -74382,7 +74584,7 @@ dit
 lGG
 qZI
 qZI
-nkq
+lIX
 dit
 ogO
 oMA
@@ -74616,10 +74818,10 @@ ijg
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
+qOV
+cWG
+hpm
+wDc
 gts
 dCV
 giZ
@@ -74872,11 +75074,11 @@ uRJ
 ijg
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+nkq
+daU
+mvv
+mvv
+bpD
 gts
 dCV
 giZ
@@ -75129,11 +75331,11 @@ uRJ
 gjP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+tBN
+pCn
+mvv
+aBH
+hCg
 gts
 dCV
 giZ
@@ -75386,10 +75588,10 @@ iFb
 gjP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
+tBN
+mvv
+mvv
+bpD
 fyf
 gts
 dCV
@@ -75643,10 +75845,10 @@ uRJ
 gjP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
+oLT
+mfD
+mfD
+hCg
 fyf
 gts
 dCV
@@ -75672,7 +75874,7 @@ dit
 pSk
 dza
 dit
-xdD
+syC
 uaf
 kBC
 rpu
@@ -76172,8 +76374,8 @@ pSk
 gmW
 gCu
 giZ
-cpK
-ish
+fTu
+uCW
 iXz
 cpK
 dkg
@@ -76429,7 +76631,7 @@ pSk
 gmZ
 gmZ
 giZ
-xdD
+ish
 cam
 gdY
 dkg
@@ -76693,8 +76895,8 @@ dkg
 kCA
 dit
 dza
-moR
 pSk
+oQz
 pSk
 nIj
 dza
@@ -76950,7 +77152,7 @@ cpK
 kIZ
 dit
 lMp
-dit
+pSk
 dit
 pSk
 mVn
@@ -77474,7 +77676,7 @@ dit
 odc
 rpu
 uqa
-vXh
+osk
 rkZ
 dCV
 gts
@@ -77716,7 +77918,7 @@ rpu
 csO
 dCV
 dCV
-lKG
+jwU
 cpK
 xdD
 dit

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -43,8 +43,12 @@
 	},
 /area/f13/wasteland)
 "acn" = (
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/f13/wood,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
 /area/f13/building)
 "acK" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -293,6 +297,15 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland)
+"ajB" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "ajD" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2"
@@ -476,6 +489,10 @@
 /obj/effect/landmark/start/f13/explorer,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"aoB" = (
+/mob/living/simple_animal/hostile/stalkeryoung,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "aoD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -1559,6 +1576,12 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"aXJ" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "aXL" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1632,25 +1655,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aZF" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "aZJ" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bar" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 4
+/obj/structure/chair/wood/modern{
+	dir = 4;
+	icon_state = "wooden_chair_old"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
+/obj/machinery/light/small{
+	dir = 1
 	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "bav" = (
 /obj/structure/spacevine{
@@ -1683,10 +1703,8 @@
 /area/f13/wasteland)
 "bbK" = (
 /obj/structure/table/wood,
-/obj/item/paper,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "bbN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2254,10 +2272,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"bqz" = (
+/obj/item/clothing/head/helmet/f13/rustedcowboyhat,
+/obj/item/clothing/suit/armor/f13/rustedcowboy,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "bqB" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/turf/open/floor/f13/wood,
+/obj/structure/destructible/tribal_torch,
+/obj{
+	name = "---Merge conflict marker---"
+	},
+/turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "bqC" = (
 /turf/open/indestructible/ground/outside/road{
@@ -2610,9 +2635,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bDt" = (
-/obj/structure/fence,
-/obj/structure/fence/corner{
-	dir = 1
+/obj/structure/destructible/tribal_torch,
+/obj{
+	name = "---Merge conflict marker---"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -2777,6 +2802,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"bHX" = (
+/obj/structure/chair/stool,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "bHZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -2939,6 +2971,14 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"bPe" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Business"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bPf" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -3292,18 +3332,29 @@
 	},
 /area/f13/farm)
 "cex" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner";
-	tag = "icon-dirtcorner"
+/obj/structure/closet/cabinet,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/area/f13/wasteland)
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/item/clothing/under/f13/classdress,
+/obj/item/clothing/mask/society,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ceT" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
 "cfc" = (
-/obj/structure/barricade/tentclothedge,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "cfn" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -3320,13 +3371,26 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/water,
 /area/f13/caves)
-"cgC" = (
-/obj/structure/chair/wood,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
+"cgu" = (
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench"
 	},
-/area/f13/wasteland)
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"cgC" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/item/clothing/under/f13/classdress,
+/obj/item/clothing/mask/society,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cgY" = (
 /mob/living/simple_animal/hostile/raider/firefighter,
 /turf/open/indestructible/ground/outside/dirt{
@@ -3650,17 +3714,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "ctE" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey"
 	},
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/turf/open/floor/f13/wood,
+/area/f13/caves)
 "ctJ" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/muzzle,
@@ -3832,6 +3891,12 @@
 	dir = 4
 	},
 /area/f13/building)
+"cBe" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cBh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -3917,9 +3982,7 @@
 	},
 /area/f13/building)
 "cGj" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
+/obj/structure/chair/wood/modern,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cGs" = (
@@ -4228,11 +4291,9 @@
 	},
 /area/f13/building)
 "cRJ" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/obj/structure/chair/wood/modern,
+/turf/open/floor/f13/wood,
+/area/f13/caves)
 "cRM" = (
 /obj/structure/debris/v3,
 /obj/structure/flora/rock/jungle,
@@ -4335,11 +4396,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cVj" = (
-/obj/structure/simple_door/tentflap_cloth{
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13/wood,
+/area/f13/caves)
 "cVw" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4433,12 +4492,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cXn" = (
-/obj/structure/destructible/tribal_torch,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/closet,
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cXB" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
@@ -4594,16 +4653,11 @@
 	},
 /area/f13/ncr)
 "dcQ" = (
-/obj/structure/mirror{
-	pixel_y = 30
-	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/pill/charcoal,
+/obj/item/reagent_containers/pill/charcoal,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "dcW" = (
 /obj/machinery/door/airlock/glass_large{
@@ -4848,18 +4902,15 @@
 	},
 /area/f13/wasteland)
 "dkj" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = -3
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "dkr" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
+/obj/machinery/washing_machine,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "dkF" = (
@@ -4951,11 +5002,10 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
 "dol" = (
-/obj/structure/table,
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/clothing_low,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "dop" = (
@@ -5065,16 +5115,25 @@
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/caves)
 "dqZ" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
+/obj/structure/closet,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "dre" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"drC" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dsb" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/road{
@@ -5144,15 +5203,6 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
-"dtq" = (
-/obj/structure/chair/stool{
-	icon_state = "bench"
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "dts" = (
 /obj/structure/simple_door/metal/store,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -5573,9 +5623,11 @@
 	},
 /area/f13/wasteland)
 "dGK" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "dGQ" = (
 /obj/structure/table/reinforced,
@@ -5747,6 +5799,18 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"dMx" = (
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "dMI" = (
 /obj/structure/chair/comfy,
 /obj/machinery/light/small/broken{
@@ -5997,10 +6061,11 @@
 	},
 /area/f13/village)
 "dXN" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress4"
+/obj/structure/chair/wood/modern{
+	dir = 4;
+	icon_state = "wooden_chair_old"
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "dXQ" = (
 /obj/structure/stone_tile/slab,
@@ -6008,12 +6073,10 @@
 /area/f13/caves)
 "dYe" = (
 /obj/structure/barricade/tentclothedge{
-	dir = 8
+	dir = 1;
+	pixel_y = -3
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "dYY" = (
 /obj/machinery/light,
@@ -6171,6 +6234,13 @@
 "eeO" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/wood/f13,
+/area/f13/building)
+"efD" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
 /area/f13/building)
 "efO" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -6739,10 +6809,11 @@
 	},
 /area/f13/building)
 "exj" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/structure/chair/wood/modern{
+	dir = 8
+	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/caves)
 "exm" = (
 /obj/structure/fence{
 	dir = 4
@@ -7127,12 +7198,8 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "eHB" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/crafting/goodparts/five,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/turf/closed/wall/f13/wood/house/broken,
+/area/f13/caves)
 "eHQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -7336,6 +7403,13 @@
 /obj/item/pen/fountain,
 /turf/open/floor/wood,
 /area/f13/building)
+"eNG" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "eNT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -7361,13 +7435,7 @@
 	},
 /area/f13/wasteland)
 "eOK" = (
-/obj/structure/chair/wood/modern{
-	dir = 4;
-	icon_state = "wooden_chair_old"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/structure/simple_door/glass,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eOX" = (
@@ -7377,8 +7445,8 @@
 	},
 /area/f13/wasteland)
 "eOZ" = (
-/obj/structure/table/wood,
-/obj/item/storage/toolbox/mechanical,
+/obj/structure/rack,
+/obj/item/stack/cable_coil,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ePh" = (
@@ -8078,6 +8146,16 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"fiY" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fjg" = (
 /obj/item/stack/rods/ten,
 /turf/open/floor/f13/wood,
@@ -8292,9 +8370,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fqg" = (
-/obj/structure/rack,
-/obj/item/stack/cable_coil,
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
 /area/f13/building)
 "fqi" = (
 /obj/structure/reagent_dispensers/barrel/three,
@@ -8309,6 +8388,12 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/legion)
+"fqP" = (
+/obj/machinery/icecream_vat,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "fqS" = (
 /obj/machinery/light{
 	dir = 1
@@ -8426,16 +8511,11 @@
 	},
 /area/f13/wasteland)
 "fuj" = (
-/obj/structure/closet/cabinet,
+/obj/structure/closet,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/effect/spawner/lootdrop/clothing_low,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/item/clothing/under/f13/classdress,
-/obj/item/clothing/mask/society,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fum" = (
@@ -8769,6 +8849,13 @@
 	},
 /turf/open/floor/plating,
 /area/f13/caves)
+"fFe" = (
+/obj/structure/flora/tree/tall,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "fFu" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/desert,
@@ -8851,14 +8938,9 @@
 	},
 /area/f13/building)
 "fHF" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gibtorso"
-	},
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "fIn" = (
 /obj/structure/table/wood,
@@ -9055,11 +9137,9 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "fPN" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fPT" = (
@@ -9113,14 +9193,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "fQY" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/item/clothing/under/f13/classdress,
-/obj/item/clothing/mask/society,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white,
-/turf/open/floor/f13/wood,
+/obj/structure/table/wood,
+/obj/structure/bedsheetbin,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "fRi" = (
 /obj/machinery/light{
@@ -9283,11 +9360,16 @@
 	},
 /area/f13/wasteland)
 "fXj" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 16
+	},
+/obj/structure/mirror{
+	dir = 8;
+	pixel_y = 28
+	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "fXs" = (
@@ -9338,6 +9420,13 @@
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"fYz" = (
+/obj/structure/table,
+/obj/item/kitchen/knife,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "fYP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/hydronutrients,
@@ -9369,6 +9458,15 @@
 	dir = 4;
 	icon_state = "outerborder"
 	},
+/area/f13/wasteland)
+"gay" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "gaV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -9973,13 +10071,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
 "gsu" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/effect/spawner/lootdrop/trash,
+/obj/structure/toilet,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "gsB" = (
@@ -10011,7 +10105,10 @@
 /turf/closed/wall/f13/store,
 /area/f13/building)
 "gtv" = (
-/obj/machinery/icecream_vat,
+/obj/structure/chair/stool{
+	icon_state = "bench"
+	},
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -10131,13 +10228,8 @@
 	},
 /area/f13/legion)
 "gwB" = (
-/obj/item/clothing/under/f13/police,
-/obj/item/clothing/head/f13/police,
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "gwJ" = (
 /obj/machinery/light/small{
@@ -10202,10 +10294,14 @@
 	},
 /area/f13/brotherhood)
 "gyG" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+/obj/structure/decoration/clock{
+	pixel_y = 30
 	},
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "gza" = (
 /obj/structure/table/wood,
@@ -10247,12 +10343,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gzM" = (
-/obj/structure/bed/mattress,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+/obj/structure/chair/stool{
+	icon_state = "bench_center"
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "gzQ" = (
 /obj/structure/rack,
@@ -10546,8 +10643,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gJx" = (
-/obj/item/instrument/guitar,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "gJI" = (
 /obj/structure/window/fulltile/house{
@@ -10624,11 +10724,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "gMV" = (
-/obj/structure/table/wood,
-/obj/item/pen,
-/obj/item/paper,
-/obj/item/pen,
-/obj/item/reagent_containers/syringe/medx,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gNe" = (
@@ -10962,6 +11059,13 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"gWF" = (
+/obj/structure/table/wood,
+/obj/item/paper,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/building)
 "gWG" = (
 /obj/item/gun/ballistic/revolver/single_shotgun,
 /turf/open/floor/f13/wood{
@@ -11054,11 +11158,11 @@
 	},
 /area/f13/wasteland)
 "gYp" = (
-/obj/structure/closet,
-/obj/item/stack/sheet/plasteel/twenty,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/f13/wood,
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "gYu" = (
 /turf/open/floor/plating,
@@ -11422,12 +11526,15 @@
 	},
 /area/f13/legion)
 "hjw" = (
-/obj/structure/chair/stool{
-	icon_state = "bench"
+/obj/structure/mirror{
+	pixel_y = 30
 	},
-/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "hjA" = (
@@ -11515,9 +11622,7 @@
 	},
 /area/f13/wasteland)
 "hmy" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
+/mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hmP" = (
@@ -11896,7 +12001,7 @@
 	},
 /area/f13/building)
 "hxp" = (
-/obj/machinery/washing_machine,
+/obj/structure/closet,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -11962,10 +12067,12 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "hyf" = (
-/obj/structure/chair/stool,
-/obj/effect/spawner/lootdrop/trash,
+/obj/structure/toilet{
+	dir = 4;
+	pixel_x = -3
+	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "hyj" = (
@@ -12116,8 +12223,10 @@
 	},
 /area/f13/building)
 "hCF" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/light/small,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -12255,11 +12364,7 @@
 	},
 /area/f13/wasteland)
 "hHC" = (
-/obj/structure/closet,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/machinery/light/small,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -12288,12 +12393,12 @@
 	},
 /area/f13/ncr)
 "hHY" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/flora/tree/tall{
+	layer = 2;
+	pixel_y = 9
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "hIb" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -12373,11 +12478,9 @@
 	},
 /area/f13/ncr)
 "hKY" = (
-/obj/structure/table/wood,
-/obj/item/folder/yellow,
-/obj/item/reagent_containers/pill/patch/jet,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/item/candle/tribal_torch,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "hLm" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -12513,6 +12616,15 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"hSu" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "hSD" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -12721,6 +12833,13 @@
 	icon_state = "hole"
 	},
 /area/f13/wasteland)
+"hYw" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "hYy" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/destructible/tribal_torch,
@@ -13021,8 +13140,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ifu" = (
+/obj/structure/ore_box,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
+/area/f13/wasteland)
 "ifQ" = (
 /obj/effect/landmark/start/f13/ncrcombatmedic,
 /turf/open/floor/f13{
@@ -13324,8 +13444,12 @@
 /turf/open/water,
 /area/f13/caves)
 "ioh" = (
-/obj/structure/chair/wood/modern,
-/turf/open/floor/f13/wood,
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner"
+	},
 /area/f13/building)
 "ioi" = (
 /obj/structure/stacklifter,
@@ -13352,10 +13476,9 @@
 	},
 /area/f13/wasteland)
 "ipl" = (
-/obj/structure/chair/wood/modern,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
-	tag = "icon-housewood3-broken"
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/building)
 "ipn" = (
@@ -13419,6 +13542,13 @@
 /obj/structure/nest/mirelurk,
 /turf/open/water,
 /area/f13/caves)
+"irH" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheethos"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "irI" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water,
@@ -13494,9 +13624,10 @@
 	},
 /area/f13/brotherhood)
 "itm" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "itI" = (
@@ -13538,10 +13669,12 @@
 	},
 /area/f13/ncr)
 "iuS" = (
-/obj/structure/chair/wood/modern{
-	dir = 4;
-	icon_state = "wooden_chair_old"
-	},
+/obj/structure/closet/cabinet,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/clothing/under/f13/blackdress,
+/obj/item/clothing/gloves/f13/lace,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iuW" = (
@@ -13673,11 +13806,12 @@
 /turf/open/floor/plating,
 /area/f13/caves)
 "iyR" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheethos"
+/obj/structure/bed/mattress{
+	icon_state = "mattress4"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
 /area/f13/building)
 "iyV" = (
 /obj/machinery/vending/clothing,
@@ -13760,15 +13894,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "iBK" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/ore_box,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/building)
 "iBT" = (
@@ -13880,10 +14008,12 @@
 	},
 /area/f13/building)
 "iGi" = (
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/ore_box,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/building)
 "iGE" = (
@@ -14386,12 +14516,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "iRr" = (
-/obj/structure/closet,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/barricade/tentclothedge{
+	dir = 4
 	},
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
 /area/f13/building)
 "iRv" = (
 /obj/structure/decoration/rag{
@@ -14406,6 +14537,14 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"iRS" = (
+/obj/structure/table/wood,
+/obj/item/pen,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/reagent_containers/syringe/medx,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "iRT" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -14473,9 +14612,14 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "iTk" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
 /area/f13/building)
 "iTt" = (
 /obj/structure/chair/wood/modern{
@@ -14505,11 +14649,8 @@
 /turf/open/water,
 /area/f13/caves)
 "iTJ" = (
-/obj/structure/table/wood,
-/obj/structure/bedsheetbin,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/nest/ghoul,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "iTL" = (
 /obj/structure/rack,
@@ -14599,10 +14740,10 @@
 	},
 /area/f13/building)
 "iYv" = (
-/obj/structure/chair/stool{
-	icon_state = "bench_center"
+/obj/structure/bed/mattress{
+	icon_state = "mattress4"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "iYw" = (
 /obj/structure/barricade/wooden/planks,
@@ -14700,8 +14841,13 @@
 	},
 /area/f13/building)
 "jbx" = (
-/obj/structure/simple_door/glass,
-/turf/open/floor/f13/wood,
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
 /area/f13/building)
 "jbI" = (
 /obj/structure/table/wood,
@@ -14761,9 +14907,6 @@
 	icon_state = "post_wood"
 	},
 /obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "jdE" = (
@@ -15060,6 +15203,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"jmr" = (
+/obj/structure/chair/wood,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "jmt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -15159,6 +15309,14 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"job" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "joc" = (
 /obj/effect/landmark/start/f13/pusher,
 /turf/open/floor/f13/wood,
@@ -15301,6 +15459,12 @@
 /obj/item/storage/backpack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"juB" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
+	},
+/area/f13/building)
 "juD" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks,
@@ -15409,9 +15573,13 @@
 	},
 /area/f13/village)
 "jxk" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood,
+/obj/structure/table,
+/obj/item/storage/firstaid,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (EAST)"
+	},
 /area/f13/building)
 "jxq" = (
 /turf/open/floor/f13/wood{
@@ -15455,11 +15623,14 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "jyf" = (
-/obj/structure/barricade/tentclothedge,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gibleg"
 	},
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "jyC" = (
 /obj/structure/car/rubbish3,
@@ -15548,14 +15719,10 @@
 	},
 /area/f13/brotherhood)
 "jAZ" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
 	},
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "jBH" = (
 /obj/structure/barricade/sandbags,
@@ -16060,9 +16227,12 @@
 	},
 /area/f13/building)
 "jTZ" = (
-/obj/structure/closet,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/bed/mattress{
+	icon_state = "mattress4"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
 	},
 /area/f13/building)
 "jUe" = (
@@ -16166,6 +16336,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
+"jWl" = (
+/obj/structure/simple_door/tentflap_cloth{
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "jWx" = (
 /obj/structure/cargocrate,
 /obj/structure/cargocrate{
@@ -16465,12 +16641,11 @@
 	},
 /area/f13/building)
 "kcZ" = (
-/obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
-	tag = "icon-dirt"
+	dir = 5;
+	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "kdg" = (
 /obj/structure/chair/wood/modern{
 	dir = 4;
@@ -16715,6 +16890,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kln" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
 "klp" = (
 /obj/structure/closet/fridge/standard,
 /obj/item/storage/box/ingredients/american,
@@ -16896,11 +17079,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "kqc" = (
-/obj/structure/decoration/clock{
-	pixel_y = 30
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
 	},
 /area/f13/building)
 "kqe" = (
@@ -17168,6 +17353,16 @@
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
+"kyF" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (WEST)"
 	},
 /area/f13/wasteland)
 "kyT" = (
@@ -17490,8 +17685,13 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "kHf" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/f13/wood,
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
 /area/f13/building)
 "kHj" = (
 /obj/structure/closet/crate/bin,
@@ -17600,12 +17800,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "kLm" = (
-/obj/structure/chair/stool,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "kLv" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -17813,11 +18012,11 @@
 	},
 /area/f13/wasteland)
 "kUe" = (
-/obj/structure/toilet,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/item/stack/ore/iron,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "kUk" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -17945,6 +18144,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"kYb" = (
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kYv" = (
 /obj/structure/simple_door/house{
 	icon_state = "glassclosing";
@@ -17956,11 +18159,8 @@
 	},
 /area/f13/building)
 "kYz" = (
-/obj/structure/chair/stool{
-	dir = 4;
-	icon_state = "bench"
-	},
-/turf/open/floor/f13/wood,
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "kYB" = (
 /obj/structure/barricade/tentclothedge,
@@ -18063,14 +18263,11 @@
 	},
 /area/f13/building)
 "lda" = (
-/obj/structure/decoration/clock{
-	pixel_y = 30
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner"
 	},
-/obj/structure/chair/stool{
-	dir = 8;
-	icon_state = "bench"
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "ldb" = (
 /obj/structure/barricade/bars,
@@ -18712,15 +18909,17 @@
 	},
 /area/f13/wasteland)
 "lvv" = (
+/obj/structure/barricade/tentclothedge,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
 	icon_state = "dirt"
 	},
 /area/f13/building)
 "lvw" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
-	tag = "icon-housewood3-broken"
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHEAST)"
 	},
 /area/f13/building)
 "lvA" = (
@@ -18879,6 +19078,16 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"lzb" = (
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "lzE" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -19389,9 +19598,7 @@
 	},
 /area/f13/ncr)
 "lPj" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress6"
-	},
+/obj/structure/simple_door/tentflap_cloth,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "lPu" = (
@@ -19500,11 +19707,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
 "lRZ" = (
-/obj/structure/chair/stool{
-	dir = 8;
-	icon_state = "bench"
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "lSD" = (
 /turf/open/indestructible/ground/outside/road{
@@ -19651,13 +19858,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "lVu" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 1
-	},
+/obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+	dir = 6;
+	icon_state = "dirt"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "lWj" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19939,6 +20145,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"mfG" = (
+/obj/structure/barricade/tentclothcorner,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "mfN" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/white/box,
@@ -20096,14 +20309,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mmH" = (
-/obj/structure/fence{
-	dir = 4
-	},
+/obj/structure/barricade/tentclothcorner,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "mmK" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -20251,10 +20461,11 @@
 /area/f13/wasteland)
 "moV" = (
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+	dir = 6;
+	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHEAST)"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "moX" = (
 /obj/structure/closet/crate{
 	anchored = 1;
@@ -20330,6 +20541,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mrm" = (
+/obj/structure/table/wood,
+/obj/item/folder/yellow,
+/obj/item/reagent_containers/pill/patch/jet,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mrq" = (
 /turf/closed/indestructible/opshuttle,
 /area/f13/building)
@@ -20388,9 +20605,12 @@
 	},
 /area/f13/wasteland)
 "msS" = (
-/obj/structure/chair/comfy/black,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/item/stack/ore/iron,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "mtl" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13{
@@ -20759,8 +20979,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "mGZ" = (
-/obj/structure/closet/crate/bin,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33";
+	tag = "icon-wasteland33"
+	},
 /area/f13/wasteland)
 "mHt" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -21214,6 +21437,13 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"mVy" = (
+/obj/structure/chair/stool,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "mVR" = (
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/floor/wood/f13/oak,
@@ -21506,20 +21736,14 @@
 	},
 /area/f13/wasteland)
 "neS" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16
-	},
-/obj/structure/mirror{
-	dir = 8;
-	pixel_y = 28
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/rack,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "neZ" = (
-/mob/living/simple_animal/hostile/radroach,
+/obj/structure/chair/bench,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nff" = (
@@ -21546,6 +21770,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
+"nfw" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "nfz" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -21877,9 +22107,7 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "nso" = (
-/obj/structure/chair/stool{
-	icon_state = "bench_center"
-	},
+/obj/structure/chair/bench,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -22143,11 +22371,10 @@
 	},
 /area/f13/wasteland)
 "nBU" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/chair/bench,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "nCl" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/dirt,
@@ -22607,8 +22834,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "nSX" = (
-/mob/living/simple_animal/hostile/wolf,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/item/stack/ore/iron,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
 "nTa" = (
 /obj/structure/fence{
@@ -22687,8 +22914,11 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
 "nUT" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/structure/rack,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/flashlight/lantern,
+/obj/item/clothing/under/overalls,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nVb" = (
@@ -23025,6 +23255,11 @@
 /obj/item/reagent_containers/syringe/medx,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"ogs" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ogO" = (
 /obj/structure/destructible/tribal_torch{
 	pixel_y = 20
@@ -23037,13 +23272,9 @@
 	},
 /area/f13/wasteland)
 "ohk" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/closet/crate/bin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ohx" = (
 /obj/structure/table,
 /obj/item/roller,
@@ -23175,11 +23406,9 @@
 	},
 /area/f13/wasteland)
 "olN" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "olP" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -23220,6 +23449,12 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"ome" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "omu" = (
 /turf/open/indestructible/ground/outside/wood,
@@ -24044,6 +24279,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"oMw" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "oMA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/settler,
@@ -24175,11 +24420,9 @@
 	},
 /area/f13/wasteland)
 "oQq" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/obj/item/stack/ore/slag,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/wasteland)
 "oQv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/iv_drip,
@@ -25186,14 +25429,9 @@
 	},
 /area/f13/city)
 "ptq" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
-	},
-/area/f13/building)
+/obj/item/stack/ore/slag,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ptP" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/desert,
@@ -25377,6 +25615,16 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
+"pAf" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "pAg" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/fakelattice{
@@ -25571,14 +25819,11 @@
 	},
 /area/f13/building)
 "pHx" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/flashlight/lantern,
+/obj/item/clothing/under/overalls,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "pHy" = (
 /mob/living/simple_animal/hostile/handy,
@@ -25698,12 +25943,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pKF" = (
-/obj/structure/barricade/tentclothcorner,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/building)
+/obj/item/stack/ore/slag,
+/obj/item/stack/ore/slag,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/wasteland)
 "pKP" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -25972,6 +26215,11 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"pSB" = (
+/obj/structure/table/wood,
+/obj/item/paper,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pSC" = (
 /obj/structure/fence/corner/wooden{
 	dir = 1
@@ -26003,12 +26251,13 @@
 	},
 /area/f13/building)
 "pTE" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/pill/charcoal,
-/obj/item/reagent_containers/pill/charcoal,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/item/stack/ore/iron,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
+	},
+/area/f13/wasteland)
 "pTM" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/inside/mountain,
@@ -26205,15 +26454,12 @@
 	},
 /area/f13/brotherhood)
 "qai" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/ore_box,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "qal" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plating,
@@ -26749,6 +26995,12 @@
 	icon_state = "verticalrightborderleft1"
 	},
 /area/f13/wasteland)
+"qpe" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qpJ" = (
 /obj/item/clothing/suit/f13/duster,
 /obj/item/clothing/suit/f13/autumn,
@@ -27486,9 +27738,10 @@
 	},
 /area/f13/ncr)
 "qMp" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 25
+/obj/structure/chair/stool{
+	icon_state = "bench"
 	},
+/obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -27732,13 +27985,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "qQT" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
+/obj/item/instrument/guitar,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "qQW" = (
 /obj/structure/lattice/catwalk,
@@ -27859,6 +28107,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"qTq" = (
+/obj/structure/chair/wood/modern,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
+	},
+/area/f13/building)
 "qTr" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
@@ -27946,6 +28201,11 @@
 /obj/structure/fluff/fokoff_sign,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"qWR" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qWU" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/breadhard,
@@ -28291,11 +28551,14 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "rkQ" = (
-/obj/structure/barricade/tentclothedge,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gibtorso"
 	},
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "rkZ" = (
 /obj/structure/table/wood,
@@ -28733,12 +28996,11 @@
 	},
 /area/f13/wasteland)
 "rDU" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "rEc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28935,6 +29197,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"rMB" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "rNa" = (
 /obj/structure/closet,
 /turf/open/floor/f13{
@@ -29028,6 +29296,14 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
+"rQu" = (
+/obj/structure/bed/mattress,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "rQx" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/wood/f13/carpet,
@@ -29391,10 +29667,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "scY" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/item/stack/ore/iron,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "sdo" = (
 /obj/structure/chair/sofa/corp/corner{
@@ -30164,6 +30438,10 @@
 "swU" = (
 /turf/closed/wall/rust,
 /area/f13/building)
+"sxo" = (
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "sxs" = (
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/outside/desert,
@@ -30224,6 +30502,10 @@
 /obj/structure/table/wood/bar,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"szv" = (
+/obj/item/chair/wood,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "szy" = (
 /obj/structure/fence{
 	dir = 4
@@ -30378,14 +30660,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sDO" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gibleg"
-	},
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/ore_box,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "sEn" = (
 /mob/living/simple_animal/hostile/gecko,
@@ -31062,8 +31338,13 @@
 	},
 /area/f13/city)
 "tat" = (
-/obj/structure/simple_door/tentflap_cloth,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/rack,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "taF" = (
 /obj/structure/fence{
@@ -31179,11 +31460,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tem" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/structure/ladder/unbreakable{
+	desc = "A sturdy ladder that leads down deep into the earth... don't fall.";
+	height = 2;
+	id = "digsite";
+	name = "ladder to the depths"
 	},
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
 "tep" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31248,18 +31531,9 @@
 	},
 /area/f13/brotherhood)
 "tha" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/item/shovel,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "thb" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/plasteel/barber{
@@ -31783,11 +32057,8 @@
 	},
 /area/f13/tunnel)
 "twY" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/item/stack/ore/slag,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "txb" = (
 /obj/structure/bus_door,
@@ -32189,6 +32460,14 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"tIQ" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tJe" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -32271,22 +32550,24 @@
 	},
 /area/f13/caves)
 "tLW" = (
-/obj/structure/destructible/tribal_torch,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/building)
+/obj/structure/nest/ghoul,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tMm" = (
 /obj/structure/table/wood,
 /obj/item/clothing/suit/armor/f13/kit,
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"tMX" = (
-/obj/item/clothing/head/helmet/f13/rustedcowboyhat,
-/obj/item/clothing/suit/armor/f13/rustedcowboy,
+"tMw" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
+	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
+"tMX" = (
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "tNa" = (
 /obj/structure/table/wood,
@@ -32299,6 +32580,12 @@
 /obj/item/reagent_containers/glass/rag/towel,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"tNk" = (
+/obj/structure/chair/stool{
+	icon_state = "bench_center"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tNm" = (
 /obj/structure/rack,
 /obj/item/storage/belt/utility/full,
@@ -32323,6 +32610,15 @@
 	tag = "icon-verticalleftborderright2"
 	},
 /area/f13/wasteland)
+"tNK" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "tNX" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/desert,
@@ -33042,6 +33338,13 @@
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland)
+"uiQ" = (
+/obj/item/stack/ore/iron,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33";
+	tag = "icon-wasteland33"
+	},
+/area/f13/wasteland)
 "ujr" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -33150,9 +33453,10 @@
 	},
 /area/f13/building)
 "umM" = (
-/mob/living/simple_animal/hostile/stalkeryoung,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/structure/table,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "umS" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -33429,6 +33733,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"ute" = (
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "utk" = (
 /obj/structure/table/wood,
 /obj/item/ammo_casing/shotgun/buckshot,
@@ -33576,8 +33888,8 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
 "uzb" = (
-/obj/item/chair/wood,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/item/stack/ore/slag,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
 "uzn" = (
 /obj/structure/chair/stool,
@@ -33597,9 +33909,7 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "uzJ" = (
-/obj/structure/chair{
-	dir = 1
-	},
+/obj/structure/nest/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uzM" = (
@@ -34145,10 +34455,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uPr" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -34454,13 +34768,8 @@
 	},
 /area/f13/wasteland)
 "uWE" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
+/obj/structure/chair/f13chair2,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "uWH" = (
 /obj/structure/chair{
@@ -34667,11 +34976,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
 "vcu" = (
-/obj/structure/fence/wooden{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/obj/item/pickaxe,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "vcF" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -34714,6 +35021,13 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"vdN" = (
+/mob/living/simple_animal/hostile/retaliate/goat/bighorn,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "vdO" = (
 /obj/structure/fence{
 	dir = 8
@@ -34756,12 +35070,7 @@
 	},
 /area/f13/wasteland)
 "veO" = (
-/obj/structure/closet/cabinet,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/clothing/under/f13/blackdress,
-/obj/item/clothing/gloves/f13/lace,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vfc" = (
@@ -35749,11 +36058,13 @@
 	},
 /area/f13/ncr)
 "vMR" = (
-/obj/structure/table,
-/obj/item/kitchen/knife,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/machinery/light/small{
+	dir = 4
 	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "vMU" = (
 /turf/open/indestructible/ground/outside/road{
@@ -35870,6 +36181,10 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"vRC" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vRK" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -36107,11 +36422,16 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"wad" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetgrey"
+"vZY" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 25
 	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"wad" = (
+/obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "wbd" = (
@@ -36137,13 +36457,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "wcA" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/structure/chair/f13chair2{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (EAST)"
+	},
+/area/f13/wasteland)
 "wcO" = (
 /obj/structure/chair/stool,
 /mob/living/simple_animal/hostile/ghoul,
@@ -36516,12 +36838,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "wqL" = (
-/obj/item/clothing/suit/armor/f13/rustedcowboy,
-/obj/item/clothing/head/helmet/f13/rustedcowboyhat,
+/obj/structure/campfire,
 /turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "wqO" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -36571,6 +36893,10 @@
 /obj/effect/landmark/start/f13/villager,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"wss" = (
+/mob/living/simple_animal/hostile/wolf,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "wsy" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical";
@@ -36667,11 +36993,14 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "wwb" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "wwF" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -36899,6 +37228,14 @@
 "wBC" = (
 /obj/structure/rack,
 /obj/item/clothing/head/crown,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"wBZ" = (
+/obj/structure/table,
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -37137,13 +37474,15 @@
 	},
 /area/f13/wasteland)
 "wKv" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
-	},
+/obj/structure/rack,
+/obj/item/storage/bag/ore,
+/obj/item/clothing/under/overalls,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"wKE" = (
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
+	dir = 4;
+	icon_state = "dirtcorner"
 	},
 /area/f13/building)
 "wKU" = (
@@ -37222,11 +37561,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
 "wMy" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
+/obj/structure/chair/f13chair2{
+	dir = 1
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "wNK" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -37261,9 +37600,9 @@
 	},
 /area/f13/building)
 "wOj" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/nest/ghoul,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "wOo" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/barber{
@@ -37709,14 +38048,9 @@
 	},
 /area/f13/wasteland)
 "wYh" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/building)
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "wYn" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -37794,6 +38128,12 @@
 /obj/item/mining_scanner,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"xba" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "xbv" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/desert,
@@ -38648,10 +38988,11 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
 "xxs" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/rack,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "xxL" = (
 /obj/machinery/light/small/broken{
@@ -38981,8 +39322,11 @@
 	},
 /area/f13/wasteland)
 "xJd" = (
-/obj/structure/chair/stool,
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
+	},
 /area/f13/wasteland)
 "xJA" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -39149,9 +39493,9 @@
 	},
 /area/f13/wasteland)
 "xNQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/structure/rack,
+/obj/item/storage/bag/ore,
+/obj/item/flashlight/lantern,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xOi" = (
@@ -39269,12 +39613,10 @@
 	},
 /area/f13/building)
 "xRS" = (
-/obj/structure/flora/tree/tall,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/structure/chair/bench,
+/obj/item/clothing/under/overalls,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "xSa" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/dirt{
@@ -39355,6 +39697,12 @@
 	tag = "icon-horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"xUy" = (
+/obj/structure/fence/wooden{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "xUO" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -39412,9 +39760,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xVZ" = (
-/obj/structure/chair/wood/modern{
-	dir = 8
-	},
+/obj/structure/chair/bench,
+/obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xWu" = (
@@ -39442,15 +39789,12 @@
 /turf/open/indestructible/ground/outside/river,
 /area/f13/wasteland)
 "xXl" = (
-/obj/item/clothing/under/f13/police,
-/obj/item/clothing/head/f13/police,
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32";
+	tag = "icon-wasteland32"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "xXo" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -39626,12 +39970,10 @@
 	},
 /area/f13/village)
 "ybq" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/barricade/sandbags,
+/obj/item/candle/tribal_torch,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ybw" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road,
@@ -39684,6 +40026,19 @@
 	tag = "icon-horizontalbottomborderbottom2"
 	},
 /area/f13/wasteland)
+"ycS" = (
+/obj/structure/chair/wood/modern{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"ycX" = (
+/obj/item/clothing/suit/armor/f13/rustedcowboy,
+/obj/item/clothing/head/helmet/f13/rustedcowboyhat,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "ydQ" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowdestroyed"
@@ -39900,13 +40255,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ykq" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/item/stack/ore/iron,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ykx" = (
 /obj/item/clothing/head/ushanka,
 /obj/structure/displaycase,
@@ -57827,7 +58178,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+sqA
 fyf
 fyf
 fyf
@@ -58861,7 +59212,7 @@ cWG
 wDc
 fyf
 fyf
-fyf
+sqA
 fyf
 fyf
 fyf
@@ -69520,16 +69871,16 @@ hfk
 mrA
 jIe
 fyf
+sqA
 fyf
 fyf
 fyf
 fyf
+sqA
 fyf
-fyf
-fyf
-fyf
-gcK
-gcK
+qOV
+cWG
+wDc
 gcK
 ktB
 "}
@@ -69678,7 +70029,7 @@ gjP
 fyf
 fyf
 fyf
-fyf
+sqA
 fyf
 fyf
 fyf
@@ -69781,12 +70132,12 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
+kln
+tNK
+tNK
+ajB
+rMB
+bpD
 gcK
 ktB
 "}
@@ -70034,16 +70385,16 @@ fyf
 fyf
 fyf
 fyf
+dUk
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
+qOV
+pAf
+iYv
+tPA
+cbr
+kYB
+hCg
 gcK
 ktB
 "}
@@ -70291,16 +70642,16 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-sqA
-fyf
+dUk
+nZr
 qOV
-cWG
-wDc
+daU
+jWl
+cbr
+xUy
+tMw
+fKq
 fyf
-gcK
 gcK
 ktB
 "}
@@ -70549,15 +70900,15 @@ fyf
 fyf
 fyf
 fyf
-fyf
+qOV
 lVu
-dYe
+mvv
 dYe
 qQT
-xxs
-bpD
+cbr
+tPA
+fKq
 fyf
-gcK
 gcK
 ktB
 "}
@@ -70803,18 +71154,18 @@ fyf
 fyf
 pis
 fyf
-dUk
 fyf
 fyf
 qOV
-wKv
-dXN
-tPA
-cbr
-kYB
-hCg
+jmr
+oAS
+mvv
+aXJ
+ome
+ome
+ome
+mfG
 fyf
-gcK
 gcK
 ktB
 "}
@@ -71061,17 +71412,17 @@ fyf
 fyf
 fyf
 dUk
-nZr
-qOV
-daU
-cVj
-cbr
-vcu
-lPj
-fKq
 fyf
+tBN
+mvv
+oAS
+nfw
+mvv
+mvv
+mvv
+aBH
+hCg
 fyf
-gcK
 gcK
 ktB
 "}
@@ -71313,22 +71664,22 @@ fyf
 fyf
 fyf
 fyf
+sqA
 fyf
 fyf
 fyf
+dUk
 fyf
-fyf
-qOV
-rDU
+tBN
 mvv
-dqZ
-gJx
-cbr
-tPA
-fKq
-fyf
-fyf
-gcK
+mvv
+mvv
+mvv
+mvv
+mvv
+bpD
+qOV
+cWG
 gcK
 ktB
 "}
@@ -71569,23 +71920,23 @@ fyf
 dUk
 fyf
 fyf
-cex
-cWG
-cWG
-wDc
 fyf
-qOV
-cgC
-oAS
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+tBN
+wss
+tCo
 mvv
-oQq
-cRJ
-cRJ
-cRJ
-pKF
-fyf
-fyf
-gcK
+mvv
+mvv
+bGM
+bpD
+tBN
+mvv
 gcK
 ktB
 "}
@@ -71809,7 +72160,7 @@ eUp
 eUp
 xzU
 fyf
-fyf
+sqA
 fyf
 wiZ
 eUp
@@ -71826,23 +72177,23 @@ fyf
 fyf
 fyf
 fyf
-nbX
-mvv
-mvv
-bpD
+fyf
+dUk
+dUk
+fyf
+fyf
+fyf
 fyf
 tBN
-mvv
-oAS
-nBU
+bGM
 mvv
 mvv
+wsC
 mvv
 aBH
 hCg
-fyf
-fyf
-gcK
+nlO
+mfD
 gcK
 ktB
 "}
@@ -72040,31 +72391,36 @@ cdc
 erY
 gmX
 koD
-dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-qOV
-cWG
-cWG
-cWG
-wDc
-bDt
+sUX
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+mKu
+jIe
+dUk
+tlD
+uxC
+uxC
+uxC
 uxC
 uxC
 uxC
@@ -72083,23 +72439,18 @@ uxC
 uxC
 uxC
 uxC
-kcZ
-pXo
-eJr
-bpD
+uxC
+uxC
+job
+mvv
+mvv
+mvv
+mvv
+aBH
+hCg
 fyf
-tBN
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-bpD
-qOV
-cWG
-wDc
-gcK
+fyf
+fyf
 gcK
 ktB
 "}
@@ -72310,53 +72661,53 @@ fyf
 fyf
 fyf
 fyf
+sqA
+fyf
+fyf
+fyf
+fyf
+jxH
+jxH
+jxH
+jxH
+jxH
+dUk
+dUk
+dUk
+thG
+fyf
+jxH
+jxH
+jxH
+jxH
+jxH
+ybq
+fyf
+fyf
+fyf
+gts
+gts
+gts
+gts
+gts
+gts
+gts
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-tBN
+kyF
+xGH
+szv
 mvv
-mvv
-mvv
-bpD
-gts
-gts
-gts
-gts
-gts
-gts
-fyf
-fyf
-gts
-gts
-gts
-gts
-gts
-gts
-gts
+aBH
+hCg
 fyf
 fyf
 fyf
 fyf
-oLT
-mfD
-mmH
-bpD
-fyf
-tBN
-nSX
-tCo
-mvv
-mvv
-mvv
-bGM
-bpD
-tBN
-mvv
-bpD
-gcK
 gcK
 ktB
 "}
@@ -72570,26 +72921,31 @@ uxC
 uxC
 uxC
 uxC
-uxC
 wEo
 fyf
-tBN
-mvv
-mvv
-mvv
-bpD
-gts
+fyf
+fyf
+fyf
+fyf
+fyf
+koe
 xXl
-fXj
-ctE
-gwB
-gts
+xXl
+thG
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+jxH
+fyf
 fyf
 fyf
 gts
 vYv
-dtq
-iBK
+qMp
+dMx
 vYv
 kIl
 gts
@@ -72599,21 +72955,16 @@ gts
 gts
 fyf
 fyf
-uWE
-hCg
-fyf
+thG
 tBN
-bGM
-mvv
-mvv
-wsC
 mvv
 aBH
 hCg
-nlO
-mfD
-hCg
-gcK
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 ktB
 "}
@@ -72827,26 +73178,31 @@ fyf
 hYy
 fyf
 fyf
-fyf
 thG
 fyf
-tBN
-mvv
-mvv
-mvv
-bpD
-gts
-vYv
-vYv
-vYv
-vYv
-gts
+hnk
+osJ
+osJ
+osJ
+kJj
+fyf
+fyf
+fyf
+thG
+ifu
+umM
+fyf
+dUk
+rsE
+dUk
+jxH
+sqA
 fyf
 fyf
 toB
 ouS
 olP
-ybq
+hYw
 ouS
 vYv
 gts
@@ -72857,20 +73213,15 @@ gts
 fyf
 fyf
 thG
-fyf
-fyf
 tBN
 mvv
-mvv
-mvv
-mvv
-aBH
-hCg
+bpD
 fyf
 fyf
 fyf
 fyf
-gcK
+fyf
+fyf
 gcK
 ktB
 "}
@@ -73071,63 +73422,63 @@ koD
 dMW
 fyf
 thG
+sYX
+sYX
+xIq
+sYX
+sYX
+xIq
+sYX
+xIq
+sYX
 fyf
-sYX
-sYX
-xIq
-sYX
-sYX
-xIq
-sYX
-sYX
-xIq
-sYX
 fyf
 fyf
 fyf
 thG
 fyf
-tBN
-mvv
-mvv
+qmc
+ioh
+iTk
+jxk
+kYz
+fyf
+fyf
+fyf
+thG
+ifu
+umM
+fyf
+fyf
+koe
+fyf
+jxH
+xXl
+fyf
+fyf
+gts
+ute
+qMp
+lzb
+vYv
+vYv
+gts
+vZY
+vYv
+wBZ
+gts
+fyf
+fyf
+xHc
+fFe
 mvv
 bpD
-gts
-gts
-gts
-vYv
-gts
-gts
-fyf
-fyf
-gts
-kqc
-dtq
-pHx
-vYv
-vYv
-gts
-qMp
-vYv
-dol
-gts
-fyf
-fyf
-thG
-fyf
-fyf
-nlO
-xGH
-uzb
-mvv
-aBH
-hCg
 fyf
 fyf
 fyf
 fyf
+sqA
 fyf
-gcK
 gcK
 ktB
 "}
@@ -73328,32 +73679,37 @@ koD
 dMW
 fyf
 thG
-fyf
 cuv
-exj
+aZF
 rpu
-gYp
+cXn
 sYX
 rpu
-jxk
-jxk
+gMV
 iAz
 sYX
 fyf
 fyf
 fyf
+fyf
 thG
 fyf
-tBN
-uRa
-mvv
-mvv
-bpD
-toB
-ybq
-uKY
-vYv
-gts
+qmc
+ipl
+cbr
+jAZ
+lda
+cWG
+cWG
+cWG
+mQZ
+cWG
+cWG
+cWG
+wcA
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -73366,25 +73722,20 @@ vYv
 olP
 vYv
 vYv
-vMR
+fYz
 gts
 fyf
 fyf
-thG
-fyf
-fyf
-fyf
-tBN
+dkK
 mvv
 aBH
-hCg
+vdN
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-gcK
 gcK
 ktB
 "}
@@ -73585,33 +73936,38 @@ koD
 dMW
 fyf
 thG
-fyf
 sYX
 rpu
 klA
-hmy
+dkj
 sYX
 iAz
 rpu
-sKH
 rpu
 sYX
 sYX
 sYX
 sYX
+fyf
 thG
 fyf
-tBN
+qmc
+uYO
+iTJ
+jTZ
+lvv
 mvv
 mvv
-mvv
-lRH
-toB
 ykq
-vYv
-scY
-gts
+mvv
+mvv
+mvv
+uWE
+wqL
+wMy
 fyf
+fyf
+sxo
 rsE
 fyf
 mFe
@@ -73627,11 +73983,7 @@ pjD
 gts
 fyf
 fyf
-thG
-fyf
-fyf
-fyf
-tBN
+dkK
 mvv
 bpD
 fyf
@@ -73641,7 +73993,6 @@ fyf
 fyf
 fyf
 fyf
-gcK
 gcK
 ktB
 "}
@@ -73842,63 +74193,63 @@ koD
 dMW
 fyf
 thG
-fyf
 sYX
-eOK
+bar
 klA
 rpu
 sYX
-iRr
-rpu
+fuj
 rpu
 iAz
 sYX
-dcQ
-dkj
+hjw
+hyf
 sYX
+fyf
 vxC
 fyf
-tBN
+jyf
+iyR
+cbr
+kcZ
+lvw
+nSX
+mvv
+ahC
+mvv
+tLW
 mvv
 mvv
-mvv
-bpD
-toB
-twY
-vYv
-vYv
+wwb
+dUk
+fyf
+fyf
+fyf
+fyf
+fyf
 gts
-fyf
-fyf
-fyf
-gts
 vYv
-hjw
-gsu
-vYv
-vYv
-vMR
 gtv
+cgu
 vYv
-qai
+vYv
+fYz
+fqP
+vYv
+oMw
 gts
 fyf
 fyf
-thG
-fyf
-fyf
-qOV
-xRS
+dkK
 mvv
 bpD
 fyf
 fyf
+dUk
 fyf
 fyf
-sqA
 fyf
 fyf
-gcK
 gcK
 ktB
 "}
@@ -74099,32 +74450,37 @@ koD
 dMW
 fyf
 thG
-fyf
 cuv
+bbK
 eOZ
 fqg
-wMy
 sYX
 iAz
 rpu
 rpu
-rpu
 jgq
 dhC
-aZF
+hCF
 sYX
 fyf
+koe
 fyf
-tBN
+qmc
+iBK
+cbr
+cbr
+lPj
 mvv
+olN
+ahC
+ahC
 mvv
+ahC
 mvv
 bpD
-toB
-iHj
-vYv
-vYv
-gts
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -74132,7 +74488,7 @@ toB
 ouS
 onQ
 onQ
-hyf
+mVy
 vYv
 rVK
 vYv
@@ -74141,21 +74497,16 @@ vYv
 gts
 fyf
 fyf
-thG
-fyf
-fyf
-tBN
-mvv
-aBH
+kyF
+mfD
 hCg
 fyf
 fyf
+dUk
 fyf
 fyf
+sqA
 fyf
-fyf
-fyf
-gcK
 gcK
 ktB
 "}
@@ -74356,44 +74707,49 @@ koD
 dMW
 fyf
 thG
-fyf
 sYX
-tLW
+bqB
 sYX
 sDp
 sYX
-iTk
+fHF
 rpu
-rpu
-jxk
+gMV
 uqa
 uqa
 sYX
 sYX
 fyf
 fyf
-tBN
+fyf
+rkQ
+iGi
+iYv
+kqc
+lRZ
+ahC
+ahC
+pKF
+ahC
+ahC
 mvv
 mvv
-mvv
-bpD
-gts
-gts
-gts
-mFe
-gts
+doX
+bKs
 fyf
 fyf
+hHY
 fyf
+koe
 gts
 iPf
 bzb
-tha
+uPr
 vYv
 auU
 gts
-uPr
-uPr
+hSu
+hSu
 vYv
 gts
 fyf
@@ -74401,9 +74757,6 @@ fyf
 thG
 fyf
 fyf
-tBN
-mvv
-bpD
 fyf
 fyf
 fyf
@@ -74411,8 +74764,6 @@ fyf
 fyf
 fyf
 fyf
-wjt
-gcK
 gcK
 ktB
 "}
@@ -74568,7 +74919,7 @@ fyf
 gts
 dCV
 giZ
-kXv
+acn
 kXv
 kXv
 fxf
@@ -74613,14 +74964,12 @@ koD
 dMW
 fyf
 thG
-rsE
 fyf
 fyf
 rsE
 fyf
 sYX
 iAz
-rpu
 rpu
 iAz
 sYX
@@ -74629,14 +74978,21 @@ wEO
 sYX
 fyf
 fyf
-tBN
+fyf
+nKV
+iRr
+jbx
+kHf
+mmH
+mvv
+ahC
+gFR
+tem
+ahC
 mvv
 mvv
 mvv
 bpD
-fyf
-fyf
-fyf
 fyf
 fyf
 fyf
@@ -74658,14 +75014,9 @@ fyf
 thG
 fyf
 fyf
-tBN
-mvv
-bpD
 fyf
 fyf
-fyf
-fyf
-fyf
+wjt
 fyf
 fyf
 fyf
@@ -74872,28 +75223,33 @@ fyf
 thG
 fyf
 fyf
-fyf
 sYX
 sYX
 sYX
 sYX
 sYX
-sDp
 sYX
 sYX
-dcQ
-olN
+hjw
+hHC
 uqa
 fyf
 fyf
-tBN
+fyf
+fyf
+fyf
+fyf
+kLm
+moV
+ahC
+oQq
+gFR
+gFR
+ahC
+uzb
 mvv
-mvv
-mvv
+ykq
 bpD
-fyf
-fyf
-fyf
 fyf
 fyf
 fyf
@@ -74907,23 +75263,18 @@ gts
 pMz
 sCf
 wPl
-dGK
+qWR
 olW
 gts
 fyf
 fyf
 thG
-dUk
-fyf
-nlO
-mfD
-hCg
-fyf
-fyf
-fyf
 fyf
 fyf
 sqA
+fyf
+fyf
+fyf
 fyf
 fyf
 gcK
@@ -75129,13 +75480,11 @@ fyf
 thG
 fyf
 fyf
-fyf
 sYX
-hxp
+dkr
 dhC
-iTJ
+fQY
 sCf
-rpu
 rpu
 sYX
 uCO
@@ -75143,19 +75492,26 @@ sDp
 uqa
 fyf
 fyf
-nlO
-tem
-mfD
-mfD
-hCg
-fyf
-fyf
-sju
 fyf
 fyf
 fyf
+rsE
+kUe
+bGM
+vtH
+ahC
+gFR
+ahC
+oQq
+ahC
+mvv
+mvv
+bpD
 fyf
 fyf
+koe
+mGZ
+dUk
 fyf
 fyf
 fyf
@@ -75174,15 +75530,10 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 dUk
+fyf
+fyf
+fyf
 gcK
 gcK
 ktB
@@ -75384,54 +75735,54 @@ koD
 dMW
 fyf
 thG
-fyf
 rsE
 fyf
 sYX
-hCF
+dol
 dhC
 dhC
-rpu
 rpu
 rpu
 rpu
 rpu
 rpu
 sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+tBN
+mvv
+mvv
+ahC
+ahC
+tha
+ahC
+nSX
+mvv
+vtH
+bpD
+fyf
+fyf
+fyf
 mGZ
+dUk
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-mGZ
+ohk
 gts
 klA
 rpu
 rkZ
-ohk
+bPe
 rpu
 gts
 fyf
 dUk
 thG
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 dUk
 fyf
@@ -75643,12 +75994,10 @@ dDC
 thG
 fyf
 fyf
-fyf
 sYX
-hHC
+dqZ
 dhC
 jbw
-rpu
 rpu
 vXh
 rpu
@@ -75658,37 +76007,39 @@ wpx
 fyf
 fyf
 fyf
+sqA
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-xJd
+nlO
+msS
+mvv
+ptq
+ahC
+mvv
+mvv
+mvv
+ahC
+aBH
+hCg
 fyf
 rsE
 fyf
+dUk
+dUk
+hHY
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-acn
+kYb
 rpu
 rpu
-bbK
-uzJ
+gWF
+drC
 rpu
 gts
 fyf
 dUk
 thG
-fyf
-dUk
-fyf
-fyf
-fyf
 fyf
 fyf
 fyf
@@ -75900,52 +76251,52 @@ fyf
 thG
 fyf
 fyf
-fyf
 uqa
-hHY
+dGK
 dhC
 dhC
 dhC
 rpu
 rpu
-rpu
-neZ
+hmy
 olW
 sYX
 fyf
 fyf
+ulH
+fyf
+ifu
+ifu
+fyf
+tBN
+mvv
+mvv
+mvv
+mvv
+aBH
+xJd
+xJd
+hCg
+wOj
+fyf
+uiQ
+fyf
+jxH
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-wrg
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-acn
+kYb
 rpu
 rpu
-jAZ
+fiY
 rpu
 rpu
 gts
 fyf
 fyf
 thG
-fyf
-fyf
-dUk
-fyf
-fyf
 fyf
 dUk
 wjt
@@ -76112,7 +76463,7 @@ dCV
 giZ
 dau
 dza
-eHB
+dza
 pSk
 pSk
 gCq
@@ -76157,13 +76508,11 @@ fyf
 thG
 fyf
 fyf
-fyf
 uqa
-hxp
+dkr
 dhC
+dkr
 hxp
-jTZ
-rkZ
 rkZ
 rkZ
 rpu
@@ -76172,37 +76521,39 @@ cuv
 fyf
 fyf
 fyf
-qOV
-cWG
-cWG
-cWG
-wDc
 fyf
+fyf
+ifu
+fyf
+nlO
 xJd
+xJd
+pTE
+xJd
+hCg
+koe
+vcu
+ifu
+wYh
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gts
-kYz
-rpu
-bqB
-uzJ
-rpu
-gts
-fyf
-fyf
-thG
 fyf
 fyf
 dUk
 fyf
 fyf
+fyf
+fyf
+gts
+itm
+rpu
+pSB
+drC
+rpu
+gts
+fyf
+fyf
+thG
 wjt
 dUk
 fyf
@@ -76413,10 +76764,8 @@ dMW
 fyf
 thG
 fyf
-fyf
-cXn
+bDt
 uqa
-sYX
 sYX
 sYX
 sYX
@@ -76429,37 +76778,39 @@ sYX
 fyf
 fyf
 fyf
-tBN
-mvv
-mvv
-mvv
-bpD
 fyf
 fyf
 fyf
+swU
+swU
+swU
+swU
+qai
+koe
 fyf
 fyf
+qai
+swU
+swU
+swU
+swU
 fyf
 fyf
+dUk
 fyf
 fyf
 fyf
 fyf
 cuv
-iYv
+tNk
 rpu
-dGK
+qWR
 rpu
 rpu
 gts
 fyf
 fyf
 thG
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 dUk
 fyf
@@ -76686,24 +77037,29 @@ fyf
 fyf
 fyf
 fyf
-tBN
-mvv
-pIn
-mvv
-bpD
 fyf
-fyf
-fyf
-fyf
+swU
+neS
+nUT
+swU
+swU
+jWO
 dUk
 fyf
+swU
+swU
+xxs
+xNQ
+swU
 fyf
 fyf
 fyf
-cXn
+fyf
+fyf
+bDt
 nZS
 gts
-lRZ
+gJx
 rpu
 rpu
 rpu
@@ -76712,11 +77068,6 @@ gts
 fyf
 fyf
 thG
-fyf
-fyf
-sqA
-fyf
-fyf
 fyf
 dUk
 wjt
@@ -76881,7 +77232,7 @@ fyf
 gts
 dCV
 giZ
-pSk
+dau
 pSk
 eLJ
 fAP
@@ -76930,8 +77281,6 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
 sYX
 sYX
 uqa
@@ -76941,17 +77290,24 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-bpD
+koe
 fyf
 fyf
 fyf
 fyf
+swU
+rpu
+rpu
+rpu
+xjA
+scY
+rpu
+rpu
+xjA
+rpu
+rpu
+oqA
+swU
 fyf
 fyf
 fyf
@@ -76969,11 +77325,6 @@ gts
 gts
 gts
 gts
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 dUk
 fyf
@@ -77187,8 +77538,6 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
 sYX
 dhC
 wEO
@@ -77200,37 +77549,39 @@ fyf
 fyf
 fyf
 fyf
-tBN
-mvv
-mvv
-mvv
-bpD
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-gts
-veO
+swU
+neZ
 rpu
-msS
-nUT
+rpu
+rDU
+sDO
+scY
+rpu
+rpu
+sDO
+rpu
+xRS
+swU
+fyf
+fyf
+fyf
 gts
 iuS
+rpu
+vRC
+ogs
+gts
+dXN
 rpu
 rpu
 rpu
 sDp
 dhC
-dkj
+hyf
 gts
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 fyf
@@ -77444,28 +77795,33 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
 sYX
-neS
-iGi
+fXj
+gYp
 sYX
 fyf
 fyf
 fyf
+hHY
+fyf
+hKY
 fyf
 fyf
 fyf
 fyf
-nlO
-mfD
-mfD
-mfD
-hCg
-fyf
-fyf
-fyf
-fyf
+swU
+nso
+rpu
+rpu
+scY
+rpu
+scY
+bHo
+rpu
+oqA
+rpu
+xVZ
+swU
 fyf
 fyf
 fyf
@@ -77473,25 +77829,20 @@ gts
 tUf
 rpu
 aug
-nUT
-gts
-pTE
-rpu
-rpu
-iuS
+ogs
 gts
 dcQ
+rpu
+rpu
+dXN
+gts
+hjw
 usW
 gts
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sqA
 fyf
 gcK
 gcK
@@ -77697,14 +78048,12 @@ koD
 dMW
 fyf
 thG
-fyf
-fyf
 sYX
 sYX
 xIq
 sYX
 sYX
-kUe
+gsu
 dhC
 sYX
 fyf
@@ -77713,38 +78062,40 @@ fyf
 fyf
 fyf
 fyf
-xJd
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-dUk
+swU
+nBU
+oqA
+rpu
+sDO
+twY
+tMX
+uzJ
+veO
+rpu
+foz
+hHR
+swU
 fyf
 fyf
 fyf
 gts
 rpu
-xNQ
+qpe
 rpu
-iyR
+irH
 rVK
-xVZ
+ycS
 jhp
-ioh
+cGj
 rkZ
 gts
 gts
 gts
 gts
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 fyf
@@ -77954,10 +78305,8 @@ koD
 dMW
 fyf
 thG
-fyf
-fyf
 sYX
-fuj
+cex
 rpu
 rkZ
 uCO
@@ -77967,19 +78316,26 @@ sYX
 fyf
 fyf
 fyf
+jxH
 fyf
 fyf
-xJd
-wrg
-fyf
-fyf
-fyf
+ifu
 fyf
 fyf
 fyf
-fyf
-fyf
-dUk
+swU
+swU
+swU
+pHx
+rpu
+aug
+twY
+rpu
+rpu
+wKv
+swU
+swU
+swU
 fyf
 fyf
 fyf
@@ -77991,14 +78347,9 @@ gts
 gts
 aYG
 rpu
-ipl
-hKY
+qTq
+mrm
 gts
-fyf
-fyf
-thG
-fyf
-fyf
 fyf
 fyf
 fyf
@@ -78211,34 +78562,39 @@ koD
 dMW
 fyf
 thG
-fyf
-fyf
 cuv
 ccF
 rpu
 rpu
-jbx
+eOK
 aug
 rpu
 sYX
 fyf
 fyf
 fyf
-cXn
+jxH
 fyf
 fyf
-xJd
+ifu
 fyf
+fyf
+fyf
+fyf
+fyf
+swU
+swU
+tat
+rpu
+twY
+scY
+vMR
+swU
+swU
 fyf
 fyf
 fyf
 dUk
-fyf
-fyf
-fyf
-dUk
-fyf
-fyf
 fyf
 cuv
 rpu
@@ -78248,22 +78604,17 @@ rpu
 gts
 rpu
 rpu
-ioh
-gMV
+cGj
+iRS
 gts
 fyf
 fyf
-thG
 fyf
 hnk
 osJ
 osJ
 osJ
 kJj
-fyf
-fyf
-fyf
-fyf
 fyf
 gcK
 gcK
@@ -78468,59 +78819,59 @@ koD
 dMW
 fyf
 thG
-fyf
-fyf
 sYX
 uCO
 uCO
 uCO
 uCO
-kHf
+gwB
 rpu
 cuv
 fyf
 fyf
 fyf
+jxH
 fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+swU
+swU
+swU
+swU
+swU
+swU
+swU
 fyf
 fyf
 fyf
 fyf
 dUk
-fyf
-fyf
-fyf
-dUk
-fyf
-fyf
 fyf
 gts
 aYG
-msS
+vRC
 dpO
 rpu
 gts
 rpu
 rXu
-ioh
+cGj
 rkZ
 gts
 fyf
 fyf
-thG
 fyf
 qmc
 wAq
-gzM
-moV
-cfc
-fyf
-fyf
-dUk
-fyf
+rQu
+wKE
+kYz
 fyf
 gcK
 gcK
@@ -78725,61 +79076,61 @@ koD
 dMW
 fyf
 thG
-fyf
-fyf
 cuv
 ccF
 aug
 rpu
-jbx
+eOK
 rpu
 rpu
 sYX
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+jxH
 fyf
 fyf
 dUk
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 gts
-lvw
-wcA
-dGK
+juB
+tIQ
+qWR
 rpu
 sDp
 rpu
 rpu
 rpu
-cGj
+cBe
 gts
 fyf
 fyf
-thG
 fyf
 qmc
-wwb
+ipl
 cbr
-gyG
-cfc
+jAZ
+kYz
 fyf
 fyf
-fyf
-fyf
-fyf
-ifu
 gcK
 gcK
 gcK
@@ -78982,24 +79333,29 @@ koD
 dMW
 fyf
 thG
-fyf
-fyf
 sYX
-fPN
+cfc
 hJF
-itm
+fPN
 uCO
-kYz
+itm
 rpu
 sYX
 fyf
 fyf
 fyf
+jxH
+jxH
+jxH
+fyf
+fyf
+fyf
+hHY
 fyf
 fyf
 fyf
 fyf
-dUk
+fyf
 fyf
 fyf
 fyf
@@ -79013,7 +79369,7 @@ fyf
 fyf
 cuv
 rpu
-xNQ
+qpe
 rpu
 rpu
 gts
@@ -79024,17 +79380,12 @@ olW
 gts
 fyf
 fyf
-thG
 fyf
 qmc
 uYO
-umM
-gyG
-cfc
-fyf
-fyf
-wuZ
-fyf
+aoB
+jAZ
+kYz
 fyf
 fyf
 gcK
@@ -79239,19 +79590,24 @@ koD
 dMW
 fyf
 thG
-fyf
-fyf
 sYX
 uCO
 uCO
 uCO
 uCO
-lda
+gyG
 rpu
 cuv
 fyf
 fyf
 fyf
+jxH
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -79281,17 +79637,12 @@ gts
 gts
 fyf
 fyf
-thG
 fyf
-sDO
-wqL
-uzn
-dkr
 jyf
-cWG
-wDc
-fyf
-fyf
+ycX
+uzn
+kcZ
+eNG
 fyf
 fyf
 gcK
@@ -79496,17 +79847,17 @@ koD
 dMW
 fyf
 thG
-fyf
-fyf
 sYX
-fQY
+cgC
 rpu
 rpu
-jbx
+eOK
 rpu
 rpu
 sYX
-mGZ
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -79525,8 +79876,8 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
+dUk
+dUk
 fyf
 fyf
 fyf
@@ -79540,15 +79891,15 @@ fyf
 fyf
 thG
 fyf
+fyf
+sqA
+fyf
+fyf
 qmc
-kLm
+bHX
 uCn
 cbr
-tat
-mvv
-bpD
-dUk
-fyf
+lPj
 fyf
 fyf
 gcK
@@ -79753,16 +80104,16 @@ koD
 dMW
 fyf
 thG
-fyf
-fyf
 sYX
 bxl
 rpu
-iuS
+dXN
 uCO
 wPl
 jhp
 sYX
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -79797,18 +80148,18 @@ fyf
 fyf
 thG
 fyf
-fHF
-nvx
-tMX
-lvv
+fyf
+fyf
+fyf
+fyf
 rkQ
-mfD
-hCg
+nvx
+bqz
+xba
+efD
 fyf
 fyf
-fyf
-fyf
-hwC
+gcK
 gcK
 gcK
 ktB
@@ -80010,16 +80361,16 @@ koD
 dMW
 fyf
 thG
-fyf
-fyf
 sYX
 ccF
-ioh
+cGj
 rkZ
 uCO
-kYz
+itm
 rpu
 sYX
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -80054,18 +80405,18 @@ sYX
 sYX
 sYX
 fyf
+fyf
+fyf
+fyf
+fyf
 nKV
-bar
-wYh
-ptq
+iRr
+jbx
+kHf
 dQD
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-hwC
+gcK
 gcK
 gcK
 ktB
@@ -80267,16 +80618,16 @@ koD
 dMW
 fyf
 thG
-fyf
-fyf
 tKZ
 uCO
 uCO
 uCO
 uCO
-nso
+gzM
 rpu
 cuv
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -80322,7 +80673,7 @@ fyf
 fyf
 fyf
 fyf
-hwC
+gcK
 gcK
 gcK
 ktB
@@ -80524,16 +80875,16 @@ koD
 dMW
 fyf
 thG
-fyf
 gcK
-gcK
+ctE
+cRJ
 wad
-ioh
-rkZ
 uCO
-lRZ
+gJx
 rpu
 sYX
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -80554,7 +80905,7 @@ jDD
 pud
 fyf
 fyf
-thG
+gay
 tBN
 mvv
 mvv
@@ -80579,7 +80930,7 @@ fyf
 fyf
 fyf
 fyf
-hwC
+gcK
 gcK
 gcK
 ktB
@@ -80783,14 +81134,14 @@ fyf
 gcK
 gcK
 gcK
-gcK
-gcK
-wOj
-xVZ
+cVj
+exj
 uCO
 rpu
 rpu
 kGD
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -80836,7 +81187,7 @@ wDc
 wuZ
 fyf
 fyf
-hwC
+gcK
 gcK
 gcK
 ktB
@@ -81041,13 +81392,13 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-rpu
-jbx
+kjR
+eOK
 sKH
 rpu
 sYX
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -81093,7 +81444,7 @@ hCg
 fyf
 fyf
 fyf
-hwC
+gcK
 gcK
 gcK
 ktB
@@ -81298,13 +81649,13 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-tKZ
+eHB
 sYX
 sYX
 sYX
 sYX
+fyf
+fyf
 fyf
 fyf
 qOV

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -713,7 +713,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
 "avO" = (
@@ -1114,28 +1114,16 @@
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "aLg" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"aLo" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/condiment/yeast,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "innercornerpieceright"
 	},
-/area/f13/building)
+/area/f13/wasteland)
+"aLo" = (
+/turf/open/floor/plating/f13/outside/road{
+	dir = 4;
+	icon_state = "crossborder"
+	},
+/area/f13/wasteland)
 "aLq" = (
 /obj/structure/sink{
 	dir = 8;
@@ -1675,6 +1663,12 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/legion)
+"bcf" = (
+/obj/effect/decal/riverbankcorner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "bcx" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -2019,6 +2013,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"bop" = (
+/obj/effect/decal/riverbank{
+	dir = 5
+	},
+/turf/open/water,
+/area/f13/wasteland)
 "boq" = (
 /obj/structure/rack,
 /obj/item/clothing/under/redeveninggown,
@@ -2756,6 +2756,9 @@
 "bLa" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
+/obj/item/flashlight{
+	icon_state = "seclite"
+	},
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
@@ -3809,6 +3812,8 @@
 	icon_state = "tall_grass_4";
 	layer = 5
 	},
+/obj/effect/decal/fakelattice,
+/obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "horizontaloutermain1"
@@ -4183,6 +4188,17 @@
 /obj/item/seeds/wheat,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"cUN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "cVg" = (
 /obj/item/trash/f13/cram,
 /turf/open/floor/f13/wood,
@@ -5425,11 +5441,14 @@
 	},
 /area/f13/village)
 "dHO" = (
-/obj/machinery/light/sign,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3"
+/obj/structure/wreck/trash/machinepiletwo{
+	layer = 3
 	},
+/obj/item/flag/oasis,
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "dHX" = (
 /obj/structure/table/wood/bar,
@@ -6459,6 +6478,10 @@
 	tag = "icon-horizontaltopbordertop2"
 	},
 /area/f13/wasteland)
+"exz" = (
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "exS" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/ruins{
@@ -6491,6 +6514,15 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"eyG" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	layer = 2;
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "eyI" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -6657,6 +6689,25 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mineral/wasteland_vendor/mining,
 /turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
+"eDI" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "eEt" = (
 /obj/structure/flora/grass/wasteland{
@@ -6975,6 +7026,20 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
+"eNf" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Bar";
+	req_one_access_txt = "28"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "barshutters"
+	},
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_y = 32
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "eNT" = (
 /obj/machinery/light/small{
@@ -8390,6 +8455,26 @@
 	},
 /turf/open/floor/wood/f13/stage_br,
 /area/f13/wasteland)
+"fEH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "barwindowshutters";
+	name = "bar window shutters button";
+	pixel_x = 6;
+	pixel_y = -32;
+	req_one_access_txt = "28"
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters button";
+	pixel_x = -6;
+	pixel_y = -32;
+	req_one_access_txt = "28"
+	},
+/obj/machinery/light/small,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "fFu" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/desert,
@@ -9097,10 +9182,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gbS" = (
-/obj/effect/decal/riverbank{
-	dir = 5
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "cross1"
 	},
-/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "gbW" = (
 /obj/structure/car,
@@ -10477,9 +10561,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "gVV" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "cross2"
+	},
+/area/f13/wasteland)
 "gWm" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2top";
@@ -11268,6 +11353,9 @@
 /area/f13/brotherhood)
 "hsk" = (
 /obj/structure/window/fulltile/wood,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
 /turf/open/floor/holofloor/carpet,
 /area/f13/building)
 "hsy" = (
@@ -11577,10 +11665,9 @@
 /turf/open/floor/carpet/green,
 /area/f13/ncr)
 "hAX" = (
-/obj/effect/decal/riverbankcorner{
-	dir = 1
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "cross3"
 	},
-/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "hBr" = (
 /turf/closed/wall/r_wall/rust,
@@ -12254,10 +12341,10 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "hXv" = (
-/obj/effect/decal/riverbankcorner{
-	dir = 4
+/turf/open/floor/plating/f13/outside/road{
+	dir = 8;
+	icon_state = "crossborder"
 	},
-/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "hXP" = (
 /obj/structure/cargocrate,
@@ -12647,7 +12734,7 @@
 /area/f13/building)
 "ijs" = (
 /obj/machinery/door/poddoor/gate/preopen{
-	id = "interiorgate"
+	id = "interiorgate2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -13308,6 +13395,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"iEG" = (
+/obj/machinery/vending/boozeomat{
+	density = 0;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "iEQ" = (
 /obj/machinery/icecream_vat,
 /turf/open/floor/f13{
@@ -15484,12 +15578,23 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"jRo" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "jRv" = (
 /obj/structure/lamp_post/quadra,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"jRH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "jRQ" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
@@ -16002,6 +16107,11 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"kfi" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "kfo" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -16421,11 +16531,10 @@
 	},
 /area/f13/wasteland)
 "ktX" = (
-/obj/structure/toilet{
+/obj/structure/sink{
 	dir = 4;
-	pixel_x = -1
+	pixel_x = 12
 	},
-/obj/structure/curtain,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
@@ -16483,6 +16592,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "kwe" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_x = -1
+	},
+/obj/structure/curtain,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
@@ -16541,9 +16655,8 @@
 	},
 /area/f13/wasteland)
 "kxq" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
@@ -16690,6 +16803,12 @@
 /obj/item/seeds/poppy/broc,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"kAp" = (
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
 "kAJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -17197,6 +17316,17 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"kRq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "kRD" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -18254,8 +18384,10 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "lzV" = (
-/obj/machinery/smartfridge/bottlerack,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "lzW" = (
 /obj/structure/simple_door/interior,
@@ -18319,17 +18451,25 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "lCi" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/turf/closed/wall/f13/wood/interior,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lCo" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "interiorgate"
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/button/door{
+	id = "frontgateshu2t";
+	name = "gate shutters";
+	pixel_x = -5;
+	pixel_y = 32
+	},
+/obj/machinery/button/door{
+	id = "interiorgate2";
+	name = "Interior door button";
+	pixel_x = 6;
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/area/f13/building)
 "lCs" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -18436,14 +18576,13 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
 "lEx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters{
+	id = "frontgateshut2";
+	name = "gate shutters"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lEC" = (
 /obj/structure/table,
@@ -19150,10 +19289,12 @@
 	},
 /area/f13/wasteland)
 "mbr" = (
+/obj/structure/barricade/wooden,
 /obj/effect/decal/fakelattice{
 	density = 0;
 	pixel_x = 17
 	},
+/obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop3"
 	},
@@ -19272,11 +19413,8 @@
 	},
 /area/f13/wasteland)
 "mfq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/boozeomat{
-	density = 0;
-	pixel_x = -32
-	},
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "mfD" = (
@@ -19309,6 +19447,8 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "mgu" = (
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "mgP" = (
@@ -19391,6 +19531,15 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0";
 	tag = "icon-horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
+"mls" = (
+/obj/structure/closet/crate/trashcart{
+	name = "corpse cart"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
 "mlw" = (
@@ -19486,8 +19635,8 @@
 	},
 /area/f13/wasteland)
 "moo" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "moA" = (
@@ -19510,9 +19659,11 @@
 	},
 /area/f13/wasteland)
 "moO" = (
-/obj/machinery/chem_dispenser/drinks/beer,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/item/instrument/eguitar{
+	anchored = 1;
+	pixel_x = 32
+	},
+/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "moX" = (
 /obj/structure/closet/crate{
@@ -19588,11 +19739,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mrg" = (
-/obj/item/instrument/eguitar{
-	anchored = 1;
-	pixel_x = 32
-	},
-/turf/closed/wall/f13/wood/interior,
+/obj/machinery/smartfridge/bottlerack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "mri" = (
 /obj/structure/simple_door/metal/store{
@@ -19766,7 +19914,7 @@
 	},
 /area/f13/building)
 "mvV" = (
-/obj/structure/musician/piano,
+/obj/machinery/jukebox,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
@@ -19948,14 +20096,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "mEn" = (
-/obj/structure/chair/stool/f13stool{
-	pixel_x = -8
+/obj/item/gun/ballistic/shotgun/trench{
+	anchored = 1;
+	pixel_y = 5
+	},
+/obj/item/gun/ballistic/shotgun/hunting{
+	anchored = 1;
+	pixel_y = -3
+	},
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_y = 3
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/oak,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "mEy" = (
 /obj/structure/destructible/tribal_torch/lit,
@@ -20008,9 +20162,8 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "mGh" = (
-/obj/machinery/jukebox,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/light/sign,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "mGr" = (
 /obj/structure/rack,
@@ -20181,20 +20334,9 @@
 	},
 /area/f13/building)
 "mMN" = (
-/obj/item/gun/ballistic/shotgun/trench{
-	anchored = 1;
-	pixel_y = 5
-	},
-/obj/item/gun/ballistic/shotgun/hunting{
-	anchored = 1;
-	pixel_y = -3
-	},
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_y = 3
-	},
+/obj/structure/musician/piano,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood/interior,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "mNi" = (
 /obj/structure/rack,
@@ -20235,8 +20377,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "mPa" = (
-/obj/machinery/light/sign,
-/turf/closed/wall/f13/wood/interior,
+/obj/structure/chair/stool/f13stool{
+	pixel_x = -8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "mPk" = (
 /obj/structure/ladder/unbreakable{
@@ -21988,6 +22136,11 @@
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"nXS" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2right"
+	},
+/area/f13/building)
 "nYY" = (
 /obj/structure/chair/comfy{
 	dir = 4;
@@ -22486,15 +22639,6 @@
 /obj/item/lipstick/jade,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"onh" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/obj/item/soap/deluxe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
 "onk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
@@ -22627,12 +22771,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "oqu" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/machinery/door/poddoor/shutters{
-	id = "barshutters"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/table/wood/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "orm" = (
 /obj/structure/table/wood/settler,
@@ -22923,10 +23066,8 @@
 	},
 /area/f13/wasteland)
 "oEF" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/microwave/stove,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "oEU" = (
 /obj/structure/chair/wood{
@@ -23119,11 +23260,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oJm" = (
-/obj/machinery/light{
-	dir = 1
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/machinery/door/poddoor/shutters{
+	id = "barshutters"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/wood/settler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "oJp" = (
 /obj/structure/chair/office,
@@ -23175,7 +23317,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "oKy" = (
-/turf/open/floor/wood/f13/oakbroken,
+/obj/structure/chair/stool/retro/backed{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "oKA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23332,7 +23477,10 @@
 /area/f13/wasteland)
 "oQv" = (
 /obj/structure/chair/booth{
-	icon_state = "booth_east_north"
+	icon_state = "booth_west_north"
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
@@ -23431,18 +23579,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oTB" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/wood/f13/oakbroken,
 /area/f13/building)
 "oUj" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
+/obj/structure/chair/f13chair2{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "oUo" = (
 /obj/structure/simple_door/interior,
@@ -24019,6 +24162,14 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
 	},
+/area/f13/wasteland)
+"pmM" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pne" = (
 /obj/effect/decal/remains/human,
@@ -24938,7 +25089,6 @@
 	},
 /area/f13/village)
 "pOo" = (
-/obj/machinery/microwave/stove,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "pOw" = (
@@ -25070,9 +25220,11 @@
 	},
 /area/f13/wasteland)
 "pSo" = (
-/obj/effect/landmark/start/f13/barkeep,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/structure/chair/stool/retro/backed{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "pSp" = (
 /obj/structure/table/wood,
@@ -25091,9 +25243,8 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "pSC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/retro/backed{
-	dir = 8
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
@@ -25294,12 +25445,6 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/village)
-"pYN" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "pZl" = (
 /obj/structure/decoration/clock{
 	pixel_y = 21
@@ -25347,7 +25492,6 @@
 /area/f13/brotherhood)
 "qbe" = (
 /obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
@@ -25409,11 +25553,13 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "qcS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	dir = 8
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/item/soap/deluxe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "qcT" = (
 /obj/structure/barricade/tentclothedge,
@@ -25503,6 +25649,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
+"qfH" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermaintop"
+	},
+/area/f13/building)
 "qfV" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
@@ -25686,7 +25838,7 @@
 /area/f13/clinic)
 "qlE" = (
 /obj/structure/chair/booth{
-	icon_state = "booth_east_south"
+	icon_state = "booth_west_south"
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
@@ -25809,6 +25961,16 @@
 	icon_state = "verticalrightborderleft1"
 	},
 /area/f13/wasteland)
+"qoZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters button";
+	pixel_y = 32;
+	req_one_access_txt = "28"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "qpx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oakbroken4,
@@ -25886,11 +26048,6 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"quy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "quV" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/knife/butcher,
@@ -25944,15 +26101,26 @@
 	},
 /area/f13/building)
 "qwq" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
 /area/f13/building)
 "qwW" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"qwZ" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop3"
+	},
+/area/f13/wasteland)
 "qxe" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
@@ -25980,9 +26148,12 @@
 	},
 /area/f13/tunnel)
 "qyj" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Sheriff Office";
+	req_one_access_txt = "62"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "qyH" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -26037,10 +26208,10 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
 "qAc" = (
-/obj/structure/window/fulltile/wood{
-	layer = 3
+/obj/structure/chair/booth{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "qAA" = (
 /obj/item/reagent_containers/glass/bucket/wood,
@@ -26148,14 +26319,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "qDM" = (
-/obj/structure/barricade/bars,
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "qDS" = (
 /obj/structure/table/wood/settler,
 /obj/item/seeds/poppy/broc,
@@ -26462,6 +26630,14 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"qMT" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "qNa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26899,9 +27075,11 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/wasteland)
 "qZO" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife/cosmicdirty,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/white{
+	desc = "It's a strangely clean little white rodent.";
+	name = "Algernon"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "ram" = (
@@ -27296,12 +27474,10 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "rpa" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/white{
-	desc = "It's a strangely clean little white rodent.";
-	name = "Algernon"
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rpu" = (
 /turf/open/floor/f13/wood,
@@ -27727,9 +27903,19 @@
 	},
 /area/f13/building)
 "rHE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_x = -32
+	},
+/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
+	anchored = 1;
+	pixel_x = -28
+	},
+/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
+	anchored = 1;
+	pixel_x = -36
+	},
+/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "rHO" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -27742,12 +27928,7 @@
 /area/f13/village)
 "rHT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	desc = "A lighting fixture.";
-	dir = 8;
-	light_color = "#008000";
-	name = "light tube"
-	},
+/obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rIA" = (
@@ -27764,8 +27945,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rJO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken,
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
 /area/f13/building)
 "rJT" = (
 /obj/structure/window/fulltile/house{
@@ -27796,13 +27979,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "rLi" = (
-/obj/structure/barricade/bars,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
+/obj/structure/wreck/trash/machinepiletwo{
+	layer = 3
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "rLn" = (
@@ -29225,6 +29406,14 @@
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"sBv" = (
+/obj/machinery/light/sign,
+/obj/structure/barricade/wooden,
+/obj/effect/decal/fakelattice,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop3"
+	},
+/area/f13/wasteland)
 "sBQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29268,29 +29457,11 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "sCF" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "interiorgate2"
 	},
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland)
 "sCK" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -29308,10 +29479,10 @@
 /turf/open/floor/wood/f13/oakbroken2,
 /area/f13/building)
 "sDj" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	dir = 8
+	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "sDp" = (
@@ -29319,8 +29490,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sDr" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken4,
+/obj/structure/window/fulltile/wood{
+	layer = 3
+	},
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "sDJ" = (
 /obj/machinery/light/small{
@@ -29567,10 +29743,9 @@
 	},
 /area/f13/building)
 "sNM" = (
-/obj/structure/window/fulltile/wood{
-	layer = 3
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermainbottom"
 	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "sNT" = (
 /obj/structure/chair{
@@ -29581,12 +29756,8 @@
 	},
 /area/f13/village)
 "sOD" = (
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
-/obj/structure/barricade/bars,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleftbottom"
 	},
 /area/f13/building)
 "sOS" = (
@@ -29645,11 +29816,11 @@
 /turf/open/floor/plating,
 /area/f13/radiation)
 "sQo" = (
-/obj/structure/wreck/trash/machinepiletwo{
-	layer = 3
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
 	},
-/obj/item/flag/oasis,
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
 "sQv" = (
 /obj/machinery/light/small{
@@ -31018,6 +31189,11 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
+"tEA" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermaintop"
+	},
+/area/f13/building)
 "tFd" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/floor/f13/wood,
@@ -31203,6 +31379,14 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"tKm" = (
+/obj/structure/simple_door/house{
+	icon_state = "room"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "tKo" = (
 /obj/structure/car/rubbish1,
@@ -31588,8 +31772,8 @@
 	},
 /area/f13/wasteland)
 "tUS" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
+/obj/effect/landmark/start/f13/barkeep,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "tVi" = (
@@ -31615,22 +31799,9 @@
 	},
 /area/f13/wasteland)
 "tWd" = (
-/obj/machinery/light/small,
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters button";
-	pixel_x = -6;
-	pixel_y = -32;
-	req_one_access_txt = "28"
-	},
-/obj/machinery/button/door{
-	id = "barwindowshutters";
-	name = "bar window shutters button";
-	pixel_x = 6;
-	pixel_y = -32;
-	req_one_access_txt = "28"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife/cosmicdirty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "tWt" = (
@@ -31693,12 +31864,9 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "tYd" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "tYe" = (
 /obj/machinery/light/small{
@@ -31807,13 +31975,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "ucw" = (
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
+/obj/structure/flora/grass/wasteland{
+	pixel_x = -3
 	},
-/obj/structure/barricade/bars,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleftbottom"
-	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ucz" = (
 /obj/structure/car/rubbish2,
@@ -32864,14 +33029,13 @@
 /area/f13/building)
 "uJP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
+	dir = 8;
+	light_color = "#008000";
+	name = "light tube"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "uKq" = (
 /obj/structure/rack,
@@ -32883,18 +33047,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uKA" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Bar";
-	req_one_access_txt = "28"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "barshutters"
-	},
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_y = 32
-	},
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "uKB" = (
 /obj/structure/rack,
@@ -32909,14 +33064,15 @@
 	},
 /area/f13/building)
 "uKG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters button";
-	pixel_y = 32;
-	req_one_access_txt = "28"
+/obj/structure/wreck/trash/five_tires{
+	pixel_x = 3;
+	pixel_y = -13
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/oil,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
 /area/f13/building)
 "uKJ" = (
 /obj/structure/table/wood/fancy/black,
@@ -32999,8 +33155,7 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "uMZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/slot_machine,
+/obj/machinery/light,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "uNC" = (
@@ -33049,9 +33204,28 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uOr" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "uOu" = (
 /obj/machinery/light/small/broken{
@@ -33125,9 +33299,8 @@
 	},
 /area/f13/bunker)
 "uQx" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/booth{
-	icon_state = "booth_east_north"
+	icon_state = "booth_west_north"
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
@@ -33154,13 +33327,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uRN" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
 	},
-/obj/machinery/light{
-	dir = 4
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner (EAST)"
 	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "uSj" = (
 /obj/structure/table/wood,
@@ -33182,19 +33356,12 @@
 	},
 /area/f13/village)
 "uSz" = (
-/obj/structure/flora/grass/wasteland{
-	pixel_x = -3
+/obj/structure/chair/booth{
+	dir = 4
 	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermainleft"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uSC" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -33594,6 +33761,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"vbz" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner"
+	},
+/area/f13/building)
 "vcb" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
@@ -34616,6 +34789,15 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"vHU" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "vHV" = (
 /obj/structure/chair,
 /obj/effect/decal/remains/human,
@@ -35347,7 +35529,7 @@
 "wkd" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
 "wki" = (
@@ -36114,6 +36296,12 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"wKM" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outermaincornerouter"
+	},
+/area/f13/building)
 "wKP" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -36670,6 +36858,10 @@
 "wYv" = (
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"wYN" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "wYO" = (
 /obj/structure/window/fulltile/house{
@@ -38075,19 +38267,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "xMP" = (
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_x = -32
-	},
-/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
-	anchored = 1;
-	pixel_x = -28
-	},
-/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
-	anchored = 1;
-	pixel_x = -36
-	},
-/turf/closed/wall/f13/wood/interior,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "xNm" = (
 /obj/structure/simple_door/tentflap_cloth,
@@ -38137,7 +38318,7 @@
 	},
 /area/f13/building)
 "xPh" = (
-/obj/effect/decal/cleanable/generic,
+/obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "xPn" = (
@@ -38210,26 +38391,9 @@
 	},
 /area/f13/building)
 "xSa" = (
-/obj/structure/wreck/trash/five_tires{
-	pixel_x = 3;
-	pixel_y = -13
-	},
-/obj/structure/flora/grass/wasteland{
-	pixel_x = -3
-	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	layer = 2;
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermainleft"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken4,
+/area/f13/building)
 "xSC" = (
 /obj/structure/closet/cardboard,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -38762,15 +38926,9 @@
 	},
 /area/f13/wasteland)
 "yht" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3"
-	},
-/area/f13/wasteland)
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "yhv" = (
 /obj/structure/simple_door/brokenglass,
 /turf/open/floor/f13/wood,
@@ -48077,8 +48235,8 @@ cWG
 cWG
 daU
 bpD
-gbS
-hXv
+fPl
+uXj
 uXj
 uXj
 uXj
@@ -49098,8 +49256,8 @@ uRJ
 unW
 tBN
 bpD
-syr
-hAX
+fPl
+uXj
 uXj
 uXj
 lqV
@@ -49355,8 +49513,8 @@ uRJ
 nrV
 tBN
 bpD
-gbS
-hXv
+fPl
+uXj
 ush
 uXj
 uXj
@@ -57907,7 +58065,7 @@ ybI
 ybI
 dkP
 sTa
-sTa
+aLo
 onk
 hbW
 ehN
@@ -58164,7 +58322,7 @@ idu
 idu
 hBN
 aJb
-tUb
+gbS
 tUb
 ehN
 ehN
@@ -58421,7 +58579,7 @@ ehN
 hOl
 sgz
 sgz
-sgz
+gVV
 ehN
 ehN
 ehN
@@ -58678,7 +58836,7 @@ kaM
 kaM
 qoS
 dmL
-fvz
+hAX
 qoS
 ehN
 ehN
@@ -58935,7 +59093,7 @@ jZE
 ees
 dNT
 gQv
-gQv
+hXv
 muk
 qnS
 erY
@@ -61747,7 +61905,7 @@ sYX
 fyf
 fyf
 tBN
-mvv
+pmM
 mvv
 bpD
 fyf
@@ -62508,7 +62666,7 @@ fyf
 fyf
 tBN
 mvv
-mvv
+pmM
 mvv
 mvv
 oHO
@@ -62674,7 +62832,7 @@ hbW
 sRp
 uVo
 qgZ
-xMm
+aLo
 ybI
 ybI
 ybI
@@ -62931,7 +63089,7 @@ erY
 apk
 cdc
 kCt
-mLr
+gbS
 hBN
 erY
 apk
@@ -63008,14 +63166,14 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+nGq
+nGq
+nGq
+nGq
+nGq
+nGq
+nGq
+nGq
 gts
 gts
 gts
@@ -63188,7 +63346,7 @@ erY
 erY
 apk
 cdc
-gRk
+gVV
 sgz
 erY
 rbe
@@ -63265,15 +63423,15 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gts
+nGq
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+dCV
 dCV
 dCV
 dCV
@@ -63445,7 +63603,7 @@ erY
 erY
 mmK
 kaM
-kaM
+hAX
 qoS
 eaO
 erY
@@ -63523,14 +63681,14 @@ fyf
 fyf
 fyf
 gts
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-gts
+dCV
+uCO
+uCO
+uCO
+uCO
+uCO
+uCO
+uCO
 dCV
 itU
 yea
@@ -63702,7 +63860,7 @@ hbW
 erY
 gmX
 uoS
-ees
+hXv
 ees
 jBH
 jBH
@@ -63781,13 +63939,13 @@ fyf
 fyf
 gts
 dCV
-dCV
-dCV
-dCV
-dCV
-dCV
-dCV
-dCV
+uCO
+oEF
+qcS
+tWd
+uOr
+iEG
+cUN
 dCV
 yla
 aRz
@@ -64038,15 +64196,15 @@ fyf
 fyf
 gts
 dCV
-uCO
-uCO
-uCO
-uCO
-uCO
-uCO
-uCO
-dCV
-aLo
+moo
+pOo
+pOo
+pOo
+pOo
+pOo
+pOo
+tKm
+vta
 vta
 vta
 aRz
@@ -64295,16 +64453,16 @@ fyf
 fyf
 gts
 dCV
-uCO
-onh
+mrg
+pOo
 pOo
 qZO
-sCF
+onz
 tUS
-mgu
-mgu
-mgu
-lEx
+kfi
+dCV
+kRq
+vta
 aRz
 eGt
 dCV
@@ -64551,19 +64709,19 @@ fyf
 fyf
 fyf
 gts
-lzV
-mfq
-mgu
-mgu
-mgu
-mgu
-mgu
-mgu
 dCV
-mgu
+mfq
+onz
+onz
+onz
+onz
+onz
+fEH
+uCO
+eDI
+vHU
 aRz
 aRz
-rpu
 dCV
 gts
 fQr
@@ -64808,14 +64966,14 @@ fyf
 fyf
 fyf
 gts
-lzV
+dCV
 mgu
-mgu
-mgu
-rpa
 onz
-pSo
-uJP
+tUS
+onz
+onz
+qMT
+onz
 dCV
 dCV
 dCV
@@ -65062,17 +65220,17 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
+nGq
+nGq
 gts
 dCV
-moo
-onz
-onz
-onz
-onz
-tWd
 uCO
+oJm
+oJm
+oJm
+oJm
+uCO
+eNf
 dCV
 iWW
 rvx
@@ -65089,7 +65247,7 @@ tvr
 tvr
 tvr
 pUi
-mvv
+pmM
 mvv
 vGl
 wDc
@@ -65319,17 +65477,17 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-gts
+nGq
+pMI
+dCV
 dCV
 moO
-onz
+oKy
 pSo
-onz
-onz
-tYd
-onz
+oKy
+oKy
+uCO
+qoZ
 dCV
 fBs
 kdJ
@@ -65577,15 +65735,15 @@ fyf
 fyf
 fyf
 nGq
-nGq
-gts
-dCV
+pMI
+kwe
 uCO
+mrS
 oqu
-oqu
-oqu
-oqu
-uCO
+rdC
+ryc
+rdC
+rdC
 uKA
 dCV
 dCV
@@ -65835,15 +65993,15 @@ wDc
 fyf
 nGq
 dCV
-dCV
-dCV
-mrg
-oEF
-pSC
-oEF
-oEF
-uCO
-uKG
+kxq
+lzW
+oIQ
+oIQ
+rdC
+oIQ
+oIQ
+oIQ
+oIQ
 xwW
 xwW
 dCV
@@ -66094,13 +66252,13 @@ nGq
 dCV
 ktX
 uCO
-mrS
-oJm
+uCO
+oIQ
+qAc
 rdC
-ryc
+uSz
 rdC
-rdC
-rdC
+xSa
 xya
 xya
 hsk
@@ -66349,19 +66507,19 @@ hCg
 fyf
 nGq
 dCV
-kwe
-lzW
-oIQ
+dCV
+lzV
+mMN
+rdC
+qDM
+tYd
+rHT
 oIQ
 rdC
-oIQ
-oIQ
-oIQ
-oIQ
 xya
 xya
 hsk
-eyp
+mls
 cam
 dkg
 dCV
@@ -66605,16 +66763,16 @@ bpD
 fyf
 fyf
 nGq
+gts
 dCV
-kxq
 uCO
-uCO
-oIQ
-pYN
-rdC
+mPa
+oTB
 sDj
-rdC
-sDr
+uJP
+sDj
+oIQ
+oIQ
 xwW
 nEi
 dCV
@@ -66861,20 +67019,20 @@ mfD
 hCg
 fyf
 fyf
-nGq
+fyf
+gts
 dCV
-dCV
-lCi
+uCO
 mvV
-rdC
-qbe
-rHE
-quy
 oIQ
+rdC
+rHE
+rdC
+rdC
 uMZ
 dCV
-dCV
-dCV
+uqa
+eMW
 gmR
 rRt
 cpK
@@ -67118,25 +67276,25 @@ fyf
 fyf
 wSj
 fyf
-nGq
+fyf
 gts
 dCV
 uCO
 mEn
-oKy
-qcS
-rHT
-qcS
+oON
+rdC
+rdC
+rdC
+rdC
 oIQ
-uOr
 xMP
-uqa
-uqa
+jRo
+kzW
 dkg
 cpK
 cpK
 mkV
-tvr
+fQr
 oFP
 oFP
 oFP
@@ -67378,22 +67536,22 @@ fyf
 fyf
 gts
 dCV
-uCO
+dCV
 mGh
-oIQ
+pSC
+rpa
 rdC
 oIQ
-rdC
-rdC
-rdC
-hqr
+oIQ
+jRH
+rpa
 uqa
-eMW
+nXS
 dkg
 cpK
 gdY
 mkV
-tvr
+bop
 uqa
 hJM
 mvv
@@ -67634,18 +67792,18 @@ fyf
 fyf
 fyf
 gts
+gts
 dCV
 uCO
-mMN
-oON
+qbe
+rHT
 rdC
-rdC
-rdC
-rdC
-rdC
+xSa
+oIQ
+rHT
 xPh
-gVV
-dkg
+drN
+qwZ
 dkg
 gdY
 jGl
@@ -67893,19 +68051,19 @@ fyf
 gts
 dCV
 dCV
-mPa
+uCO
 oQv
 qlE
-rdC
 oIQ
-rdC
+yht
+yht
 uQx
 qlE
 uqa
-cam
+sBv
 dkg
 cam
-dkg
+cah
 ajD
 uze
 rjH
@@ -68148,17 +68306,17 @@ fyf
 fyf
 fyf
 gts
-gts
 dCV
-uCO
-oTB
-quy
-rdC
+dCV
+dCV
+dCV
+dCV
+dCV
 sDr
-rdC
-quy
-aLg
-drN
+sDr
+sDr
+dCV
+dCV
 mbr
 qCu
 jGl
@@ -68405,17 +68563,17 @@ fyf
 fyf
 fyf
 nGq
-gts
 dCV
-uCO
+lCi
+lCi
 oUj
-qwq
-oIQ
-oIQ
-oIQ
+dCV
+uKG
+kzW
+vbz
 uRN
 qwq
-uqa
+kAp
 dHO
 cam
 jGl
@@ -68662,18 +68820,18 @@ fyf
 upX
 fyf
 nGq
-gts
 dCV
-uCO
-uCO
+rWL
+xdD
+xdD
 qyj
 rJO
-oIQ
-oIQ
-uCO
-uCO
-uqa
-yht
+vbz
+wKM
+tEA
+kzW
+ids
+cpK
 dkg
 jPG
 cam
@@ -68742,7 +68900,7 @@ cpK
 wKP
 wKP
 sUr
-rvP
+eme
 vPU
 fyf
 fyf
@@ -68919,18 +69077,18 @@ igz
 igz
 igz
 nGq
-gts
-gts
 dCV
+lCo
+xdD
+xdD
 dCV
-qAc
-qAc
+kzW
 sNM
-sNM
-dCV
-dCV
-pMI
-sQo
+eyG
+qfH
+kzW
+cpK
+cpK
 cpK
 cpK
 sKG
@@ -69176,24 +69334,24 @@ sTa
 ybI
 hxQ
 gts
-gts
 dCV
-dCV
-dCV
-qDM
+lEx
+lEx
+lEx
+pMI
 rLi
 sOD
 ucw
-uSz
-xSa
-rRR
+wIK
+ybI
+ybI
 lXd
 ybI
 ybI
 llP
 onk
 ybI
-ybI
+dpc
 eTL
 lhp
 lhp
@@ -69433,11 +69591,11 @@ aJb
 aJb
 aJb
 aJb
+lEG
 aJb
-lCo
 hBN
 aJb
-aJb
+sCF
 tUb
 idu
 idu
@@ -69690,11 +69848,11 @@ dmL
 ehN
 hOl
 hOl
-hOl
 lEG
 hOl
 hOl
 hOl
+lEG
 erY
 erY
 erY
@@ -69945,13 +70103,13 @@ fyf
 rlN
 btW
 kaM
-btW
-hOl
-hOl
+kaM
+kaM
 lEG
+kaM
 hOl
 oUy
-oUy
+sQo
 oUy
 sPJ
 ier
@@ -70470,7 +70628,7 @@ sYX
 sYX
 sYX
 sYX
-cpK
+exz
 ajD
 hbW
 hOl
@@ -71004,8 +71162,8 @@ rgI
 rgI
 xdD
 gts
-cpK
-cpK
+ptf
+gNA
 unI
 hbW
 erY
@@ -71243,7 +71401,7 @@ rpu
 sYX
 dkg
 ajD
-hbW
+agH
 erY
 hOl
 lZP
@@ -73052,7 +73210,7 @@ dxG
 dkg
 dkg
 dkg
-cpK
+rRt
 vmg
 uqa
 kGP
@@ -76895,7 +77053,7 @@ gts
 gts
 dCV
 dCV
-ids
+wYN
 ids
 lTx
 dit
@@ -80664,7 +80822,7 @@ hbW
 dFQ
 gmX
 fLc
-sJw
+aLo
 ybI
 hYJ
 ybI
@@ -80921,7 +81079,7 @@ hbW
 cdc
 dFQ
 tUb
-idu
+gbS
 idu
 hBN
 aJb
@@ -81178,7 +81336,7 @@ hbW
 cdc
 cdc
 rbe
-ehN
+gVV
 ehN
 ehN
 hOl
@@ -81435,7 +81593,7 @@ hbW
 cdc
 cdc
 kaM
-kaM
+hAX
 qoS
 btW
 pSn
@@ -81692,7 +81850,7 @@ hbW
 bJB
 gmX
 uoS
-fsm
+hXv
 gQv
 jZE
 ees
@@ -85855,7 +86013,7 @@ hbW
 dFQ
 gmX
 fLc
-ybI
+aLo
 ybI
 ybI
 ybI
@@ -85911,7 +86069,7 @@ ybI
 ybI
 ybI
 ybI
-ybI
+aLo
 onk
 hbW
 erY
@@ -86112,7 +86270,7 @@ hbW
 toS
 dFQ
 tUb
-idu
+gbS
 idu
 idu
 idu
@@ -86168,7 +86326,7 @@ aJb
 tUb
 idu
 dbY
-idu
+gbS
 idu
 erY
 erY
@@ -86369,7 +86527,7 @@ agH
 cdc
 cdc
 cdc
-ehN
+gVV
 ehN
 ehN
 hOl
@@ -86425,7 +86583,7 @@ dmL
 sgz
 kjQ
 dmL
-ehN
+gVV
 ehN
 erY
 erY
@@ -86626,7 +86784,7 @@ hbW
 cdc
 cdc
 kaM
-kaM
+hAX
 kaM
 kaM
 kaM
@@ -86682,7 +86840,7 @@ btW
 fvz
 kaM
 btW
-kaM
+hAX
 kaM
 erY
 erY
@@ -86693,8 +86851,8 @@ wGJ
 erY
 erY
 erY
-ehN
-ehN
+oBQ
+oBQ
 btW
 btW
 btW
@@ -86883,7 +87041,7 @@ hbW
 bJB
 gmX
 uoS
-ees
+hXv
 ees
 ees
 ees
@@ -86939,7 +87097,7 @@ ees
 ees
 ees
 ees
-ees
+hXv
 muk
 hbW
 erY
@@ -91092,7 +91250,7 @@ gcK
 gcK
 gcK
 gcK
-sVl
+iOv
 sVl
 hom
 hom
@@ -91349,7 +91507,7 @@ gcK
 gcK
 gcK
 gcK
-sVl
+iOv
 sVl
 hom
 nTm
@@ -91606,7 +91764,7 @@ gcK
 gcK
 gcK
 gcK
-sVl
+iOv
 sVl
 hom
 jNl
@@ -91863,7 +92021,7 @@ gcK
 gcK
 gcK
 gcK
-sVl
+iOv
 sVl
 ucJ
 qWU
@@ -92120,7 +92278,7 @@ gcK
 gcK
 gcK
 gcK
-sVl
+iOv
 sVl
 hom
 tQV
@@ -97622,7 +97780,7 @@ ybI
 ybI
 ybI
 hQr
-erY
+aLg
 erY
 erY
 ajO
@@ -97673,7 +97831,7 @@ ybI
 ybI
 ybI
 hQr
-erY
+aLg
 erY
 erY
 ajO
@@ -97829,169 +97987,169 @@ uXj
 gVp
 mvv
 gCd
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-cdc
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+erY
+erY
+erY
+erY
+erY
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
 wkd
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
 erY
 erY
 erY
 erY
 erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
 avu
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+idu
 erY
 wGJ
 wGJ
@@ -99572,7 +99730,7 @@ mvv
 doX
 wDc
 syr
-uXj
+bcf
 uXj
 eXO
 mvv
@@ -99885,169 +100043,169 @@ uXj
 odZ
 mvv
 gCd
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-cdc
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-cdc
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-cdc
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-sCK
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-cdc
-erY
-erY
-erY
-erY
-erY
-erY
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+vpJ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
 erY
 erY
 erY

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -1,4 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aac" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1";
+	tag = "icon-horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "aav" = (
 /obj/item/clothing/head/cone,
 /turf/open/floor/plating/dirt/dark,
@@ -7,6 +13,11 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
 /area/f13/caves)
+"aaS" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermainleft"
+	},
+/area/f13/building)
 "abd" = (
 /obj/structure/decoration/hatch{
 	dir = 4
@@ -16,19 +27,12 @@
 	},
 /area/f13/wasteland)
 "abi" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	pixel_x = -11;
-	pixel_y = 8
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbrokenvertical"
 	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6
-	},
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32"
-	},
-/area/f13/wasteland)
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "abC" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -36,9 +40,7 @@
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/item/reagent_containers/pill/patch/healingpowder,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "abL" = (
 /obj/structure/barricade/sandbags,
@@ -56,6 +58,11 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"acI" = (
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "acW" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/f13{
@@ -63,10 +70,11 @@
 	},
 /area/f13/building)
 "adn" = (
-/obj/item/seeds/poppy/broc,
-/obj/machinery/hydroponics/soil,
+/obj/structure/fence/corner{
+	dir = 1
+	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/farm)
+/area/f13/wasteland)
 "adq" = (
 /turf/open/indestructible/ground/outside/water{
 	density = 1;
@@ -75,10 +83,9 @@
 	},
 /area/f13/caves)
 "adD" = (
-/obj/structure/chair/bench,
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+/obj/structure/fermenting_barrel,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "adN" = (
@@ -104,9 +111,11 @@
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
 "aep" = (
-/obj/effect/landmark/start/f13/slave,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "aeJ" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -124,8 +133,19 @@
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pda,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"afp" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plating,
+/area/f13/radiation)
+"afK" = (
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "afL" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -138,6 +158,18 @@
 	icon_state = "horizontalbottombordertop2"
 	},
 /area/f13/wasteland)
+"afR" = (
+/obj/structure/table/wood/settler,
+/obj/item/storage/backpack/satchel/leather/withwallet,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "agr" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -163,14 +195,8 @@
 "agO" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"agP" = (
-/obj/structure/decoration/clock{
-	pixel_y = -34
-	},
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "agU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/machinepile,
@@ -179,11 +205,11 @@
 	},
 /area/f13/caves)
 "agX" = (
-/obj/structure/fence/wooden{
+/obj/machinery/light/small/broken{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aha" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -216,20 +242,16 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"ahK" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "aik" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/suit/f13/sexymaid,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"aim" = (
+/obj/structure/rack,
+/obj/item/seeds/cannabis,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "aip" = (
 /obj/structure/rack,
 /obj/item/storage/backpack/spearquiver,
@@ -248,6 +270,10 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"ajj" = (
+/obj/structure/wreck/trash/two_tire,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/clinic)
 "ajp" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "shadowright"
@@ -296,17 +322,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"ajX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "akm" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt,
@@ -340,25 +355,32 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"akJ" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"akO" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "akU" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland)
-"akY" = (
-/obj/machinery/door/airlock/glass_large{
-	name = "Followers Clinic";
-	req_one_access_txt = "124"
+"alk" = (
+/obj/machinery/computer/operating{
+	dir = 8
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "followershutters";
-	name = "followers shutters"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "all" = (
 /obj/structure/closet/crate/wicker,
 /turf/open/indestructible/ground/outside/dirt{
@@ -374,11 +396,19 @@
 	},
 /area/f13/wasteland)
 "alM" = (
-/obj/structure/table/optable,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
+/obj/effect/landmark/start/f13/prospector,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"alN" = (
+/obj/structure/simple_door/metal/fence{
+	door_type = "fence_wood";
+	icon_state = "fence_wood"
 	},
-/area/f13/followers)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "alV" = (
 /obj/item/shard,
 /turf/open/floor/f13/wood,
@@ -395,18 +425,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
-"amq" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"amy" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/chapel{
-	dir = 5
-	},
-/area/f13/village)
 "ana" = (
 /obj/structure/sign/poster/prewar/poster67{
 	pixel_y = 32
@@ -420,6 +438,13 @@
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"anc" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "anl" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_l,
@@ -428,6 +453,13 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
+"anu" = (
+/obj/structure/easel,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "anA" = (
@@ -440,6 +472,14 @@
 	icon_state = "verticaloutermainbottom"
 	},
 /area/f13/wasteland)
+"anK" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "anP" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -451,7 +491,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/f13/explorer,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "aoD" = (
 /obj/structure/rack,
@@ -521,24 +561,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "arb" = (
-/obj/structure/decoration/hatch,
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontalinnermain2left"
+/obj/structure/sink/kitchen{
+	pixel_y = 28
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ars" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderrighttop"
 	},
 /area/f13/wasteland)
-"arx" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 5
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "arC" = (
 /obj/structure/chair{
 	dir = 4
@@ -600,11 +632,20 @@
 	},
 /area/f13/building)
 "aun" = (
-/obj/structure/lamp_post/quadra,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/area/f13/wasteland)
+/obj/structure/closet/fridge,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aut" = (
 /obj/item/lighter,
 /obj/item/clothing/mask/cigarette/cigar,
@@ -662,18 +703,16 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"avx" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/reagent_containers/medspray/sterilizine,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -30
-	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/followers)
+"avO" = (
+/obj/structure/closet/cabinet,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/masks,
+/obj/item/lighter,
+/obj/item/clothing/suit/toggle/labcoat/f13/followers,
+/obj/item/storage/box/pillbottles,
+/obj/item/reagent_containers/syringe/medx,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "awj" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -704,9 +743,7 @@
 /area/f13/wasteland)
 "awT" = (
 /obj/effect/landmark/start/f13/auxilia,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "axA" = (
 /obj/structure/lattice/catwalk,
@@ -732,20 +769,20 @@
 /obj/item/clothing/gloves/boxing,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"ayf" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "ayE" = (
 /obj/item/storage/money_stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"ayJ" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = -1
-	},
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/city)
 "aze" = (
 /obj/structure/closet/cabinet,
 /obj/item/stack/sheet/metal,
@@ -754,15 +791,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"azj" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "azk" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/wasteland)
+/obj/structure/closet/fridge,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "azz" = (
 /obj/item/ammo_casing/a556,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -779,11 +815,11 @@
 	},
 /area/f13/farm)
 "aAk" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2right"
+/obj/structure/chair/wood/fancy{
+	dir = 4
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aAr" = (
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/f13/wood{
@@ -814,13 +850,20 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "aAO" = (
-/obj/item/clothing/head/cone{
-	anchored = 1;
-	pixel_x = 13
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_y = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_y = 10
+	},
+/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aAP" = (
 /obj/effect/decal/remains/human,
 /obj/structure/spider/stickyweb,
@@ -830,39 +873,19 @@
 	},
 /area/f13/building)
 "aAR" = (
-/obj/structure/bed/mattress,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+/obj/structure/chair/wood/fancy{
+	dir = 8
 	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "aBk" = (
 /obj/structure/dresser,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"aBx" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13/wood,
-/area/f13/village)
 "aBH" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
 	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"aCn" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "busladder";
-	layer = 2
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
 "aCP" = (
@@ -879,44 +902,12 @@
 	name = "lake water"
 	},
 /area/f13/caves)
-"aDk" = (
-/obj/structure/rack,
-/obj/item/seeds/chili,
-/obj/item/seeds/coffee,
-/obj/item/seeds/tea,
-/obj/item/seeds/xander,
-/obj/item/seeds/grass,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/wheat/rice,
-/obj/item/seeds/cotton,
-/obj/item/seeds/grass,
-/obj/item/seeds/wheat,
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
-"aDl" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters{
-	id = "prospectorshutters"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/city)
 "aDq" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbroken"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"aDs" = (
-/obj/structure/noticeboard,
-/turf/closed/wall/f13/wood,
-/area/f13/city)
 "aDw" = (
 /obj/structure/chair/left{
 	dir = 4
@@ -929,27 +920,58 @@
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "aDX" = (
-/obj/structure/fermenting_barrel,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/area/f13/wasteland)
-"aFu" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/item/storage/toolbox/drone,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"aET" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/item/taperecorder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"aEX" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/area/f13/building)
+"aFw" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/AMinus,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
 	},
-/obj/machinery/light/small/broken{
-	dir = 4
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"aFD" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/area/f13/building)
 "aFF" = (
-/obj/structure/weightlifter,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/obj/item/clothing/shoes/singery,
+/obj/item/clothing/under/singery,
+/obj/item/clothing/under/f13/bartenderalt,
+/obj/item/clothing/shoes/f13/fancy,
+/obj/item/reagent_containers/food/drinks/flask,
+/obj/item/toy/clockwork_watch,
+/obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
+/obj/effect/spawner/lootdrop/minor/bowler_or_that,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aFM" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -961,52 +983,53 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"aGv" = (
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_y = 32
+"aGh" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
 	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+/area/f13/wasteland)
+"aGj" = (
+/obj/structure/fence/wooden{
+	dir = 4
 	},
-/area/f13/city)
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "aGw" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"aGX" = (
-/obj/structure/bed/dogbed{
-	pixel_x = -10;
-	pixel_y = 13
+"aGO" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop3";
+	tag = "icon-horizontalbottombordertop3"
 	},
-/obj/machinery/light/small{
-	dir = 1
+/area/f13/wasteland)
+"aHE" = (
+/obj/item/trash/can,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"aHz" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/eyebot{
-	faction = list("neutral");
-	name = "PE-A"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/city)
+/area/f13/building)
 "aHH" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "aHN" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
 	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/city)
+/area/f13/wasteland)
 "aHS" = (
 /obj/structure/chair{
 	dir = 1
@@ -1014,15 +1037,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"aHZ" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright1"
-	},
-/area/f13/wasteland)
 "aIb" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/dirt,
@@ -1049,13 +1063,12 @@
 	icon_state = "verticalleftborderright2"
 	},
 /area/f13/wasteland)
-"aJZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+"aJK" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottomright";
+	tag = "icon-horizontaltopborderbottomright"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "aKs" = (
 /obj/item/clothing/shoes/sneakers/black,
 /turf/open/floor/f13/wood,
@@ -1088,9 +1101,27 @@
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "aLg" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/attachments,
-/turf/open/floor/f13/wood,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"aLo" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "aLq" = (
 /obj/structure/sink{
@@ -1116,6 +1147,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"aLF" = (
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/obj/structure/curtain,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aLW" = (
 /obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/dirt,
@@ -1168,10 +1205,27 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"aNZ" = (
+/obj/structure/chair/bench{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "aOc" = (
 /obj/structure/simple_door/dirtyglass,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"aOg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/car/bike{
+	pixel_x = -12;
+	pixel_y = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "aOE" = (
 /obj/structure/displaycase,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -1184,29 +1238,16 @@
 	desc = "A sign denoting the presence of a likely very moist molerat.";
 	name = "wet molerat sign"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"aPg" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "aPr" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/city)
 "aPw" = (
 /obj/structure/rack,
 /obj/item/weldingtool,
@@ -1223,8 +1264,13 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"aPF" = (
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "aPN" = (
 /obj/structure/fireplace{
 	dir = 8
@@ -1237,18 +1283,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
-"aQa" = (
-/obj/structure/table/wood,
-/obj/item/melee/curator_whip{
-	desc = "It stings like hell to be hit by.";
-	name = "Slave whip"
-	},
-/obj/item/melee/curator_whip{
-	desc = "It stings like hell to be hit by.";
-	name = "Slave whip"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "aQe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -1259,6 +1293,20 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"aQm" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/f13/leatherarmor,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/item/storage/bag/plants,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "aQw" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -1267,12 +1315,41 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"aQN" = (
+/obj/item/retractor,
+/obj/item/hemostat,
+/obj/item/surgicaldrill,
+/obj/item/storage/belt/medical,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"aRc" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/wasteland)
+"aRz" = (
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "aRF" = (
 /obj/item/crafting/large_gear,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/village)
+"aRG" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
+"aRT" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "aRW" = (
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/road{
@@ -1304,6 +1381,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"aTh" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "aTv" = (
 /obj/structure/wreck/trash/machinepile,
 /obj/effect/decal/cleanable/dirt,
@@ -1311,31 +1394,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"aTE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerbordercorner"
-	},
-/area/f13/wasteland)
-"aTI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/prewar/poster86{
-	pixel_y = -32
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
 "aUb" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/f13/wood,
-/area/f13/village)
-"aUc" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheethos"
 	},
-/area/f13/city)
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aUl" = (
 /obj/structure/fence,
 /obj/structure/fence,
@@ -1378,16 +1444,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
-"aVq" = (
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/city)
-"aVC" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
-	},
-/area/f13/city)
 "aVF" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/ruins{
@@ -1419,12 +1475,11 @@
 	},
 /area/f13/legion)
 "aWF" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetUSA"
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/village)
 "aXi" = (
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
@@ -1437,17 +1492,18 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"aXk" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/wood,
-/area/f13/village)
 "aXu" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"aXy" = (
+/obj/item/ammo_casing/caseless,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "aXC" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -1476,6 +1532,11 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"aXR" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/syringe/medx,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "aYk" = (
 /obj/structure/sink{
 	pixel_y = 15
@@ -1489,12 +1550,19 @@
 	},
 /area/f13/village)
 "aYp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
-	},
+/obj/item/twohanded/required/kirbyplants/dead,
+/obj/item/reagent_containers/pill/fixer,
+/obj/item/reagent_containers/pill/insulin,
+/turf/open/floor/wood,
 /area/f13/wasteland)
+"aYu" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "aYG" = (
 /obj/structure/decoration/clock{
 	pixel_y = 30
@@ -1510,6 +1578,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"aYU" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "aYV" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1519,21 +1593,11 @@
 	},
 /area/f13/brotherhood)
 "aYY" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
-"aZn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "aZz" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -1557,22 +1621,6 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/brotherhood)
-"baS" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/knife/butcher,
-/obj/item/clothing/suit/apron/chef,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/city)
-"baY" = (
-/obj/structure/sign/poster/prewar/poster89{
-	pixel_y = 32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "bbf" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
@@ -1590,6 +1638,12 @@
 /obj/item/kirbyplants,
 /turf/open/water,
 /area/f13/brotherhood)
+"bbR" = (
+/mob/living/simple_animal/hostile/gecko,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2"
+	},
+/area/f13/wasteland)
 "bbS" = (
 /turf/closed/wall/f13/wood,
 /area/f13/brotherhood)
@@ -1608,22 +1662,26 @@
 	},
 /area/f13/legion)
 "bcx" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
-"bcF" = (
-/obj/machinery/light{
-	dir = 8
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
+/area/f13/village)
 "bcM" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"bdg" = (
+/obj/structure/chair/wood/worn{
+	dir = 4
+	},
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bdG" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -1655,9 +1713,9 @@
 	},
 /area/f13/tunnel)
 "bet" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
 "bew" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1673,18 +1731,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"beG" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
-"bfq" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+"beE" = (
+/mob/living/simple_animal/hostile/wolf,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0";
+	tag = "icon-verticalrightborderleft0"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "bfu" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
@@ -1701,24 +1754,19 @@
 /obj/structure/table/wood,
 /obj/item/kitchen/knife,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"bgz" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_north"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/city)
+/area/f13/wasteland)
 "bgY" = (
 /turf/closed/indestructible/riveted,
 /area/f13/tcoms)
-"bhl" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Bar";
-	req_one_access_txt = "28"
+"bhr" = (
+/obj/structure/fence{
+	dir = 8
 	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/legion)
 "bhC" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road{
@@ -1753,10 +1801,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "bix" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/item/storage/box/drinkingglasses,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"biJ" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "biN" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -1773,6 +1827,9 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"bjo" = (
+/turf/closed/mineral/random/low_chance,
+/area/f13/city)
 "bjs" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -1803,6 +1860,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"bkj" = (
+/obj/structure/dresser,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "bkr" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plating/dirt/dark,
@@ -1839,19 +1902,24 @@
 /area/f13/building)
 "bla" = (
 /obj/structure/chair/wood{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/obj/effect/landmark/start/f13/campfollower,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"blp" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 10
-	},
-/area/f13/village)
 "blv" = (
 /obj/structure/decoration/shock,
 /turf/closed/wall/rust,
 /area/f13/caves)
+"blH" = (
+/obj/item/scalpel,
+/obj/item/cautery,
+/obj/item/razor,
+/obj/item/surgical_drapes,
+/obj/item/reagent_containers/medspray/sterilizine,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "blS" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small/broken{
@@ -1859,12 +1927,6 @@
 	},
 /turf/open/water,
 /area/f13/caves)
-"blX" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/turf/closed/wall/f13/store,
-/area/f13/city)
 "blZ" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1872,34 +1934,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"bmg" = (
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/structure/rack,
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"bmr" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/mayor,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
-"bmu" = (
-/obj/structure/rack,
-/obj/item/stack/f13Cash/random/ncr/high,
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "bmx" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -1907,25 +1941,19 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"bmK" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "bmW" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"bnm" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/open/floor/plasteel/chapel{
-	dir = 6
+"bnf" = (
+/obj/structure/sink{
+	pixel_y = 28
 	},
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "bnn" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -1970,13 +1998,6 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"boj" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
-	},
-/area/f13/wasteland)
 "bol" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -2035,12 +2056,28 @@
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"bpo" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "bpA" = (
 /obj/structure/table/wood/settler,
 /obj/item/clothing/head/helmet/f13/raidercombathelmet,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"bpB" = (
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/item/radio/off,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "bpD" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -2077,25 +2114,21 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"bqw" = (
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/followers)
 "bqB" = (
 /obj/structure/table/wood,
 /obj/item/paper,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"bqC" = (
-/obj/machinery/jukebox,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "bqH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"brr" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain2bottom";
+	tag = "icon-verticaloutermain2bottom"
+	},
+/area/f13/wasteland)
 "brE" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -2103,9 +2136,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/legion)
-"brH" = (
-/turf/closed/wall/f13/store,
-/area/f13/city)
 "brZ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -2113,9 +2143,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"bsb" = (
-/turf/closed/wall/f13/tentwall,
-/area/f13/city)
 "bsf" = (
 /obj/structure/table,
 /obj/item/trash/sosjerky,
@@ -2127,11 +2154,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
-"bts" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/open/floor/wood,
-/area/f13/village)
+"bto" = (
+/obj/effect/landmark/start/f13/deputy,
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/pinup_ride{
+	pixel_x = -32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "btN" = (
 /turf/closed/wall/f13/wood,
 /area/f13/ncr)
@@ -2140,6 +2171,21 @@
 	icon_state = "verticalrightborderleft2"
 	},
 /area/f13/wasteland)
+"buo" = (
+/obj/item/reagent_containers/food/snacks/grown/broc,
+/obj/item/reagent_containers/food/snacks/grown/broc,
+/obj/item/reagent_containers/food/snacks/grown/broc,
+/obj/item/reagent_containers/food/snacks/grown/broc,
+/obj/item/reagent_containers/food/snacks/grown/xander,
+/obj/item/reagent_containers/food/snacks/grown/xander,
+/obj/item/reagent_containers/food/snacks/grown/xander,
+/obj/item/reagent_containers/food/snacks/grown/xander,
+/obj/structure/closet/fridge{
+	desc = "An old pre-war fridge. This one is proudly labeled as lead-lined"
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "buu" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -2151,6 +2197,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
+"buC" = (
+/obj/effect/landmark/start/f13/deputy,
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "buD" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -2166,10 +2218,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
 "buO" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
+	},
+/area/f13/village)
 "buW" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2184,6 +2237,14 @@
 /obj/machinery/recharger,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"bvq" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
+	},
+/area/f13/wasteland)
 "bvs" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2203,32 +2264,48 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"bwo" = (
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright1"
+"bvV" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/city)
+"bwb" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -10;
+	tag = "icon-sink (WEST)"
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"bwo" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
+	},
+/area/f13/village)
 "bwE" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
-"bwG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
-/area/f13/wasteland)
+"bwF" = (
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bwM" = (
 /obj/effect/landmark/start/f13/auxilia,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "bwW" = (
 /obj/structure/table/wood/settler,
@@ -2298,11 +2375,9 @@
 	},
 /area/f13/building)
 "bzf" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/f13/wasteland)
 "bzm" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -2311,30 +2386,18 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "bzq" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/floorgrime,
 /area/f13/village)
-"bzr" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "bzB" = (
 /obj/item/ammo_casing/c10mm/ap,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop3"
 	},
 /area/f13/wasteland)
-"bzG" = (
-/turf/open/floor/plasteel/stairs/old,
-/area/f13/village)
 "bzK" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/dirt{
@@ -2348,11 +2411,17 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"bzZ" = (
-/obj/effect/landmark/start/f13/prospector,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+"bzU" = (
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/building)
+"bzV" = (
+/obj/structure/simple_door/room,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "bAe" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -2371,6 +2440,15 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"bAJ" = (
+/obj/structure/simple_door/house{
+	icon_state = "interior";
+	tag = "icon-interior"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "bAS" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -2387,6 +2465,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"bAX" = (
+/obj/machinery/grill,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "bBi" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -2395,6 +2479,13 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
+/area/f13/wasteland)
+"bBm" = (
+/obj/structure/flora/grass/wasteland{
+	layer = 4.2;
+	pixel_x = -3
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "bBG" = (
 /obj/structure/chair/sofa/corp,
@@ -2418,18 +2509,18 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"bCm" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavement"
+	},
+/area/f13/building)
 "bCG" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
-"bDb" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/turf/closed/wall/f13/wood/interior,
-/area/f13/city)
 "bDr" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/worn,
@@ -2468,26 +2559,18 @@
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
+"bEy" = (
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0";
+	tag = "icon-horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
 "bEB" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/f13Cash/random/ncr/low,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
-"bEP" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright";
-	layer = 2
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "storeshutters";
-	name = "store shutters"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"bER" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "bEX" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
@@ -2515,10 +2598,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"bFl" = (
-/obj/structure/legion_extractor,
+"bFr" = (
+/obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
+/area/f13/wasteland)
 "bFA" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -2549,25 +2632,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"bFY" = (
-/obj/structure/sign/poster/prewar/poster66{
-	pixel_x = -32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "bFZ" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland)
-"bGu" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "bGw" = (
@@ -2578,12 +2646,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"bGO" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/building)
 "bHa" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -2595,14 +2657,28 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"bHr" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
+"bHt" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"bHF" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/area/f13/building)
+"bHX" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetbrown";
+	tag = "icon-sheetbrown"
 	},
-/area/f13/followers)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bIh" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/clinic)
@@ -2610,11 +2686,7 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/brotherhood)
 "bIV" = (
-/obj/structure/chair/bench,
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
-	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/wasteland)
 "bIX" = (
 /obj/item/stack/sheet/mineral/wood,
@@ -2622,15 +2694,6 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
-"bJe" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/obj/item/soap/deluxe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "bJo" = (
 /obj/structure/fence/corner/wooden{
 	dir = 1
@@ -2654,12 +2717,12 @@
 	},
 /area/f13/building)
 "bKs" = (
-/obj/effect/decal/waste,
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2"
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/wasteland)
 "bKv" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2670,16 +2733,20 @@
 /obj/structure/mirror,
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
-"bKE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "bKJ" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"bLa" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/building)
 "bLL" = (
@@ -2708,11 +2775,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"bMP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "bMZ" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood,
@@ -2751,10 +2813,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"bOG" = (
-/obj/machinery/microwave/stove,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
+"bOH" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
+	},
+/area/f13/building)
 "bOO" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2769,31 +2836,31 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "bPj" = (
-/obj/structure/fence{
-	dir = 8
+/obj/machinery/light/small/broken{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/wasteland)
 "bPk" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence/corner{
+/obj/machinery/light/small/broken{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/legion)
+/turf/open/floor/wood,
+/area/f13/building)
 "bPH" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
+"bPU" = (
+/obj/structure/cable{
+	icon_state = "1-2";
+	tag = "icon-1-2"
+	},
+/obj/item/storage/trash_stack,
+/turf/open/floor/plating,
+/area/f13/caves)
 "bQh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2808,6 +2875,24 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"bQy" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/shreds{
+	pixel_x = -6;
+	pixel_y = -12
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"bQB" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/tunnel)
 "bQI" = (
 /obj/item/flag/bos,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -2824,13 +2909,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"bQV" = (
-/turf/closed/wall/rust,
-/area/f13/village)
-"bRq" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/followers)
+"bQU" = (
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "bRz" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -2839,12 +2925,18 @@
 	},
 /area/f13/ncr)
 "bRF" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/table/wood,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/pen,
+/obj/item/pen,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1{
+	layer = 2.1
 	},
-/area/f13/legion)
+/turf/open/floor/wood,
+/area/f13/building)
 "bRG" = (
 /obj/structure/disposalpipe/broken{
 	dir = 4
@@ -2855,17 +2947,25 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"bRP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/kitchenspike,
-/obj/structure/decoration/hatch{
-	dir = 1;
-	layer = 2.5
+"bSk" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
+"bSE" = (
+/obj/structure/table,
+/obj/item/kitchen/knife,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/area/f13/city)
+/area/f13/building)
 "bSR" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
@@ -2906,17 +3006,18 @@
 /obj/machinery/mineral/wasteland_vendor/medical,
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
-"bVq" = (
-/obj/structure/mirror{
-	pixel_y = 32
+"bUR" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft1"
 	},
-/obj/structure/sink{
-	pixel_y = 15
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/city)
+/area/f13/wasteland)
+"bVp" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bVT" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -2934,16 +3035,32 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"bWt" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
+	},
+/area/f13/wasteland)
+"bWx" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 9;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "bWB" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland)
 "bWF" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/machinery/trading_machine/ammo,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bWS" = (
 /obj/machinery/shower{
 	dir = 4
@@ -2964,10 +3081,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"bXC" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/followers)
 "bXM" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -2986,11 +3099,16 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
-"bZq" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
+"bZU" = (
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/obj/structure/closet/cabinet,
+/obj/item/gun/ballistic/automatic/pistol/m1911,
+/obj/item/ammo_box/magazine/m45,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "caa" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3001,15 +3119,17 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"cai" = (
-/obj/machinery/light/small,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/city)
 "cam" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland)
+"caq" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/building)
 "cbf" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/road{
@@ -3038,12 +3158,31 @@
 	},
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/legion)
+"ccf" = (
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gibleg"
+	},
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "ccF" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheetgrey"
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"ccG" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/chem_pile{
+	pixel_x = -10;
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/supermart,
 /area/f13/building)
 "cdc" = (
 /turf/open/indestructible/ground/outside/road{
@@ -3056,6 +3195,23 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
+"cdL" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
+"cek" = (
+/obj/structure/toilet{
+	pixel_y = 13
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "ces" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -3063,10 +3219,18 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
+"ceL" = (
+/obj/structure/simple_door/tentflap_cloth,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "ceT" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"cfd" = (
+/obj/structure/flora/wasteplant/wild_broc,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "cfn" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -3076,26 +3240,39 @@
 "cfp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/wood,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "cfD" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/water,
 /area/f13/caves)
-"cfK" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowbottom"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
-"cht" = (
-/obj/structure/fence{
-	dir = 1
-	},
+"cgi" = (
+/obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 9;
-	icon_state = "outerpavement"
+	icon_state = "horizontaloutermainleft";
+	tag = "icon-horizontaloutermainleft"
 	},
+/area/f13/wasteland)
+"cgy" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"cgA" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHEAST)"
+	},
+/area/f13/wasteland)
+"cht" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"chK" = (
+/obj/structure/flora/wasteplant/wild_feracactus,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "chM" = (
 /obj/structure/window/fulltile/house{
@@ -3117,19 +3294,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"chX" = (
-/obj/structure/closet/cabinet,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "house1ladder";
-	layer = 2
-	},
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "cia" = (
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/outside/dirt{
@@ -3144,12 +3308,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ciw" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife/cosmicdirty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "ciH" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -3159,6 +3317,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"ciL" = (
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "cjf" = (
 /obj/machinery/light/sign/chiken_ranch,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3178,31 +3345,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "cjG" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/structure/flora/wasteplant/wild_fungus,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "cjS" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"cjU" = (
-/obj/machinery/door/airlock/vault{
-	autoclose = "TRUE";
-	layer = 2;
-	name = "Bank Vault";
-	req_one_access_txt = "62"
-	},
-/obj/machinery/door/poddoor/ert{
-	id = "bankvault";
-	layer = 3;
-	name = "Vault"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "cjV" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
@@ -3211,6 +3361,10 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/village)
+"ckf" = (
+/obj/machinery/power/smes,
+/turf/open/floor/plating,
+/area/f13/radiation)
 "ckt" = (
 /obj/structure/sink/puddle,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3259,31 +3413,23 @@
 /obj/structure/closet/crate/wicker,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
-"clL" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetblue"
+"cly" = (
+/obj/structure/simple_door/bunker,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
-"cmj" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/farm)
-"cmF" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -10
+"clO" = (
+/obj/structure/simple_door/house{
+	icon_state = "interior";
+	tag = "icon-interior"
 	},
 /turf/open/floor/f13{
-	icon_state = "freezerfloor"
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/followers)
-"cmI" = (
-/obj/structure/girder,
-/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
 "cmR" = (
 /obj/structure/wreck/trash/two_barrels,
@@ -3335,16 +3481,10 @@
 /obj/machinery/smartfridge/drying_rack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"coZ" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/building)
 "cph" = (
 /obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /obj/effect/spawner/lootdrop/clothing_low,
-/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "cpu" = (
@@ -3355,16 +3495,16 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"cpJ" = (
+/obj/structure/chair/office/dark{
+	dir = 4;
+	icon_state = "officechair_dark"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cpK" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"cpL" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowleft"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "cqe" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light{
@@ -3387,33 +3527,29 @@
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"crd" = (
+/obj/item/trash/cheesie,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "crp" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"crA" = (
-/obj/structure/fence{
-	dir = 4
+"crW" = (
+/obj/structure/simple_door/metal/fence{
+	door_type = "fence_wood";
+	icon_state = "fence_wood"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/followers)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "csk" = (
 /turf/open/water,
 /area/f13/caves)
-"csl" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "csO" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
@@ -3421,14 +3557,6 @@
 "csQ" = (
 /turf/open/floor/wood/f13,
 /area/f13/building)
-"csY" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/white{
-	desc = "It's a strangely clean little white rodent.";
-	name = "Algernon"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "cte" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt,
@@ -3458,6 +3586,14 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
+"ctT" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "ctZ" = (
 /obj/structure/fence/corner{
 	dir = 4;
@@ -3468,19 +3604,20 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"cuf" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	tag = "icon-wooden_chair_new (NORTH)"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "cuv" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"cuz" = (
-/obj/structure/fence/corner{
-	dir = 5
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
-	},
-/area/f13/followers)
 "cuG" = (
 /turf/open/indestructible/ground/outside/water{
 	density = 1;
@@ -3493,6 +3630,13 @@
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/water,
 /area/f13/caves)
+"cuZ" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	tag = "icon-dirt"
+	},
+/area/f13/wasteland)
 "cvp" = (
 /obj/structure/chair/comfy/plywood{
 	dir = 4
@@ -3506,86 +3650,30 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"cvE" = (
-/obj/structure/destructible/tribal_torch{
-	pixel_y = 20
-	},
-/obj/structure/wreck/trash/three_barrels,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "cvH" = (
 /obj/structure/table/wood/settler,
 /obj/item/pickaxe,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"cvO" = (
-/obj/structure/flora/tree/tall{
-	pixel_x = -14;
-	pixel_y = 3
-	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "hole"
-	},
-/area/f13/wasteland)
-"cwg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/city)
-"cwB" = (
-/obj/structure/table/wood,
-/obj/machinery/door/poddoor/shutters{
-	id = "countershutters";
-	name = "counter shutters"
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"cwF" = (
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_x = -32
-	},
-/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
-	anchored = 1;
-	pixel_x = -28
-	},
-/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
-	anchored = 1;
-	pixel_x = -36
-	},
-/turf/closed/wall/f13/wood/interior,
-/area/f13/city)
-"cwO" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "shopladder"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"cxy" = (
-/obj/machinery/power/solar,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
+"cvI" = (
+/obj/structure/simple_door/room,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"cwS" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
+	icon_state = "verticalleftborderleftbottom";
+	tag = "icon-verticalleftborderleftbottom"
 	},
 /area/f13/wasteland)
+"cwW" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "cxL" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -3609,6 +3697,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"czA" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plating,
+/area/f13/caves)
 "czE" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibtorso"
@@ -3618,6 +3710,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"czR" = (
+/mob/living/simple_animal/hostile/wolf,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "czU" = (
 /obj/item/reagent_containers/food/snacks/grown/chili,
 /mob/living/simple_animal/hostile/wolf/alpha,
@@ -3637,35 +3733,17 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"cAW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_east_north"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "cBb" = (
-/obj/structure/simple_door/bunker,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/obj/structure/table/wood,
+/obj/item/kitchen/knife/cosmicdirty,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cBh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"cBB" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
 "cBS" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/wood/f13/old,
@@ -3680,6 +3758,13 @@
 /mob/living/simple_animal/hostile/raider/thief,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"cDk" = (
+/obj/item/clothing/suit/armor/f13/rustedcowboy,
+/obj/item/clothing/head/helmet/f13/rustedcowboyhat,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "cFe" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/destructible/tribal_torch/lit,
@@ -3688,19 +3773,25 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"cFJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	dir = 8
+"cFx" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_y = 12
 	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"cGb" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	pixel_x = 3;
+	pixel_y = 7
 	},
-/area/f13/farm)
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 5
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "cGj" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -3719,10 +3810,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
-"cGw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "cGL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -3759,23 +3846,20 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"cHH" = (
+/obj/structure/flora/wasteplant/wild_punga,
+/turf/open/water,
+/area/f13/wasteland)
 "cIh" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetUSA"
+	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "cIm" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/structure/table/wood/bar,
 /turf/open/floor/f13/wood,
-/area/f13/clinic)
-"cIA" = (
-/mob/living/simple_animal/hostile/stalker,
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "cIL" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -3785,12 +3869,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland)
-"cJZ" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
 "cKg" = (
@@ -3809,30 +3887,33 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
+"cKp" = (
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "cKC" = (
-/obj/structure/fence/corner{
-	dir = 6
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
-	},
-/area/f13/legion)
-"cKN" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "124"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
+/obj/structure/table/wood,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"cLk" = (
+/mob/living/simple_animal/hostile/gecko,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cLo" = (
 /obj/structure/bookcase,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"cLD" = (
+/obj/machinery/vending/cola/random,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "cLP" = (
 /obj/item/paper,
 /obj/machinery/light/small{
@@ -3859,10 +3940,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"cLZ" = (
-/obj/item/candle/infinite,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "cMk" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -3878,37 +3955,17 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "cNE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"cNJ" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
-/area/f13/wasteland)
-"cNF" = (
-/obj/structure/table/reinforced,
-/obj/item/taperecorder,
-/obj/item/pda/engineering,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/ncr)
-"cNH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
-"cOg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerbordercorner"
-	},
-/area/f13/city)
-"cOi" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "clinicladder"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "cOk" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -3936,9 +3993,26 @@
 /obj/structure/sink/puddle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"cPg" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"cOW" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/hatchet,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/obj/item/reagent_containers/spray/pestspray,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner"
+	},
 /area/f13/wasteland)
+"cPg" = (
+/obj/machinery/light/small,
+/obj/structure/table/wood/settler,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cPn" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -3954,6 +4028,15 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"cPI" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cPR" = (
 /obj/structure/chair/wood/fancy,
 /obj/machinery/light/small/broken{
@@ -3961,14 +4044,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"cPX" = (
-/obj/machinery/light/small/broken{
-	dir = 1
+"cPV" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
-/area/f13/village)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "cPZ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -3986,29 +4067,20 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"cQU" = (
-/obj/structure/sign/departments/medbay,
-/turf/closed/wall/f13/supermart,
-/area/f13/city)
+"cQM" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "cRh" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
-"cRk" = (
-/obj/structure/rack,
-/obj/item/book/granter/trait/chemistry,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "cRH" = (
-/obj/machinery/mineral/wasteland_vendor/advcomponents,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood/fancy,
+/obj/item/restraints/handcuffs,
+/obj/item/melee/chainofcommand/tailwhip/kitty,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cRM" = (
 /obj/structure/debris/v3,
 /obj/structure/flora/rock/jungle,
@@ -4042,15 +4114,16 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
+"cSF" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2bottom";
+	tag = "icon-verticalleftborderleft2bottom"
+	},
+/area/f13/wasteland)
 "cSH" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"cSO" = (
-/obj/structure/barricade/bars,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "cST" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/dirt,
@@ -4063,9 +4136,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
-"cTc" = (
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "cTp" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/desert,
@@ -4089,27 +4159,18 @@
 /obj/item/seeds/wheat,
 /obj/item/seeds/wheat,
 /obj/item/seeds/wheat,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "cVg" = (
 /obj/item/trash/f13/cram,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cVw" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/cable,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
+	},
+/area/f13/wasteland)
 "cVx" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -4136,20 +4197,30 @@
 	icon_state = "dirt"
 	},
 /area/f13/legion)
+"cVW" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "cWq" = (
 /obj/structure/closet/crate/freezer/blood{
 	pixel_y = -5
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "cWy" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "cWB" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright1"
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "cWG" = (
@@ -4176,21 +4247,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"cXb" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"cXh" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/grimy,
-/area/f13/village)
 "cXj" = (
 /obj/structure/simple_door/tent,
 /obj/structure/decoration/rag,
@@ -4203,12 +4259,15 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"cXB" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#845f58"
+"cXP" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/city)
 "cXU" = (
 /obj/machinery/door/airlock/hatch{
@@ -4231,16 +4290,6 @@
 /obj/structure/sign/poster/contraband/pinup_vixen,
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
-"cYT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "bankvault";
-	name = "bank vault button";
-	pixel_y = -32;
-	req_one_access_txt = "62"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "cYY" = (
 /obj/machinery/vending/coffee,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4255,37 +4304,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"cZE" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gibtorso"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/building)
-"cZT" = (
-/obj/structure/decoration/clock{
-	pixel_x = 32;
-	pixel_y = -2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "cZW" = (
 /obj/machinery/vending/cola/random,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"dau" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/trashcart,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
 "daB" = (
 /obj/structure/chair/wood/worn{
 	dir = 4
@@ -4299,10 +4323,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "daM" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32"
-	},
+/obj/structure/simple_door/metal/fence,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "daU" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -4310,19 +4332,27 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"dba" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
-"dbh" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/knife,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+"daW" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop3";
+	tag = "icon-horizontaltopbordertop3"
 	},
+/area/f13/wasteland)
+"daY" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"dbh" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "dbt" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4396,25 +4426,23 @@
 /obj/item/trash/f13/dog,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ddR" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowhorizontal";
-	layer = 3
+"ddf" = (
+/obj/structure/fence{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"deb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
+"def" = (
+/obj/structure/table/wood/settler,
+/obj/item/lighter,
+/obj/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/city)
-"def" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/building)
 "deE" = (
 /obj/structure/chair/wood/modern{
 	dir = 8;
@@ -4423,8 +4451,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "deQ" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "deU" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4439,14 +4469,15 @@
 	},
 /area/f13/caves)
 "dfx" = (
-/obj/structure/destructible/tribal_torch{
-	pixel_x = 10
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetblue"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/obj/machinery/light/small/broken{
+	dir = 1
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dfQ" = (
 /obj/structure/fence{
 	dir = 4
@@ -4463,30 +4494,23 @@
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"dgt" = (
-/obj/machinery/trading_machine/ammo,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "dgB" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "dgG" = (
-/obj/structure/fermenting_barrel,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+/obj/structure/decoration/clock/old{
+	pixel_y = 32
 	},
-/area/f13/farm)
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dgK" = (
 /obj/effect/landmark/start/f13/shaman,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"dgS" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/ketchup,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "dhh" = (
 /obj/item/stack/sheet/animalhide/human,
 /turf/open/indestructible/ground/outside/ruins{
@@ -4495,12 +4519,22 @@
 	},
 /area/f13/wasteland)
 "dhB" = (
-/obj/machinery/light/sign,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3"
+/obj/structure/rack,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/tomato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/sugarcane,
+/obj/item/seeds/sugarcane,
+/obj/machinery/light/small/broken{
+	dir = 1
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dhC" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -4517,6 +4551,11 @@
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"dim" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "dit" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/building)
@@ -4572,27 +4611,24 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"djk" = (
-/obj/structure/decoration/sign{
-	desc = "It's a portrait of a person you don't know anything about.";
-	icon_state = "painting_president";
-	name = "portrait";
-	pixel_y = -32
+"djH" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0";
+	tag = "icon-verticalinnermain0"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
+/area/f13/wasteland)
 "djK" = (
 /obj/item/storage/backpack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"dkd" = (
-/obj/structure/rack,
-/obj/item/watertank,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/followers)
+"djY" = (
+/mob/living/simple_animal/chick,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"dkf" = (
+/obj/machinery/workbench,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "dkg" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
@@ -4607,6 +4643,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"dkE" = (
+/obj/item/clothing/gloves/botanic_leather,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "dkF" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/machinery/light/small{
@@ -4626,9 +4666,15 @@
 	},
 /area/f13/building)
 "dlb" = (
-/mob/living/simple_animal/hostile/wolf,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/structure/rack,
+/obj/item/shovel/spade,
+/obj/item/shovel,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/cultivator,
+/obj/item/storage/bag/plants,
+/obj/item/scythe,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dlB" = (
 /obj/structure/car/rubbish1,
 /obj/structure/car/rubbish3,
@@ -4658,25 +4704,6 @@
 /obj/structure/chair/wood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"dmq" = (
-/obj/machinery/light/small,
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters button";
-	pixel_x = -6;
-	pixel_y = -32;
-	req_one_access_txt = "28"
-	},
-/obj/machinery/button/door{
-	id = "barwindowshutters";
-	name = "bar window shutters button";
-	pixel_x = 6;
-	pixel_y = -32;
-	req_one_access_txt = "28"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "dmJ" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -4714,11 +4741,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"dop" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
+"doo" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_y = 12
 	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "doB" = (
 /obj/machinery/light/small/broken,
@@ -4726,14 +4754,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
-"doF" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "doM" = (
 /obj/structure/ore_box,
 /turf/open/floor/f13/wood,
@@ -4755,6 +4775,18 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"doZ" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2right";
+	tag = "icon-horizontaltopborderbottom2right"
+	},
+/area/f13/wasteland)
+"dpc" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland)
 "dpg" = (
 /obj/structure/car/rubbish2,
 /turf/closed/wall/r_wall/rust,
@@ -4766,6 +4798,16 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"dpA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
+"dpC" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "dpG" = (
 /obj/structure/chair/office/dark,
@@ -4779,39 +4821,67 @@
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"dpN" = (
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
-/turf/closed/wall/rust,
-/area/f13/caves)
 "dpO" = (
 /obj/structure/table/wood,
 /obj/item/paper,
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dpS" = (
-/obj/machinery/trading_machine/armor,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"dpZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "dqc" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"dqf" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
+"dqk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
+	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
 	},
 /area/f13/wasteland)
 "dqn" = (
 /obj/item/clothing/under/f13/cowboyg,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"dqo" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"dqw" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_y = 9
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
+"dqD" = (
+/obj/structure/table/wood/settler,
+/obj/item/crafting/abraxo,
+/obj/item/crafting/duct_tape,
+/obj/structure/sink/kitchen{
+	pixel_y = 27
+	},
+/obj/structure/mirror{
+	pixel_x = -26;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/building)
 "dqI" = (
 /obj/structure/table/wood/settler,
@@ -4821,6 +4891,24 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"dro" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0";
+	tag = "icon-horizontaltopborderbottom0"
+	},
+/area/f13/wasteland)
+"drK" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
+"drN" = (
+/obj/structure/window/fulltile/wood,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dsh" = (
 /obj/structure/rack,
 /obj/item/clothing/head/sombrero,
@@ -4829,12 +4917,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"dsi" = (
-/obj/structure/table/wood,
-/obj/item/phone,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/wood,
-/area/f13/village)
 "dsn" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -4883,6 +4965,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"dtI" = (
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/structure/table/wood/fancy,
+/obj/effect/spawner/lootdrop/three_course_meal,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "dtJ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "badboys";
@@ -4890,6 +4979,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"dtK" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "dtO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -4965,10 +5060,18 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
-"dwx" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"dwk" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/book/bible,
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
+"dwG" = (
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/legion)
 "dwR" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -4980,20 +5083,17 @@
 	},
 /area/f13/building)
 "dwS" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "dxf" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/village)
-"dxm" = (
-/obj/item/twohanded/required/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/grimy,
 /area/f13/village)
 "dxo" = (
 /obj/machinery/light/small,
@@ -5011,12 +5111,26 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"dxG" = (
+/obj/structure/railing,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "dxJ" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"dxS" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
+	},
+/area/f13/wasteland)
 "dys" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -5027,16 +5141,6 @@
 /obj/structure/closet,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"dyH" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
-"dyO" = (
-/obj/machinery/vending/snack,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "dyQ" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -5045,19 +5149,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "dza" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/item/pen/fountain,
+/obj/item/pen/fountain,
+/obj/item/pen/fountain,
+/obj/item/pen/fountain,
+/turf/open/floor/wood,
+/area/f13/building)
 "dzf" = (
-/obj/structure/fence{
+/obj/structure/chair/wood{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dzE" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -5117,15 +5221,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"dAX" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/landmark/start/f13/ncrmp,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/ncr)
 "dBa" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -5151,6 +5246,22 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"dCk" = (
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2"
+	},
+/area/f13/wasteland)
+"dCx" = (
+/obj/structure/flora/wasteplant/wild_xander,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"dCJ" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "dCU" = (
 /obj/structure/table,
 /turf/open/floor/f13/wood,
@@ -5196,11 +5307,6 @@
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"dDF" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "dDK" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5229,6 +5335,10 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
+"dEY" = (
+/obj/structure/fence/corner/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "dFc" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -5242,6 +5352,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"dFM" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "dFQ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left"
@@ -5252,12 +5367,6 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dGL" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_7"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "dGQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -5265,21 +5374,27 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"dGZ" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowleft"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
-"dHq" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+"dGR" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outermaincornerouter";
+	tag = "icon-outermaincornerouter (WEST)"
 	},
 /area/f13/wasteland)
+"dHl" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (NORTH)"
+	},
+/area/f13/wasteland)
+"dHq" = (
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dHN" = (
 /obj/structure/table/wood,
 /obj/item/mining_scanner,
@@ -5287,11 +5402,18 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"dIN" = (
+"dHO" = (
+/obj/machinery/light/sign,
+/obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright2"
+	icon_state = "horizontaltopbordertop3"
 	},
-/area/f13/city)
+/area/f13/wasteland)
+"dHX" = (
+/obj/structure/table/wood/bar,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dIR" = (
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/road{
@@ -5314,6 +5436,13 @@
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/wood/interior,
 /area/f13/village)
+"dJs" = (
+/obj/structure/lamp_post/quadra,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland)
 "dJv" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/f13/police,
@@ -5340,9 +5469,11 @@
 	},
 /area/f13/building)
 "dJY" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/wood,
-/area/f13/village)
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/obj/item/clothing/under/f13/classdress,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dKa" = (
 /obj/machinery/light/small,
 /obj/effect/decal/remains/human,
@@ -5355,6 +5486,13 @@
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
+"dKt" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
+	},
+/area/f13/building)
 "dKA" = (
 /obj/structure/table,
 /obj/item/kitchen/knife{
@@ -5370,23 +5508,14 @@
 /area/f13/building)
 "dKR" = (
 /obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/stage_tr,
-/area/f13/wasteland)
-"dLa" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/supermart,
-/area/f13/city)
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/kitchen/fork,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dLb" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"dLg" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/crafting/goodparts/five,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "dLl" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/desert,
@@ -5421,6 +5550,20 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
+"dNg" = (
+/obj/item/ammo_casing/c9mm/ap,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
+	},
+/area/f13/wasteland)
+"dNt" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innermaincornerinner";
+	tag = "icon-innermaincornerinner"
 	},
 /area/f13/wasteland)
 "dNT" = (
@@ -5485,6 +5628,12 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"dPw" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housebase";
+	tag = "icon-housebase"
+	},
+/area/f13/building)
 "dQf" = (
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -5519,23 +5668,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"dRN" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	termtag = "Business"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "dRT" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/suit/armor/f13/slavelabor,
 /obj/item/clothing/under/f13/legslavef,
 /obj/item/clothing/shoes/f13/rag,
+/obj/effect/landmark/start/f13/slave,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"dSd" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"dSx" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1";
+	tag = "icon-verticalinnermain1"
+	},
+/area/f13/wasteland)
 "dTl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -5544,32 +5698,6 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"dTv" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"dTT" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
-"dTY" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood/house,
-/area/f13/city)
-"dUk" = (
-/obj/structure/chair,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "dUv" = (
 /turf/open/floor/carpet/black,
 /area/f13/legion)
@@ -5606,9 +5734,26 @@
 	},
 /area/f13/wasteland)
 "dWt" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"dWw" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/legion)
+"dWz" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/wood/f13/oakbroken3,
+/area/f13/building)
 "dWH" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt{
@@ -5617,12 +5762,11 @@
 	},
 /area/f13/wasteland)
 "dWR" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/area/f13/legion)
+/area/f13/building)
 "dWZ" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -5673,10 +5817,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "dZT" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
+/obj/structure/table/wood/settler,
+/obj/item/toy/cards/deck,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "ean" = (
 /obj/structure/table/wood,
@@ -5688,7 +5831,7 @@
 "eaA" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/mineral/wood/fifty,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "eaO" = (
 /obj/item/ammo_casing/a50MG,
@@ -5709,13 +5852,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"ebc" = (
-/turf/open/floor/plasteel/chapel,
-/area/f13/village)
-"ebl" = (
-/obj/structure/closet/cabinet,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "ebv" = (
 /obj/structure/closet,
 /obj/effect/turf_decal/stripes/white/box,
@@ -5726,10 +5862,6 @@
 /obj/item/trash/cheesie,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ebT" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
 "ecm" = (
 /obj/structure/table/snooker{
 	dir = 1
@@ -5737,6 +5869,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"ecx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cargocrate,
+/obj/structure/cargocrate{
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
 "ecM" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
@@ -5762,10 +5903,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"edO" = (
-/obj/structure/flora/grass/wasteland,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "ees" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
@@ -5782,12 +5919,10 @@
 	},
 /area/f13/brotherhood)
 "egb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "egn" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -5838,21 +5973,25 @@
 	},
 /area/f13/wasteland)
 "ehP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+/obj/machinery/light/small/broken{
+	dir = 1
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/building)
 "ehV" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"eid" = (
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight"
 	},
-/turf/open/water,
-/area/f13/caves)
-"eip" = (
-/obj/structure/sign/poster/prewar/poster88,
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "eiB" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/item/reagent_containers/food/drinks/beer/light{
@@ -5889,6 +6028,12 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"eiJ" = (
+/obj/effect/decal/riverbank{
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/wasteland)
 "ejk" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5913,24 +6058,12 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
 "ejD" = (
-/obj/structure/fence/corner{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
+/obj/machinery/seed_extractor,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ejT" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/wasteland)
-"ekp" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "ekI" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/item/flashlight,
@@ -5995,16 +6128,6 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
-"ems" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetblue"
-	},
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/village)
 "emz" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/tunnel)
@@ -6015,16 +6138,14 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"enp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "botany";
-	name = "Botany shutters"
+"emZ" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
+/area/f13/building)
 "enx" = (
 /obj/structure/decoration/clock/old,
 /turf/closed/wall/f13/store,
@@ -6062,17 +6183,6 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"eov" = (
-/obj/structure/rack,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/spray/plantbgone,
-/obj/item/reagent_containers/spray/plantbgone,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "eoA" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light,
@@ -6091,6 +6201,12 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
+"epy" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft3";
+	tag = "icon-verticalleftborderleft3"
+	},
 /area/f13/wasteland)
 "epF" = (
 /obj/structure/fence,
@@ -6111,9 +6227,9 @@
 	},
 /area/f13/wasteland)
 "eqo" = (
-/obj/structure/car/rubbish1,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0"
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33";
+	tag = "icon-wasteland33"
 	},
 /area/f13/wasteland)
 "eqv" = (
@@ -6125,6 +6241,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"eqx" = (
+/obj/structure/table/wood/settler,
+/obj/item/storage/box/matches,
+/obj/item/storage/fancy/candle_box,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "eqF" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -6149,13 +6275,7 @@
 	},
 /area/f13/wasteland)
 "esj" = (
-/obj/structure/closet/cabinet,
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/machinery/biogenerator,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "esD" = (
@@ -6165,13 +6285,6 @@
 /obj/item/storage/bag/ore,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"esE" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "esP" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2bottom"
@@ -6186,11 +6299,10 @@
 	},
 /area/f13/building)
 "etg" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/wasteland)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "etG" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -6204,12 +6316,6 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland)
-"etN" = (
-/obj/structure/closet/crate/trashcart{
-	name = "corpse cart"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "etV" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6233,18 +6339,19 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"euL" = (
-/obj/machinery/computer/operating,
-/obj/item/disk/surgery,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/followers)
 "euP" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
 /area/f13/caves)
+"evc" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetcmo";
+	tag = "icon-sheetcmo"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "evs" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -6254,6 +6361,16 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
+"evz" = (
+/obj/structure/table,
+/obj/item/kitchen/knife/butcher,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "evL" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -6263,6 +6380,13 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"evP" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "evU" = (
 /obj/machinery/grill,
 /turf/open/indestructible/ground/outside/desert,
@@ -6274,6 +6398,14 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "bar"
+	},
+/area/f13/building)
+"ewa" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
 /area/f13/building)
 "ewd" = (
@@ -6296,9 +6428,12 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland)
-"exL" = (
-/turf/open/floor/wood/f13/carpet,
-/area/f13/village)
+"exn" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2";
+	tag = "icon-horizontaltopbordertop2"
+	},
+/area/f13/wasteland)
 "exS" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/ruins{
@@ -6312,21 +6447,39 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
 "eyg" = (
-/obj/structure/decoration/hatch{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/wasteland)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "eyi" = (
 /obj/item/trash/f13/steak,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"eyp" = (
+/obj/structure/closet/crate/trashcart{
+	name = "corpse cart"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "eyI" = (
-/obj/structure/simple_door/metal/dirtystore,
-/turf/open/floor/wood,
-/area/f13/village)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"eyN" = (
+/obj/structure/chair{
+	dir = 4;
+	tag = "icon-chair (EAST)"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/clothing/under/pants/f13/ghoul,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "eyV" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -6356,7 +6509,7 @@
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "ezx" = (
 /obj/structure/rack,
@@ -6387,21 +6540,13 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
-"eAl" = (
-/obj/item/twohanded/required/kirbyplants/dead,
-/obj/item/reagent_containers/pill/fixer,
-/obj/item/reagent_containers/pill/insulin,
-/turf/open/floor/wood,
-/area/f13/village)
-"eAK" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/store,
-/area/f13/city)
-"eAS" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"eAo" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "eBc" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/computer/terminal{
@@ -6445,19 +6590,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eCJ" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/item/clothing/under/f13/shiny,
-/obj/structure/closet/cabinet,
-/obj/item/clothing/suit/chaplain/nun,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplain/holidaypriest,
-/obj/item/storage/backpack/cultpack,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/item/clothing/shoes/f13/fancy,
-/obj/item/storage/box/matches,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermainleft";
+	tag = "icon-horizontaloutermainleft"
+	},
+/area/f13/wasteland)
 "eCK" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13{
@@ -6484,15 +6622,12 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
-"eDT" = (
+"eDz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/iv_drip,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/wasteland_vendor/mining,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
 "eEt" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -6506,10 +6641,13 @@
 	},
 /area/f13/wasteland)
 "eEC" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "eEI" = (
 /obj/structure/toilet{
 	dir = 4
@@ -6522,13 +6660,10 @@
 	},
 /area/f13/building)
 "eEK" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
-/area/f13/wasteland)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "eEL" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -6548,6 +6683,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"eFs" = (
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench";
+	tag = "icon-bench (WEST)"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "eFA" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -6557,6 +6702,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"eFL" = (
+/mob/living/simple_animal/hostile/wolf,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2";
+	tag = "icon-verticalleftborderright2"
+	},
+/area/f13/wasteland)
 "eFW" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -6565,12 +6717,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "eGo" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerbordercorner";
+	tag = "icon-outerbordercorner (EAST)"
+	},
+/area/f13/wasteland)
 "eGs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -6579,6 +6731,25 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"eGt" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/knife/butcher,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"eGu" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "eGz" = (
 /obj/structure/table,
 /obj/machinery/chem_master{
@@ -6608,21 +6779,17 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "eHB" = (
-/mob/living/simple_animal/hostile/eyebot,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "eHQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/structure/simple_door/wood,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"eIg" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
-	},
-/area/f13/wasteland)
 "eIC" = (
 /obj/item/flag/ncr,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6659,19 +6826,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
-"eJr" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
-"eJu" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
 "eJN" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -6696,12 +6850,15 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"eKs" = (
-/obj/structure/decoration/rag{
-	pixel_x = -14
+"eKz" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	tag = "icon-housewindow"
 	},
-/turf/closed/wall/rust,
-/area/f13/caves)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "eKB" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -6722,22 +6879,20 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"eLb" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
+"eLd" = (
+/obj/structure/table,
+/obj/item/kitchen/fork,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/area/f13/legion)
+/area/f13/building)
 "eLe" = (
-/obj/structure/sink{
-	pixel_y = 15
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "eLo" = (
 /obj/item/clothing/under/jabroni,
@@ -6745,12 +6900,6 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"eLJ" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/fork,
-/turf/open/floor/f13/wood,
-/area/f13/village)
 "eMs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/debris/v3,
@@ -6788,28 +6937,12 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"eNs" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_north"
+"eMZ" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
 	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"eNC" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/obj/item/clothing/shoes/singery,
-/obj/item/clothing/under/singery,
-/obj/item/clothing/under/f13/bartenderalt,
-/obj/item/clothing/shoes/f13/fancy,
-/obj/item/reagent_containers/food/drinks/flask,
-/obj/item/toy/clockwork_watch,
-/obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
-/obj/effect/spawner/lootdrop/minor/bowler_or_that,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "eNT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -6841,24 +6974,17 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
+"eOY" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "eOZ" = (
 /obj/structure/table/wood,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ePh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	req_one_access_txt = "25"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"ePw" = (
-/obj/structure/table/wood,
-/obj/item/lipstick/random,
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "ePz" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6868,24 +6994,6 @@
 "ePI" = (
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/f13/wood/house,
-/area/f13/village)
-"ePQ" = (
-/obj/structure/fence/corner{
-	dir = 6
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
-"ePT" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = 30
-	},
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/wood/f13/carpet,
 /area/f13/village)
 "eQb" = (
 /obj/effect/decal/remains{
@@ -6929,12 +7037,6 @@
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/f13,
 /area/f13/building)
-"eQH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/legion)
 "eQR" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
@@ -6961,14 +7063,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"eRC" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright1"
-	},
-/area/f13/wasteland)
 "eRJ" = (
 /obj/structure/fence{
 	dir = 4
@@ -6976,17 +7070,21 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"eRO" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = 30
-	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/village)
 "eRT" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/wood/f13,
+/area/f13/building)
+"eRU" = (
+/obj/structure/barricade/bars,
+/obj/structure/window/reinforced/fulltile{
+	layer = 2.8
+	},
+/obj/structure/fence{
+	pixel_x = -16
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
 "eSh" = (
 /obj/structure/barricade/sandbags,
@@ -6999,6 +7097,21 @@
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"eSC" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 4;
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter (EAST)"
+	},
+/area/f13/wasteland)
+"eSF" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "eST" = (
 /obj/structure/rack,
 /obj/item/claymore/machete/warclub,
@@ -7017,11 +7130,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "eTJ" = (
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain3"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
-/area/f13/wasteland)
+/area/f13/building)
+"eTL" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/building)
 "eTO" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -7031,15 +7150,15 @@
 	},
 /area/f13/building)
 "eTZ" = (
-/obj/effect/decal/waste{
-	pixel_x = 18;
-	pixel_y = 12
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/eyebot{
+	faction = list("neutral");
+	name = "PE-A"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outermaincornerinner"
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "eUg" = (
 /obj/structure/campfire/stove,
 /obj/effect/decal/cleanable/dirt,
@@ -7057,11 +7176,6 @@
 /obj/item/bedsheet/black,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"eUp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood/interior,
-/area/f13/city)
 "eUz" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -7079,25 +7193,26 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/village)
-"eUQ" = (
-/obj/structure/barricade/bars,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "frontgateshut";
-	name = "gate shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "eVb" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/rust,
-/area/f13/caves)
-"eVh" = (
-/obj/machinery/grill,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+/obj/structure/holohoop{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
+"eVh" = (
+/obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "eVQ" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/bundle/costume/chicken,
@@ -7109,12 +7224,6 @@
 /area/f13/bar)
 "eWe" = (
 /turf/open/floor/wood/f13/stage_b,
-/area/f13/caves)
-"eWk" = (
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
-/turf/closed/wall/r_wall/rust,
 /area/f13/caves)
 "eWA" = (
 /obj/structure/toilet{
@@ -7144,7 +7253,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "eXw" = (
-/turf/closed/mineral/random/low_chance,
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "eXA" = (
 /turf/open/indestructible/ground/outside/ruins{
@@ -7212,8 +7322,14 @@
 	},
 /area/f13/building)
 "eZg" = (
-/obj/machinery/vending/cola/random,
-/turf/closed/mineral/random/low_chance,
+/obj/structure/closet,
+/obj/item/reagent_containers/pill/patch/jet,
+/obj/item/reagent_containers/pill/patch/jet,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"eZr" = (
+/obj/item/trash/can,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "eZs" = (
 /obj/structure/fence/wooden{
@@ -7255,12 +7371,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"faI" = (
-/obj/structure/girder,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/city)
 "faW" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
@@ -7305,15 +7415,54 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fbH" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
+/obj/effect/decal/waste{
+	pixel_x = 18;
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland)
+"fbM" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "fck" = (
-/turf/open/water,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/f13/caves)
+"fcr" = (
+/obj/structure/destructible/tribal_torch{
+	pixel_y = 20
+	},
+/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
 /area/f13/wasteland)
+"fcw" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/computer/terminal{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"fcA" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fcE" = (
 /obj/structure/reagent_dispensers/barrel/three{
 	pixel_x = -14
@@ -7366,6 +7515,13 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"fej" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "fek" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -7386,6 +7542,17 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"feM" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetcmo"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "feR" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -7405,10 +7572,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"ffy" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+"ffw" = (
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ffA" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/mineral/random/low_chance,
@@ -7463,6 +7630,10 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"fgn" = (
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "fgp" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -7471,15 +7642,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"fgI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
 "fgL" = (
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/f13,
@@ -7495,6 +7657,17 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"fhs" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "clinicdesk";
+	name = "counter shutters"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "fhG" = (
 /obj/structure/simple_door/metal/fence{
 	door_type = "fence_wood";
@@ -7530,14 +7703,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"fjC" = (
-/obj/structure/sign/poster/contraband/pinup_ride{
-	pixel_x = -32
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
-	},
-/area/f13/wasteland)
 "fjR" = (
 /obj/item/kitchen/knife/butcher,
 /turf/open/floor/f13/wood,
@@ -7575,24 +7740,40 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"flP" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Gatehouse";
-	req_one_access_txt = "62"
+"fkW" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
+"flj" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Secret"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
+"flI" = (
+/obj/structure/fence/wooden{
+	dir = 1
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "fmm" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
 "fmn" = (
 /obj/structure/chair/wood{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/landmark/start/f13/campfollower,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "fmr" = (
 /obj/structure/toilet{
@@ -7604,11 +7785,10 @@
 	},
 /area/f13/village)
 "fmO" = (
-/obj/structure/girder,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom2left"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "fmP" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -7622,18 +7802,24 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"fmV" = (
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/clinic)
 "fmW" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"fmX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright1"
-	},
-/area/f13/city)
 "fnB" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -7672,6 +7858,12 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"foB" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "foM" = (
 /obj/structure/chair/wood,
 /obj/machinery/light/small/broken{
@@ -7680,12 +7872,20 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "foN" = (
-/obj/structure/bus_door,
+/obj/item/toy/beach_ball/holoball,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
-	icon_state = "outerpavement"
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"foX" = (
+/obj/structure/fence/wooden{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "fpg" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -7707,6 +7907,11 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
+"fps" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "fpt" = (
 /obj/item/clothing/suit/armor/f13/kit,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7716,10 +7921,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "fpF" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetcmo"
-	},
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "fqa" = (
@@ -7735,26 +7939,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fqi" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 25
+/obj/structure/reagent_dispensers/barrel/three,
+/obj/effect/decal/waste{
+	icon_state = "goo5"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/decal/riverbank,
+/turf/open/water,
+/area/f13/wasteland)
 "fqL" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
 /area/f13/legion)
 "fqS" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
+/obj/structure/holohoop{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright1"
-	},
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "frr" = (
 /obj/machinery/mineral/wasteland_vendor/crafting{
@@ -7763,29 +7964,29 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fru" = (
-/obj/structure/girder,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom2"
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
-/area/f13/wasteland)
-"frx" = (
-/obj/structure/fence{
-	dir = 4
+/area/f13/radiation)
+"frv" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/decoration/rag,
-/obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"frx" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13/wood{
+	icon_state = "housebase"
 	},
-/area/f13/wasteland)
+/area/f13/radiation)
 "frz" = (
-/obj/structure/fence{
-	dir = 4
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/legion)
+/area/f13/radiation)
 "frB" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
@@ -7804,6 +8005,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
+"frO" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "frY" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -7832,13 +8037,13 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/water,
 /area/f13/caves)
-"fsQ" = (
-/obj/machinery/light/small{
-	dir = 4
+"fsO" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
-/obj/structure/fireplace,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/area/f13/building)
 "fsU" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_tr,
@@ -7849,20 +8054,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/legion)
 "ftz" = (
-/obj/structure/table,
-/obj/item/kitchen/knife,
+/obj/machinery/microwave/stove,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
-"fuc" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/storage/fancy/cigarettes/cigars,
-/obj/item/lighter,
-/turf/open/floor/wood/f13/stage_bl,
-/area/f13/city)
 "fug" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7898,9 +8094,10 @@
 	},
 /area/f13/ncr)
 "fuN" = (
-/obj/structure/simple_door/metal/fence,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/legion)
+/turf/open/floor/f13/wood{
+	icon_state = "housebase"
+	},
+/area/f13/radiation)
 "fuU" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -7909,18 +8106,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"fvi" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Followers Clinic"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
-"fvt" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "fvz" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2bottom"
@@ -7948,15 +8133,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"fxf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/city)
 "fxx" = (
 /obj/item/picket_sign,
 /turf/open/indestructible/ground/outside/road{
@@ -7978,27 +8154,13 @@
 "fyf" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"fyo" = (
-/obj/machinery/button/door{
-	id = "exteriorgate";
-	name = "Exterior door button";
-	pixel_x = -6;
-	pixel_y = 32
+"fyI" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetblue"
 	},
-/obj/machinery/button/door{
-	id = "interiorgate";
-	name = "Interior door button";
-	pixel_x = 6;
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
-"fyy" = (
-/mob/living/simple_animal/hostile/stalkeryoung,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "fyO" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/machinery/light/small/broken{
@@ -8059,15 +8221,26 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"fAP" = (
-/obj/structure/chair/wood{
-	dir = 4
+"fAB" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
 	},
-/area/f13/city)
+/area/f13/building)
+"fAG" = (
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"fAN" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2";
+	tag = "icon-horizontalinnermain2"
+	},
+/area/f13/wasteland)
 "fBl" = (
 /obj/structure/rack,
 /obj/item/camera,
@@ -8085,6 +8258,16 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"fBs" = (
+/obj/structure/bonfire,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outermaincornerouter"
+	},
+/area/f13/wasteland)
 "fBx" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden,
@@ -8112,6 +8295,19 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"fBO" = (
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"fBT" = (
+/obj/structure/simple_door/room,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/clinic)
 "fCg" = (
 /obj/structure/billboard/ritas,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8119,10 +8315,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"fCA" = (
-/obj/machinery/light/small/broken,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/village)
 "fCB" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/f13/wood{
@@ -8141,6 +8333,10 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"fCW" = (
+/obj/structure/flora/wasteplant/wild_punga,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "fDi" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/floor/f13/wood,
@@ -8152,17 +8348,9 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"fDx" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"fDp" = (
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "fDG" = (
 /obj/structure/fence/wooden{
 	dir = 1;
@@ -8170,28 +8358,6 @@
 	},
 /turf/open/floor/wood/f13/stage_br,
 /area/f13/legion)
-"fEg" = (
-/obj/structure/table/wood/fancy/black,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/city)
-"fEW" = (
-/obj/structure/sign/poster/ncr/democracy{
-	pixel_x = -32
-	},
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2bottom"
-	},
-/area/f13/wasteland)
-"fFh" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 8
-	},
-/area/f13/village)
 "fFu" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/desert,
@@ -8223,13 +8389,6 @@
 /obj/item/bedsheet/black,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"fFT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
 "fGc" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8253,21 +8412,64 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"fGj" = (
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/building)
+"fGl" = (
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "fGr" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"fGS" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbrokenvertical"
+"fGA" = (
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
+/obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"fHx" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/stage_bl,
 /area/f13/wasteland)
+"fGC" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
+"fGS" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHWEST)"
+	},
+/area/f13/wasteland)
+"fHx" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"fIa" = (
+/obj/structure/simple_door/bunker,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/wasteland)
+"fIk" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/legion)
 "fIn" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -8289,15 +8491,19 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"fJj" = (
-/obj/structure/chair/stool{
-	icon_state = "bench_center"
+"fIV" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner (WEST)"
 	},
-/obj/machinery/light/small{
-	dir = 1
+/area/f13/wasteland)
+"fJj" = (
+/obj/structure/chair/office{
+	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
 "fJl" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8314,17 +8520,21 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
-"fKt" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
-"fKN" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/wolf/alpha{
-	desc = "Legion mongrels are dogs owned and bred by the Houndmasters of Caesar's Legion. Mongrels are mainly used in combat and scouting missions by the Legion.";
-	faction = list("neutral");
-	name = "Brutus"
+"fKJ" = (
+/obj/structure/closet/fridge,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/crafting/wonderglue,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"fKN" = (
+/obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "fKU" = (
@@ -8332,44 +8542,57 @@
 /obj/item/lighter,
 /turf/open/floor/f13,
 /area/f13/building)
+"fKW" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
 "fLc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
-"fLB" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/wolf{
-	desc = "Legion mongrels are dogs owned and bred by the Houndmasters of Caesar's Legion. Mongrels are mainly used in combat and scouting missions by the Legion.";
-	faction = list("neutral");
-	health = 200;
-	maxHealth = 200;
-	name = "Lupa";
-	tame = 1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/legion)
 "fLC" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32"
 	},
 /area/f13/wasteland)
+"fLJ" = (
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fLN" = (
 /obj/structure/rack,
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"fMj" = (
-/obj/structure/girder,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom2right"
+"fLR" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/city)
 "fMu" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
+"fMv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken,
+/area/f13/legion)
+"fMy" = (
+/obj/structure/simple_door/tentflap_cloth,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "fMO" = (
 /obj/item/ammo_casing/c10mm/ap{
 	dir = 5
@@ -8389,13 +8612,16 @@
 /obj/structure/chair,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"fNB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
+"fNz" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "fNP" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -8405,11 +8631,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"fOe" = (
-/obj/effect/landmark/start/f13/sheriff,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "fOf" = (
 /obj/structure/sign/poster/prewar/poster90,
 /turf/closed/wall/f13/wood,
@@ -8434,6 +8655,25 @@
 /obj/machinery/light/broken,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"fOQ" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"fPl" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_y = 12
+	},
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole"
+	},
+/area/f13/wasteland)
 "fPL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/hydroponics{
@@ -8451,6 +8691,14 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"fPP" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "fPT" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -8463,21 +8711,15 @@
 /obj/item/twohanded/spear,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"fQc" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
+	},
+/area/f13/wasteland)
 "fQr" = (
-/obj/structure/chair/wood/worn{
-	dir = 4
-	},
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"fQt" = (
-/obj/item/flag/oasis{
-	density = 0;
-	pixel_y = 24
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/riverbank,
+/turf/open/water,
 /area/f13/wasteland)
 "fQu" = (
 /obj/machinery/hydroponics/soil{
@@ -8486,19 +8728,21 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"fQv" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fQz" = (
 /obj/structure/table/wood/poker{
 	name = "felt table"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
-"fQE" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/taperecorder,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"fQV" = (
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "fQW" = (
 /obj/item/folder/yellow,
 /obj/item/folder/yellow,
@@ -8510,11 +8754,8 @@
 /area/f13/village)
 "fQY" = (
 /obj/structure/closet/cabinet,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/item/clothing/under/f13/classdress,
 /obj/item/clothing/mask/society,
 /obj/item/clothing/shoes/laceup,
@@ -8532,6 +8773,13 @@
 "fRx" = (
 /obj/structure/table,
 /turf/open/floor/f13,
+/area/f13/building)
+"fRM" = (
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "133"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "fRR" = (
 /obj/structure/disposalpipe/broken,
@@ -8553,19 +8801,19 @@
 	icon_state = "verticalleftborderright2top"
 	},
 /area/f13/wasteland)
-"fSz" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_7"
+"fSD" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain3";
+	tag = "icon-verticalinnermain3"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
-"fSE" = (
-/obj/structure/rack,
-/obj/item/kitchen/knife,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/item/storage/box/bodybags,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/wasteland)
+"fTj" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontaltopborderbottom2left";
+	tag = "icon-horizontaltopborderbottom2left (WEST)"
+	},
+/area/f13/wasteland)
 "fTn" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood{
@@ -8598,13 +8846,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "fTW" = (
-/obj/structure/fence/corner/wooden{
-	dir = 1
-	},
-/obj/structure/fence/corner/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "fUb" = (
@@ -8624,9 +8869,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/village)
-"fVn" = (
-/turf/closed/wall/f13/wood,
-/area/f13/city)
 "fVt" = (
 /obj/structure/tires/two,
 /turf/open/floor/f13/wood{
@@ -8639,26 +8881,24 @@
 	},
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
-"fVH" = (
-/obj/structure/sign/poster/prewar/poster82{
-	pixel_x = 32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "fVT" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/soymilk,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "fVZ" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6";
-	pixel_x = -28
+/obj/effect/decal/waste{
+	icon_state = "goo5"
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
+/turf/open/floor/f13/wood{
+	icon_state = "housebase"
 	},
-/area/f13/wasteland)
+/area/f13/radiation)
+"fWi" = (
+/obj/structure/table/wood,
+/obj/item/clothing/suit/armor/f13/raider/raidermetal,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fWj" = (
 /obj/item/ammo_casing/caseless{
 	dir = 6
@@ -8701,19 +8941,6 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
-"fXP" = (
-/obj/structure/flora/tree/tall{
-	density = 0;
-	icon_state = "tree_3";
-	pixel_x = -29;
-	pixel_y = 17
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"fXY" = (
-/obj/structure/closet/crate/coffin,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "fYa" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8730,6 +8957,16 @@
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/legion)
+"fYv" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	tag = "icon-wooden_chair_new (NORTH)"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "fYP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/hydronutrients,
@@ -8742,20 +8979,14 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
-"fZm" = (
+"fYZ" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/settler,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"fZu" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/city)
 "fZv" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -8768,6 +8999,17 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"gan" = (
+/obj/structure/closet,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"gaF" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/legion)
 "gaV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt{
@@ -8775,10 +9017,24 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"gaZ" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "gbd" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/f13,
 /area/f13/building)
+"gbl" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "gbn" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights,
@@ -8809,6 +9065,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"gbS" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottomleft"
+	},
+/area/f13/building)
 "gbW" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -8821,6 +9082,11 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
+"gck" = (
+/obj/structure/closet,
+/obj/item/storage/box/gloves,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "gcK" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -8855,10 +9121,14 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
-"gfc" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/f13/village)
+"geR" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2bottom";
+	tag = "icon-verticalleftborderleft2bottom"
+	},
+/area/f13/wasteland)
 "gfB" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -8866,12 +9136,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gfR" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Farm";
-	req_one_access_txt = "25"
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
 	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "gfY" = (
 /obj/structure/bed/mattress{
@@ -8885,6 +9154,17 @@
 	dir = 8
 	},
 /turf/open/floor/f13,
+/area/f13/building)
+"ggk" = (
+/obj/structure/closet,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/disk/surgery/oasis,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "ggo" = (
 /obj/structure/car,
@@ -8921,37 +9201,22 @@
 	},
 /area/f13/wasteland)
 "ghx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (EAST)"
+	},
 /area/f13/wasteland)
 "ghD" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small/broken,
 /turf/open/water,
 /area/f13/caves)
-"ghE" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"ghG" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "ghX" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"gim" = (
-/obj/machinery/shower,
-/obj/structure/curtain,
-/obj/item/soap/deluxe,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/city)
 "gin" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
@@ -8978,6 +9243,16 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"giH" = (
+/obj/structure/table/wood,
+/obj/structure/wreck/trash/halftire{
+	pixel_y = -21
+	},
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "giX" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/f13{
@@ -9035,14 +9310,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"gjM" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/city)
 "gjP" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/village)
@@ -9064,14 +9331,30 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
-"gkZ" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = -30
+"gks" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
 	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/village)
+/area/f13/building)
+"gkv" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft2bottom";
+	tag = "icon-verticalrightborderleft2bottom"
+	},
+/area/f13/wasteland)
+"gkS" = (
+/obj/effect/decal/remains/human,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"gld" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/f13/radiation)
 "gln" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -9095,46 +9378,40 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/ncr)
 "gmR" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbroken"
+/obj/machinery/vending/cola/space_up,
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 12
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"gmW" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "followersdeskshutters";
-	name = "followers shutters"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
 	},
-/obj/structure/table/reinforced,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
+/area/f13/wasteland)
 "gmX" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland)
 "gmZ" = (
-/obj/structure/table/wood/settler,
-/obj/item/toy/cards/deck,
-/turf/open/floor/f13/wood,
-/area/f13/village)
-"gne" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/light/sign/oasis,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright3"
 	},
-/obj/machinery/photocopier,
-/turf/open/floor/carpet/black,
-/area/f13/city)
+/area/f13/wasteland)
 "gnf" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2"
 	},
 /area/f13/wasteland)
+"gnj" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/table,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "gnk" = (
 /turf/open/floor/f13,
 /area/f13/building)
@@ -9147,25 +9424,17 @@
 /obj/structure/decoration/clock/active,
 /turf/closed/wall/f13/wood,
 /area/f13/brotherhood)
-"gof" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/computer/terminal{
+"gon" = (
+/obj/machinery/shower{
 	dir = 4;
-	termtag = "Business"
+	icon_state = "shower"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/decoration/hatch,
+/obj/structure/window{
+	dir = 4
 	},
-/area/f13/city)
-"gok" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/attachments,
-/obj/effect/spawner/lootdrop/f13/attachments,
-/obj/effect/spawner/lootdrop/f13/attachments,
-/obj/effect/spawner/lootdrop/f13/attachments,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "goC" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -9174,12 +9443,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "goK" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
+/obj/structure/table/wood/fancy/black,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = 30
 	},
-/area/f13/legion)
+/obj/item/modular_computer/laptop/preset/civillian,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel/grimy,
+/area/f13/wasteland)
 "goO" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -9209,6 +9481,21 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"gpv" = (
+/obj/structure/table/wood/poker,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"gpz" = (
+/obj/structure/bed,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "gpC" = (
 /obj/structure/debris/v3,
 /turf/closed/mineral/random/low_chance,
@@ -9250,23 +9537,28 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"gqj" = (
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
+	},
+/area/f13/wasteland)
+"gqo" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gqz" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
-"gqE" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/city)
 "grc" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
@@ -9277,26 +9569,20 @@
 /obj/structure/chair/right,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
-"grj" = (
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
 "grp" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottomright"
 	},
 /area/f13/wasteland)
 "grC" = (
-/obj/machinery/power/solar,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table/wood/fancy/black,
+/obj/structure/decoration/clock/active{
+	pixel_y = 30
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
+/obj/item/reagent_containers/pill/patch/turbo{
+	layer = 2.4
 	},
+/turf/open/floor/plasteel/grimy,
 /area/f13/wasteland)
 "gsa" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -9333,6 +9619,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"gsy" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gsB" = (
 /obj/machinery/washing_machine,
 /obj/item/crafting/abraxo,
@@ -9341,13 +9632,17 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"gsP" = (
+/obj/structure/bed/mattress/pregame,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gsV" = (
-/obj/structure/decoration/rag,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/turf/closed/wall/f13/wood,
-/area/f13/legion)
+/turf/open/floor/plating,
+/area/f13/wasteland)
 "gtj" = (
 /obj/structure/simple_door/metal/fence{
 	dir = 8
@@ -9379,17 +9674,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"gtY" = (
-/obj/structure/sink{
-	pixel_y = 15
+"gue" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
 	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/city)
+/area/f13/legion)
 "guh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -9442,15 +9733,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gvN" = (
-/obj/structure/closet/cabinet,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/rack,
+/obj/item/stack/sheet/metal{
+	amount = 50
 	},
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/item/clothing/under/f13/classdress,
-/obj/item/clothing/mask/society,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gvW" = (
@@ -9462,13 +9752,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "gwn" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "S5"
+/obj/structure/table/wood/fancy/black,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = 30
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/turf/open/floor/plasteel/grimy,
 /area/f13/wasteland)
 "gws" = (
 /obj/machinery/shower{
@@ -9501,19 +9792,22 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"gxk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	desc = "A lighting fixture.";
-	dir = 8;
-	light_color = "#008000";
-	name = "light tube"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "gxn" = (
 /obj/effect/mob_spawn/human/corpse,
 /obj/structure/cross,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"gxv" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Gatehouse";
+	req_one_access_txt = "62"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"gxK" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "gxO" = (
@@ -9571,29 +9865,19 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"gzD" = (
-/obj/structure/table,
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"gzG" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom2left"
-	},
-/area/f13/city)
 "gzQ" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/item/clothing/under/f13/classdress,
-/obj/item/clothing/mask/society,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
 /area/f13/building)
 "gzW" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/clothing_low,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "gzY" = (
@@ -9606,6 +9890,13 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
+"gAv" = (
+/obj/structure/chair/bench,
+/obj/effect/landmark/start/f13/settler,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "gAU" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -9624,11 +9915,6 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
-"gBj" = (
-/obj/structure/chair/office,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "gBu" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9636,11 +9922,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"gBT" = (
-/obj/machinery/photocopier,
-/obj/item/toner,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "gBW" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -9651,6 +9932,14 @@
 /obj/structure/closet/crate/miningcar,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"gCc" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
 "gCd" = (
 /obj/structure/fence{
 	dir = 4
@@ -9662,21 +9951,6 @@
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"gCq" = (
-/obj/structure/curtain,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
-"gCu" = (
-/obj/structure/table/wood,
-/obj/item/folder,
-/obj/item/folder,
-/obj/item/folder,
-/obj/item/folder,
-/obj/item/camera/detective{
-	name = "camera"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "gCw" = (
 /obj/structure/car/rubbish1,
 /turf/closed/wall/r_wall/rust,
@@ -9686,24 +9960,9 @@
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
 "gCN" = (
-/obj/structure/wreck/trash/halftire,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
-	},
+/obj/structure/chair/office/dark,
+/turf/open/floor/wood,
 /area/f13/wasteland)
-"gCU" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
-"gDl" = (
-/obj/structure/dresser,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "gDn" = (
 /obj/structure/fence{
 	dir = 8
@@ -9715,6 +9974,13 @@
 "gDs" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
+"gDJ" = (
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2top";
+	tag = "icon-verticalleftborderleft2top"
+	},
 /area/f13/wasteland)
 "gDZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -9749,53 +10015,27 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"gET" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 5
-	},
-/obj/structure/sink/well,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "gEY" = (
-/obj/structure/simple_door/house{
-	icon_state = "room"
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
+/area/f13/building)
+"gFA" = (
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "gFR" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
-"gFV" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "clinicfrontdoor";
-	name = "clinic shutters";
-	pixel_x = 32;
-	pixel_y = 6;
-	req_one_access_txt = "62"
-	},
-/obj/machinery/button/door{
-	id = "clinicstorage";
-	name = "clinic storage";
-	pixel_x = 32;
-	pixel_y = -6;
-	req_one_access_txt = "62"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "gGp" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "gGt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/floor/plasteel/chapel{
+	dir = 5
+	},
 /area/f13/wasteland)
 "gGu" = (
 /obj/structure/simple_door/metal/store{
@@ -9835,17 +10075,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
-"gHP" = (
-/obj/machinery/light,
-/obj/item/flag/oasis,
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderrightbottom"
-	},
-/area/f13/wasteland)
 "gHT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9858,6 +10087,10 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
+"gHW" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "gHX" = (
 /obj/structure/chair/stool{
 	icon_state = "bench"
@@ -9867,11 +10100,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"gIA" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "gIE" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/police,
@@ -9879,12 +10107,6 @@
 /obj/item/clothing/shoes/combat,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"gJI" = (
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/city)
 "gJP" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -9895,36 +10117,26 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"gJW" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "gJY" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
 /area/f13/building)
-"gKG" = (
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
-"gKP" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
+"gKg" = (
+/obj/structure/table/wood,
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"gLx" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"gLH" = (
-/obj/structure/table,
-/obj/item/roller,
-/obj/item/roller,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_x = 30;
-	pixel_y = -3
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
+"gKP" = (
+/obj/effect/decal/riverbankcorner,
+/turf/open/water,
+/area/f13/wasteland)
 "gLX" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -9974,10 +10186,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"gNB" = (
-/obj/structure/fermenting_barrel,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "gND" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -9987,14 +10195,10 @@
 "gOf" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
-/area/f13/radiation)
-"gOs" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/turf/open/floor/f13/wood{
+	icon_state = "housebase"
 	},
-/turf/closed/wall/f13/wood,
-/area/f13/city)
+/area/f13/radiation)
 "gOD" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/simple_door/metal/ventilation,
@@ -10066,13 +10270,6 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
-"gPX" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	req_one_access_txt = "48"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "gQp" = (
 /obj/machinery/processor,
 /turf/open/floor/f13{
@@ -10088,10 +10285,18 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13,
 /area/f13/building)
+"gQA" = (
+/mob/living/simple_animal/hostile/raider,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "gQL" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"gQO" = (
+/obj/item/stack/f13Cash/random/med,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "gQQ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -10101,13 +10306,12 @@
 	},
 /area/f13/building)
 "gQW" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/area/f13/legion)
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/wasteland)
 "gRa" = (
 /obj/structure/barricade/bars,
 /obj/structure/fence,
@@ -10116,9 +10320,12 @@
 	},
 /area/f13/wasteland)
 "gRf" = (
+/obj/structure/fence{
+	dir = 1
+	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
-	icon_state = "dirtcorner"
+	icon_state = "dirt"
 	},
 /area/f13/legion)
 "gRk" = (
@@ -10133,15 +10340,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"gRs" = (
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "gSf" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -10155,6 +10353,18 @@
 /obj/structure/chair/bench,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"gSp" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 25
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"gSq" = (
+/obj/structure/table/wood,
+/obj/item/clothing/suit/armor/f13/raider/sadist,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gSt" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerpavementcorner"
@@ -10174,12 +10384,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"gTC" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
 "gTD" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/wood,
@@ -10201,19 +10405,22 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"gUb" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "gUq" = (
-/obj/structure/statue/sandstone/mars{
-	pixel_x = -1
-	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/carpet/airless,
 /area/f13/legion)
 "gVd" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 10
+/obj/structure/table/wood/poker,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = 30
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/wasteland)
 "gVh" = (
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt,
@@ -10230,34 +10437,35 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"gVE" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
 "gVQ" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress6"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"gWh" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Church Backroom";
-	req_one_access_txt = "25"
+"gVV" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"gWm" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2top";
+	tag = "icon-verticalleftborderleft2top"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/area/f13/wasteland)
 "gWo" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"gWF" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
+	},
+/area/f13/building)
 "gWG" = (
 /obj/item/gun/ballistic/revolver/single_shotgun,
 /turf/open/floor/f13/wood{
@@ -10291,16 +10499,6 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"gXz" = (
-/obj/structure/kitchenspike,
-/obj/structure/decoration/hatch{
-	dir = 1;
-	layer = 2.5
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/city)
 "gXK" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/sneakers/black{
@@ -10359,12 +10557,6 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"gYu" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_2"
-	},
-/turf/open/water,
-/area/f13/caves)
 "gYA" = (
 /obj/structure/rack,
 /obj/item/cultivator,
@@ -10377,15 +10569,35 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"gYL" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -10;
+	tag = "icon-sink (WEST)"
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "gZi" = (
 /obj/structure/mirelurkegg,
 /turf/open/water,
 /area/f13/caves)
-"gZD" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/desert,
+"gZx" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"gZJ" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/oakbroken2,
+/area/f13/legion)
 "hab" = (
 /obj/structure/chair/left{
 	dir = 4
@@ -10412,6 +10624,14 @@
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"haN" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "haP" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/dirt,
@@ -10431,19 +10651,25 @@
 /obj/structure/window/fulltile/wood,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
-"hbK" = (
-/obj/machinery/light{
-	dir = 4
+"hbG" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "botany";
-	name = "Botany button";
-	pixel_y = -25
+/obj/structure/closet/fridge,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/food,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
+/area/f13/building)
 "hbO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -10456,7 +10682,7 @@
 "hcr" = (
 /obj/structure/table/wood,
 /obj/item/pickaxe,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "hcK" = (
 /obj/structure/rack,
@@ -10483,6 +10709,13 @@
 /obj/structure/mirror,
 /turf/closed/wall/r_wall/rust,
 /area/f13/ncr)
+"hdi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/f13/building)
 "hdr" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/cash_legion_low,
@@ -10528,6 +10761,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"hfK" = (
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "hfV" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -10581,14 +10822,12 @@
 	},
 /area/f13/caves)
 "hgJ" = (
-/obj/machinery/power/solar,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table/wood/poker,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = 30
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
+/turf/open/floor/wood/f13/carpet,
 /area/f13/wasteland)
 "hgM" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -10630,12 +10869,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"hhK" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
+"hhQ" = (
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "hio" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/balaclava,
@@ -10645,15 +10885,19 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"hiB" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
+	},
+/area/f13/building)
 "hiG" = (
-/obj/structure/decoration/clock{
-	pixel_y = 30
+/mob/living/simple_animal/hostile/wolf{
+	faction = list("hostile","wolf","raider");
+	name = "raider dog"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "hiS" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -10668,15 +10912,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
-"hjb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "frontgateshut";
-	name = "gate shutters";
-	pixel_y = 32
+"hiX" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2";
+	tag = "icon-verticalinnermain2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/wasteland)
 "hjc" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -10698,20 +10939,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"hjP" = (
-/obj/structure/rack,
-/obj/item/shovel/spade,
-/obj/item/shovel,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/cultivator,
-/obj/item/clothing/gloves/botanic_leather,
-/obj/item/clothing/gloves/botanic_leather,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "hke" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -10736,11 +10963,27 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"hkL" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "hkW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft3"
 	},
 /area/f13/wasteland)
+"hlh" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "hlo" = (
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
@@ -10755,27 +10998,15 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"hlQ" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	req_one_access_txt = "25"
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/city)
 "hmc" = (
-/obj/structure/fence{
-	dir = 1
+/obj/structure/table/wood/poker,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = 30
 	},
-/obj/structure/fence{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/wasteland)
 "hmd" = (
 /obj/structure/car/rubbish4,
 /obj/effect/decal/cleanable/glass,
@@ -10813,15 +11044,30 @@
 	},
 /area/f13/building)
 "hnq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/wood/poker,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = 30
+	},
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_x = 30
+	},
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/wasteland)
+"hnx" = (
+/obj/structure/bonfire,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain3"
+	},
 /area/f13/wasteland)
 "hnB" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2right";
+	tag = "icon-horizontaloutermain2right"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "hom" = (
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
@@ -10830,33 +11076,32 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/tunnel)
+"hop" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "hoG" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"hoX" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"hoS" = (
+/obj/machinery/vending/nukacolavend,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hpc" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "hpj" = (
-/obj/structure/fence{
-	dir = 8
+/obj/machinery/light/small/broken{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
-	},
+/turf/open/floor/wood,
 /area/f13/wasteland)
 "hpm" = (
 /obj/item/storage/trash_stack,
@@ -10890,10 +11135,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"hpY" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "hqr" = (
 /obj/machinery/vending/games,
 /turf/open/floor/f13/wood,
@@ -10908,9 +11149,11 @@
 	},
 /area/f13/building)
 "hqC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
+	},
 /area/f13/wasteland)
 "hqL" = (
 /obj/structure/bonfire,
@@ -10930,6 +11173,28 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"hqQ" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
+	},
+/area/f13/wasteland)
+"hrs" = (
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench";
+	tag = "icon-bench (EAST)"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
+	},
+/area/f13/wasteland)
 "hrx" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13,
@@ -10949,6 +11214,15 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"hsc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/iv_drip,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "hsh" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -10959,6 +11233,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"hsk" = (
+/obj/structure/window/fulltile/wood,
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "hsy" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -10985,10 +11263,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "hsP" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical";
+	tag = "icon-housewindowvertical (NORTHEAST)"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "htf" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -11032,14 +11315,6 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/water,
 /area/f13/caves)
-"htQ" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Bank";
-	req_one_access_txt = "25"
-	},
-/turf/open/floor/plasteel/stairs/old,
-/area/f13/city)
 "hul" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/head/helmet/gladiator,
@@ -11052,13 +11327,12 @@
 	icon_state = "shadowright"
 	},
 /area/f13/wasteland)
-"huU" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+"huA" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermaintop";
+	tag = "icon-verticaloutermaintop"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "huW" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood{
@@ -11070,10 +11344,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
 "hvk" = (
-/obj/effect/landmark/start/f13/auxilia,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/table,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "hvp" = (
 /obj/structure/flora/grass/wasteland{
@@ -11094,13 +11366,6 @@
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet/green,
 /area/f13/ncr)
-"hwn" = (
-/obj/machinery/sleeper{
-	density = 1;
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "hwr" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -11122,32 +11387,6 @@
 /obj/structure/fence,
 /turf/closed/wall/f13/tunnel,
 /area/f13/wasteland)
-"hxk" = (
-/obj/machinery/button/door{
-	id = "bankdesk";
-	name = "desk shutters";
-	pixel_x = -6;
-	pixel_y = -32;
-	req_one_access_txt = "62"
-	},
-/obj/machinery/button/door{
-	id = "bankvault";
-	name = "bank vault button";
-	pixel_x = 6;
-	pixel_y = -32;
-	req_one_access_txt = "62"
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/city)
-"hxn" = (
-/obj/structure/chair,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "hxp" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/f13{
@@ -11185,24 +11424,16 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hxQ" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/item/flag/oasis,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
 	},
-/obj/effect/landmark/start/f13/campfollower,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"hxU" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
+/area/f13/wasteland)
 "hxX" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "hyf" = (
 /obj/structure/chair/stool,
@@ -11253,10 +11484,16 @@
 	icon_state = "horizontalbottomborderbottomright"
 	},
 /area/f13/wasteland)
+"hzq" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2left"
+	},
+/area/f13/wasteland)
 "hzr" = (
 /obj/structure/table/wood,
 /obj/structure/table/wood,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "hzt" = (
 /obj/structure/bed/pod,
@@ -11284,23 +11521,24 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"hzX" = (
+/obj/structure/table/wood,
+/obj/item/trash/sosjerky{
+	icon_state = "plate";
+	tag = "icon-plate"
+	},
+/obj/item/kitchen/fork{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hAC" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
-"hAN" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "followerladder"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "hAV" = (
 /obj/structure/fireplace,
 /turf/open/floor/carpet/green,
@@ -11354,10 +11592,28 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"hDe" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "hDf" = (
 /obj/structure/simple_door/interior,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
+"hDr" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland)
 "hDC" = (
 /obj/structure/decoration/shock,
 /turf/closed/wall/r_wall/rust,
@@ -11382,12 +11638,16 @@
 	},
 /area/f13/building)
 "hEa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
+/obj/item/flag/oasis,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"hEe" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hEm" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/metal{
@@ -11397,11 +11657,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"hET" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "hFb" = (
 /obj/structure/sink{
 	dir = 8
@@ -11410,10 +11665,27 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"hFi" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/f13/radiation)
 "hFl" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
+"hFz" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "hFM" = (
 /obj/structure/chair/wood/worn{
 	dir = 4
@@ -11430,12 +11702,12 @@
 	},
 /area/f13/legion)
 "hFY" = (
-/obj/structure/holohoop{
-	dir = 4
+/obj/structure/table/wood/fancy/black,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_x = -30
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
-	},
+/turf/open/floor/plasteel/grimy,
 /area/f13/wasteland)
 "hGr" = (
 /obj/machinery/shower{
@@ -11446,6 +11718,13 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
+"hGx" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontaltopborderbottom2right";
+	tag = "icon-horizontaltopborderbottom2right (WEST)"
+	},
+/area/f13/wasteland)
 "hGJ" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalbottom"
@@ -11454,14 +11733,9 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"hHi" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/breadhard,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "hHk" = (
 /obj/structure/simple_door/fakeglass,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "hHm" = (
 /obj/effect/decal/remains{
@@ -11471,13 +11745,10 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"hHr" = (
-/obj/machinery/light/small,
+"hHs" = (
+/mob/living/simple_animal/hostile/stalker,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/followers)
-"hHz" = (
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/area/f13/building)
 "hHC" = (
 /obj/structure/closet,
 /obj/machinery/light/small{
@@ -11488,22 +11759,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"hHD" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_south"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "hHH" = (
 /obj/structure/decoration/hatch,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
-"hHR" = (
-/obj/machinery/door/morgue,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "hHS" = (
 /obj/structure/fence/wooden{
 	dir = 1
@@ -11530,29 +11791,22 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/brotherhood)
+"hIY" = (
+/obj/structure/decoration/hatch,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop3";
+	tag = "icon-horizontalbottombordertop3"
+	},
+/area/f13/wasteland)
 "hJd" = (
-/obj/structure/rack,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/tomato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/sugarcane,
-/obj/item/seeds/sugarcane,
-/obj/machinery/light/small/broken{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/turf/open/floor/plasteel/grimy,
+/area/f13/wasteland)
 "hJf" = (
-/obj/structure/bed/dogbed{
-	pixel_x = -1;
-	pixel_y = 7
-	},
-/turf/open/floor/f13/wood,
+/obj/structure/bed/dogbed,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "hJg" = (
 /obj/structure/campfire/barrel,
@@ -11579,6 +11833,10 @@
 "hJG" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
+"hJM" = (
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hJQ" = (
 /obj/item/storage/trash_stack,
@@ -11610,6 +11868,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"hKQ" = (
+/obj/structure/chair/stool,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "hKY" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
@@ -11621,17 +11883,23 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"hLs" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outermaincornerouter";
+	tag = "icon-outermaincornerouter (WEST)"
+	},
+/area/f13/wasteland)
 "hLv" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/wasteland)
-"hMs" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
 "hMz" = (
 /obj/structure/stone_tile/block/burnt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11647,10 +11915,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "hMM" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetcmo"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "hMQ" = (
@@ -11673,6 +11941,27 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"hNw" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/item/clothing/under/f13/shiny,
+/obj/item/clothing/under/f13/shiny,
+/obj/item/clothing/under/f13/settler,
+/obj/item/clothing/under/f13/settler,
+/obj/item/clothing/under/f13/relaxedwear,
+/obj/item/clothing/under/f13/relaxedwear,
+/obj/item/clothing/under/f13/spring,
+/obj/item/clothing/under/f13/spring,
+/obj/structure/closet/cabinet,
+/obj/item/holybeacon,
+/obj/item/clothing/accessory/pocketprotector/cosmetology,
+/obj/item/clothing/under/rank/chaplain,
+/obj/item/clothing/shoes/sneakers/black,
+/obj/item/clothing/head/nun_hood,
+/obj/item/storage/backpack/cultpack,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hNC" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/desert,
@@ -11684,11 +11973,11 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "hNY" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/farm)
+/obj/structure/table/wood/fancy/black,
+/obj/item/folder/blue,
+/obj/item/pen,
+/turf/open/floor/plasteel/grimy,
+/area/f13/wasteland)
 "hNZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
@@ -11702,14 +11991,24 @@
 	},
 /area/f13/wasteland)
 "hOs" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowbottom"
 	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/wasteland)
+"hOC" = (
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/f13/legion)
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/building)
+"hOD" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "hOJ" = (
 /obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13/wood,
@@ -11719,21 +12018,9 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "hPL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "followersdeskshutters";
-	name = "followers shutters"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
-"hPV" = (
-/obj/structure/chair/wood/modern{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken2,
+/area/f13/legion)
 "hQr" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerturn"
@@ -11745,16 +12032,43 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"hQS" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/wasteland)
 "hRl" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"hRA" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft1";
+	tag = "icon-verticalrightborderleft1"
+	},
+/area/f13/wasteland)
+"hRF" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hRU" = (
 /obj/structure/closet/fridge/cannibal,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"hRZ" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "hSD" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -11767,16 +12081,6 @@
 	icon_state = "horizontaltopbordertop2"
 	},
 /area/f13/wasteland)
-"hTh" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "hTj" = (
 /obj/machinery/light{
 	dir = 8;
@@ -11799,29 +12103,6 @@
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"hTS" = (
-/obj/structure/table,
-/obj/machinery/light/fo13colored/Red{
-	bulb_colour = "#008000";
-	desc = "A lighting fixture.";
-	dir = 4;
-	light_color = "#008000";
-	name = "light tube"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Secret"
-	},
-/obj/machinery/light/fo13colored/Red{
-	bulb_colour = "#008000";
-	desc = "A lighting fixture.";
-	dir = 4;
-	light_color = "#008000";
-	name = "light tube"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "hTV" = (
 /obj/structure/tires/two,
 /turf/open/floor/f13/wood,
@@ -11842,12 +12123,20 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"hUm" = (
+/obj/effect/spawner/lootdrop/crafts,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hUv" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"hUG" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "hUK" = (
 /obj/structure/table/wood/fancy,
@@ -11867,6 +12156,12 @@
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
+"hUW" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "hVb" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/indestructible/ground/outside/road{
@@ -11874,18 +12169,11 @@
 	},
 /area/f13/wasteland)
 "hVd" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6";
-	pixel_x = -28
+/obj/structure/musician/piano{
+	desc = "What a wierd piano..";
+	name = "minimoog"
 	},
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/tires,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
+/turf/open/floor/wood/f13/carpet,
 /area/f13/wasteland)
 "hVp" = (
 /mob/living/simple_animal/hostile/handy,
@@ -11918,24 +12206,6 @@
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland)
-"hWq" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/structure/flora/grass/wasteland{
-	layer = 4.2;
-	pixel_x = -3
-	},
-/obj/structure/flora/tree/tall{
-	layer = 4;
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33"
-	},
-/area/f13/wasteland)
 "hWJ" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -11950,11 +12220,15 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"hXu" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hXv" = (
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/turf/open/floor/plasteel/chapel{
+	dir = 9
 	},
-/area/f13/village)
+/area/f13/wasteland)
 "hXP" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/outside/road{
@@ -11968,10 +12242,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"hYe" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
 "hYh" = (
 /obj/item/clothing/shoes/laceup,
 /turf/open/floor/f13/wood,
@@ -11995,32 +12265,47 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"hYI" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (NORTH)"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/building)
 "hYJ" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"hYR" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "hYZ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"hZo" = (
-/obj/structure/musician/piano,
-/obj/effect/decal/cleanable/dirt,
+"hZm" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8;
+	tag = "icon-comfychair (WEST)"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"hZs" = (
+/obj/structure/chair/wood/worn{
+	dir = 4
+	},
 /turf/open/floor/f13/wood,
-/area/f13/city)
+/area/f13/wasteland)
 "hZv" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
+	},
 /area/f13/village)
 "hZw" = (
 /obj/structure/fence/corner/wooden{
@@ -12078,14 +12363,17 @@
 /obj/structure/stone_tile/block/cracked,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ibs" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#845f58"
+"ibg" = (
+/obj/structure/rack,
+/obj/item/kitchen/fork{
+	pixel_x = 8;
+	pixel_y = 2
 	},
-/obj/structure/window/fulltile/wood,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "ibA" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/outside/desert,
@@ -12173,6 +12461,16 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/ncr)
+"iec" = (
+/obj/structure/fence/corner/wooden{
+	dir = 1
+	},
+/obj/structure/fence/corner/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "iem" = (
 /obj/structure/fence{
 	dir = 1
@@ -12223,6 +12521,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"ifs" = (
+/obj/structure/fence{
+	dir = 8;
+	icon_state = "straight"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ifQ" = (
 /obj/effect/landmark/start/f13/ncrcombatmedic,
 /turf/open/floor/f13{
@@ -12241,12 +12546,7 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
 "igy" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32"
-	},
+/turf/open/floor/wood,
 /area/f13/wasteland)
 "igz" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12259,10 +12559,6 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"ihm" = (
-/obj/effect/landmark/start/f13/shopkeeper,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "iic" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/kitchen{
@@ -12294,22 +12590,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"iiG" = (
-/obj/structure/flora/tree/tall{
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
-"iiH" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Mayor's Office";
-	req_one_access_txt = "62"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "iiN" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -12325,11 +12605,24 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
-"ijm" = (
-/obj/structure/simple_door/metal/fence,
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+"ijl" = (
+/obj/structure/closet/cabinet,
+/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/syringe/medx,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"ijs" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "interiorgate"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland)
+"ijv" = (
+/obj/structure/statue/wood/headstonewood,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ijO" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -12360,30 +12653,14 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ilc" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "ilh" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/turf/open/floor/wood/f13/carpet,
+/area/f13/wasteland)
 "ill" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
 /turf/closed/mineral/random/low_chance,
 /area/f13/brotherhood)
-"ilq" = (
-/obj/structure/chair/wood/modern{
-	dir = 8;
-	icon_state = "wooden_chair_old"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "ilu" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -12399,10 +12676,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"ilI" = (
-/obj/structure/chair/pew/left,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "ilL" = (
 /obj/structure/fence{
 	dir = 4
@@ -12412,15 +12685,15 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ilM" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_7"
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/turf/open/water,
-/area/f13/radiation)
+/turf/open/floor/wood/f13/carpet,
+/area/f13/wasteland)
 "ime" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "imk" = (
 /obj/item/ammo_casing/a50MG,
@@ -12453,10 +12726,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
-"inc" = (
-/obj/machinery/vending/games,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"inj" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/building)
 "inl" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /obj/effect/decal/cleanable/dirt,
@@ -12476,6 +12753,13 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2"
 	},
+/area/f13/wasteland)
+"inI" = (
+/obj/structure/fence/corner{
+	dir = 6;
+	icon_state = "corner"
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "inO" = (
 /obj/machinery/light/small{
@@ -12499,15 +12783,41 @@
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
+"ioQ" = (
+/obj/structure/flora/grass/wasteland{
+	layer = 4.2;
+	pixel_x = -3
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole";
+	tag = "icon-hole"
+	},
+/area/f13/wasteland)
 "ioU" = (
-/obj/structure/chair/stool,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner"
+	},
+/area/f13/wasteland)
+"ioV" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"ipj" = (
-/obj/machinery/smartfridge/drying_rack,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
+"ioY" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
+"ipm" = (
+/obj/structure/chair/stool{
+	icon_state = "bench_center"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ipn" = (
 /obj/structure/chair/wood/fancy{
 	dir = 4
@@ -12519,9 +12829,12 @@
 /obj/item/storage/backpack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"ipS" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+"ipG" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "iqx" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice,
@@ -12533,6 +12846,10 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
+"iqF" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "iqH" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical/old,
@@ -12557,6 +12874,12 @@
 /obj/structure/stone_tile/surrounding/burnt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"irf" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "irk" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -12579,15 +12902,6 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"ish" = (
-/obj/structure/chair/pew,
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"isv" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/breadhard,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "isy" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood{
@@ -12609,14 +12923,13 @@
 	},
 /area/f13/legion)
 "isL" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table/wood/poker,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_x = 30
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/wasteland)
 "isO" = (
 /obj/item/radio/intercom{
@@ -12650,13 +12963,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"itI" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright2"
-	},
-/area/f13/wasteland)
 "itJ" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -12668,10 +12974,28 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"itU" = (
+/obj/structure/kitchenspike,
+/obj/structure/decoration/hatch{
+	dir = 1;
+	layer = 2.5
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "itY" = (
 /obj/structure/table/wood,
 /obj/item/lighter,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"iub" = (
+/obj/structure/decoration/sign{
+	desc = "It's a portrait of a person you don't know anything about.";
+	icon_state = "painting_president";
+	name = "portrait"
+	},
+/turf/closed/wall/f13/wood,
 /area/f13/building)
 "iul" = (
 /obj/structure/chair/comfy/black{
@@ -12686,6 +13010,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
+"iuG" = (
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "iuS" = (
 /obj/structure/chair/wood/modern{
 	dir = 4;
@@ -12694,12 +13022,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ivi" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_y = -11
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (NORTH)"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ivJ" = (
 /obj/structure/table/glass,
 /turf/open/floor/f13,
@@ -12721,11 +13050,9 @@
 	},
 /area/f13/building)
 "iwm" = (
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/f13/village)
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
 "iwp" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -12745,6 +13072,20 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ixu" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
+"ixC" = (
+/obj/structure/table/wood,
+/obj/structure/wreck/trash/one_tire{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland)
 "ixG" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13,
@@ -12760,23 +13101,10 @@
 /mob/living/simple_animal/hostile/wolf/alpha,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"iyo" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermainbottom"
-	},
-/area/f13/wasteland)
-"iys" = (
-/obj/structure/fence/corner,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "iyu" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/legion)
+/obj/structure/chair/bench,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "iyv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
@@ -12825,6 +13153,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"iAm" = (
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "iAz" = (
 /obj/structure/bed,
 /turf/open/floor/f13/wood,
@@ -12842,6 +13176,17 @@
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"iAX" = (
+/obj/structure/cable{
+	icon_state = "0-5";
+	tag = "icon-0-5"
+	},
+/obj/structure/cable{
+	icon_state = "0-9";
+	tag = "icon-0-9"
+	},
+/turf/open/floor/plating,
+/area/f13/caves)
 "iBo" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -12849,14 +13194,9 @@
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
 "iBv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
-	},
-/area/f13/wasteland)
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall/rust,
+/area/f13/building)
 "iBF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -12876,8 +13216,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"iBO" = (
+/obj/structure/bed/mattress/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "iBT" = (
-/obj/item/flag/oasis,
+/obj/machinery/mineral/wasteland_vendor/attachments{
+	icon_state = "weapon_idle"
+	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "iCx" = (
@@ -12896,16 +13242,15 @@
 /obj/structure/rack,
 /obj/item/flashlight/lantern,
 /obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
+"iDJ" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
 	},
-/area/f13/legion)
-"iDX" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/crafting/armor_plate/ten,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "iEg" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -12915,11 +13260,28 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"iEn" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
+	},
+/area/f13/wasteland)
 "iEp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"iEQ" = (
+/obj/machinery/icecream_vat,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "iEX" = (
 /obj/structure/rack,
 /obj/item/storage/fancy/cracker_pack,
@@ -12942,8 +13304,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "iFr" = (
-/obj/structure/cargocrate,
-/turf/open/indestructible/ground/outside/desert,
+/obj/machinery/mineral/wasteland_vendor/crafting{
+	icon_state = "parts_idle"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
 /area/f13/wasteland)
 "iFI" = (
 /turf/closed/wall/r_wall/rust,
@@ -12970,12 +13336,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"iGd" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "iGi" = (
 /obj/machinery/light,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -12983,10 +13343,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"iGt" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"iGk" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "iGE" = (
 /obj/structure/toilet{
 	dir = 1
@@ -13002,16 +13367,14 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"iGN" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "iGO" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iGP" = (
-/obj/structure/statue/sandstone/gravestone,
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
 /area/f13/wasteland)
 "iGS" = (
 /obj/machinery/computer/slot_machine,
@@ -13045,6 +13408,11 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"iHr" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/building)
 "iHt" = (
 /obj/structure/bed/mattress,
 /obj/effect/landmark/start/f13/pusher,
@@ -13062,6 +13430,13 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"iHP" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/building)
 "iHQ" = (
@@ -13093,6 +13468,12 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"iIc" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole";
+	tag = "icon-hole"
+	},
+/area/f13/wasteland)
 "iIi" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_tl,
@@ -13109,14 +13490,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/ncr)
-"iIz" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
 "iID" = (
 /obj/structure/chair/booth{
 	dir = 8
@@ -13140,14 +13513,10 @@
 	},
 /area/f13/wasteland)
 "iIS" = (
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
+/turf/open/floor/plasteel/chapel{
+	dir = 4
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/barber{
-	icon_state = "plating"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "iJc" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -13161,6 +13530,16 @@
 /obj/item/clothing/under/f13/raiderharness,
 /turf/open/floor/f13,
 /area/f13/building)
+"iJw" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
+"iJG" = (
+/obj/item/instrument/guitar,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "iJJ" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/small/broken{
@@ -13172,6 +13551,14 @@
 /obj/structure/table/wood,
 /obj/item/clothing/under/f13/raiderrags,
 /turf/open/floor/f13,
+/area/f13/building)
+"iJS" = (
+/obj/structure/table/wood/settler,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "iJW" = (
 /obj/structure/chair/comfy/brown{
@@ -13204,20 +13591,6 @@
 /obj/item/clothing/under/f13/female/tribal,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"iLc" = (
-/turf/closed/wall/f13/wood/house,
-/area/f13/city)
-"iLr" = (
-/obj/structure/closet/cabinet,
-/obj/item/storage/backpack{
-	icon_state = "satchel"
-	},
-/obj/item/storage/backpack{
-	icon_state = "satchel"
-	},
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "iLD" = (
 /obj/item/seeds/cannabis,
 /obj/item/seeds/cannabis,
@@ -13231,29 +13604,39 @@
 "iLQ" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/caves)
 "iMc" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/effect/spawner/lootdrop/trash,
+/obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"iMi" = (
-/obj/structure/closet/crate/grave,
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"iMV" = (
-/mob/living/simple_animal/hostile/wolf{
-	desc = "The dogs that survived the Great War are a larger, and tougher breed, size of a wolf.<br>This one seems to be a very good boy.";
-	faction = list("neutral");
-	health = 200;
-	maxHealth = 200;
-	name = "Runt";
-	tame = 1
+"iMd" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/carpet/airless,
+/area/f13/legion)
+"iMi" = (
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/turf/open/floor/f13/wood,
+/area/f13/building)
+"iMl" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/city)
+"iMJ" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/pill/patch/turbo,
+/obj/item/reagent_containers/pill/patch/turbo,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "iNb" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -13303,51 +13686,28 @@
 /area/f13/wasteland)
 "iNI" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
-"iNN" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Private"
+"iNO" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/turf/open/floor/wood,
-/area/f13/village)
+/area/f13/building)
 "iNQ" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"iNR" = (
-/obj/structure/table/wood/poker,
-/obj/item/chair/stool/retro/black,
-/obj/item/chair/stool/retro/black,
-/obj/item/chair/stool/retro/black,
-/obj/item/chair/stool/retro/black,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "iNU" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
-"iNX" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/city)
-"iOd" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/building)
 "iOg" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
@@ -13370,14 +13730,24 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"iOv" = (
+/obj/machinery/button/door{
+	id = "frontgateshut";
+	name = "gate shutters";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "iOB" = (
 /obj/effect/landmark/poster_spawner/prewar,
 /turf/closed/wall/f13/store,
 /area/f13/village)
 "iOF" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/plasteel/barber{
-	icon_state = "plating"
+/obj/structure/table/wood/settler,
+/obj/item/flashlight/lamp,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/building)
 "iOM" = (
@@ -13414,24 +13784,25 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
-"iPW" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
+"iPN" = (
+/obj/structure/decoration/hatch{
+	dir = 1;
+	layer = 2.5
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/wasteland)
+"iPY" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "iQs" = (
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood/f13,
 /area/f13/building)
-"iQK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/city)
 "iQR" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -13491,6 +13862,11 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/village)
+"iRz" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "iRC" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -13499,17 +13875,12 @@
 	},
 /area/f13/wasteland)
 "iRE" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_y = 12
-	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "hole"
-	},
+/obj/item/twohanded/required/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/grimy,
+/area/f13/wasteland)
+"iRN" = (
+/obj/structure/closet/crate/wicker,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "iRT" = (
 /obj/structure/curtain{
@@ -13563,31 +13934,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "iSE" = (
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
+/turf/open/floor/plasteel/grimy,
 /area/f13/wasteland)
-"iSH" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"iSV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
 "iTk" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -13626,23 +13974,27 @@
 /obj/item/clothing/under/f13/pinkdress,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"iTV" = (
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/obj/structure/fence/corner/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "iTX" = (
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"iVd" = (
-/obj/machinery/light/small{
-	dir = 4
+"iVc" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/city)
-"iVn" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Mayor's Office";
-	req_one_access_txt = "62"
-	},
-/turf/open/floor/carpet/black,
 /area/f13/city)
 "iVE" = (
 /obj/structure/flora/grass/wasteland{
@@ -13668,8 +14020,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "iWi" = (
-/obj/structure/simple_door/metal/fence,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/simple_door/glass,
+/turf/open/floor/wood,
 /area/f13/wasteland)
 "iWV" = (
 /obj/structure/table/wood,
@@ -13678,13 +14030,23 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"iWW" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	layer = 2;
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "iXi" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "iXz" = (
-/obj/structure/closet/crate/grave/lead_researcher,
-/turf/open/indestructible/ground/outside/desert,
+/obj/machinery/light/small/broken,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/wasteland)
 "iXX" = (
 /obj/structure/rack,
@@ -13713,6 +14075,15 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"iYP" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical";
+	tag = "icon-housewindowvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "iYY" = (
 /obj/structure/chair/sofa/corp/corner,
 /obj/effect/decal/cleanable/dirt,
@@ -13732,6 +14103,17 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"iZE" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "jae" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -13831,14 +14213,29 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "jcl" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/item/storage/trash_stack,
+/mob/living/simple_animal/hostile/gecko,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"jcn" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
 /area/f13/building)
 "jcp" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"jcu" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/knife,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/building)
 "jcB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
@@ -13853,6 +14250,12 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"jdv" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "jdE" = (
 /obj/machinery/light{
 	dir = 8
@@ -13862,6 +14265,17 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
+"jdK" = (
+/obj/structure/spider/stickyweb,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "jei" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -13887,17 +14301,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"jeX" = (
-/obj/structure/chair/office,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "jfu" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/mob/living/simple_animal/hostile/wolf/alpha{
+	desc = "Legion mongrels are dogs owned and bred by the Houndmasters of Caesar's Legion. Mongrels are mainly used in combat and scouting missions by the Legion.";
+	faction = list("neutral");
+	name = "Brutus"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "jfx" = (
 /obj/structure/fence/wooden{
@@ -13911,9 +14322,6 @@
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/wood,
 /area/f13/village)
-"jfV" = (
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/city)
 "jgq" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -13979,11 +14387,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jhx" = (
-/obj/structure/kitchenspike,
+/obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
+"jhB" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertopleft";
+	tag = "icon-horizontaltopbordertopleft"
+	},
+/area/f13/wasteland)
 "jix" = (
 /obj/machinery/autolathe/constructionlathe,
 /obj/machinery/light{
@@ -13999,11 +14413,12 @@
 	},
 /area/f13/ncr)
 "jiP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+/obj/structure/table/wood/poker,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = -30
 	},
+/turf/open/floor/wood/f13/carpet,
 /area/f13/wasteland)
 "jiR" = (
 /obj/structure/table/reinforced,
@@ -14020,18 +14435,22 @@
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/rust,
 /area/f13/caves)
+"jiX" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jjU" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"jkj" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+"jkh" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
-/obj/effect/landmark/start/f13/mayor,
-/turf/open/floor/carpet/black,
-/area/f13/city)
+/area/f13/building)
 "jkk" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -14067,13 +14486,19 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"jlB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+"jkY" = (
+/obj/machinery/light/small,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/wasteland)
+/area/f13/city)
+"jlB" = (
+/obj/structure/chair/wood/worn{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jlT" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14084,14 +14509,22 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"jml" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheethos"
+"jmm" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_y = 12
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
+	},
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 12
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole"
+	},
+/area/f13/wasteland)
 "jmq" = (
 /obj/item/clothing/head/f13/rastacap,
 /obj/structure/closet/cabinet,
@@ -14121,12 +14554,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"jmz" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright"
+"jmY" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 10
 	},
+/obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
-/area/f13/city)
+/area/f13/wasteland)
 "jmZ" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -14178,6 +14613,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"jnV" = (
+/obj/structure/decoration/clock{
+	pixel_y = 21
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "jnW" = (
 /obj/structure/rack,
 /obj/item/restraints/handcuffs,
@@ -14200,6 +14644,25 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_r,
 /area/f13/bar)
+"jpd" = (
+/obj/structure/table,
+/obj/item/pen{
+	pixel_y = 9
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
+"jpr" = (
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jps" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
@@ -14239,6 +14702,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"jqM" = (
+/mob/living/simple_animal/hostile/cazador/young,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "jrx" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14257,17 +14726,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"jrX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop2"
-	},
-/area/f13/wasteland)
-"jsP" = (
+"jsw" = (
+/obj/machinery/smartfridge/drying_rack,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"jsX" = (
+/obj/structure/wreck/trash/engine,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/farm)
+/area/f13/wasteland)
 "jtc" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -14294,15 +14762,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"jtu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/city)
 "juc" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -14331,22 +14790,25 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/ncr)
-"juV" = (
-/obj/effect/landmark/start/f13/ncrlogisticsofficer,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/ncr)
+"jvt" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "jvw" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"jvA" = (
-/obj/machinery/smartfridge/chemistry,
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
+"jvN" = (
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "jvT" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -14463,14 +14925,24 @@
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/effect/landmark/start/f13/decanvet,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"jyl" = (
+/obj/structure/wreck/car,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "jyC" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"jyF" = (
+/obj/structure/campfire,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "jzn" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -14493,22 +14965,38 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"jzN" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical"
-	},
+"jzC" = (
+/obj/machinery/microwave/stove,
+/obj/effect/decal/cleanable/salt,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"jAf" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
+"jzN" = (
+/obj/structure/table/wood/poker,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_x = 30
 	},
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = -30
+	},
+/turf/open/floor/wood/f13/carpet,
 /area/f13/wasteland)
+"jAf" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowleft";
+	layer = 2
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "storeshutters";
+	name = "store shutters"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jAi" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/wood/f13/carpet,
@@ -14519,6 +15007,15 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/brotherhood)
+"jAK" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "jAZ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -14556,6 +15053,12 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"jCg" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "jCC" = (
 /obj/structure/musician/piano,
 /turf/open/floor/f13{
@@ -14577,27 +15080,38 @@
 	},
 /area/f13/caves)
 "jEd" = (
-/obj/structure/rack,
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/floor/plasteel/chapel{
+	dir = 10
+	},
 /area/f13/wasteland)
+"jEl" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/knife,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "jEp" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
 /area/f13/legion)
+"jEP" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
 "jEX" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/turf/open/floor/plasteel/chapel{
+	dir = 6
 	},
 /area/f13/wasteland)
 "jFb" = (
-/obj/structure/sign/poster/ripped{
-	pixel_x = -32
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2top"
+/turf/open/floor/plasteel/chapel{
+	dir = 8
 	},
 /area/f13/wasteland)
 "jFl" = (
@@ -14607,9 +15121,9 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "jGl" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
 "jGz" = (
@@ -14634,9 +15148,12 @@
 	},
 /area/f13/village)
 "jIe" = (
-/obj/structure/campfire,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outermaincornerouter";
+	tag = "icon-outermaincornerouter (NORTH)"
+	},
+/area/f13/wasteland)
 "jIf" = (
 /mob/living/simple_animal/hostile/ghoul{
 	name = "Jim"
@@ -14647,7 +15164,7 @@
 /obj/structure/curtain{
 	color = "#845f58"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "jIB" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14693,12 +15210,32 @@
 /obj/item/clothing/suit/f13/sexymaid,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"jKV" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+"jKq" = (
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench";
+	tag = "icon-bench (WEST)"
 	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
+	},
+/area/f13/wasteland)
+"jKx" = (
+/obj/structure/closet/cabinet,
+/obj/item/storage/backpack{
+	icon_state = "satchel"
+	},
+/obj/item/storage/backpack{
+	icon_state = "satchel"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13/wood,
 /area/f13/building)
+"jKV" = (
+/turf/open/floor/plasteel/chapel,
+/area/f13/wasteland)
 "jLK" = (
 /obj/structure/closet,
 /obj/item/clothing/gloves/combat,
@@ -14710,64 +15247,53 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"jLV" = (
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
 "jMj" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/radiation)
-"jMz" = (
-/obj/structure/table/wood/fancy,
-/obj/item/restraints/handcuffs,
-/obj/item/melee/chainofcommand/tailwhip/kitty,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+"jMy" = (
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gibtorso"
+	},
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "jMC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "outermaincornerouter"
 	},
 /area/f13/wasteland)
-"jME" = (
-/obj/structure/girder/reinforced,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "jMN" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
 /area/f13/village)
-"jNj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
+"jMO" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
+	},
 /area/f13/wasteland)
+"jNj" = (
+/obj/structure/table/wood/settler,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "jNl" = (
-/obj/structure/table,
-/turf/open/floor/f13/wood,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"jNs" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/white/box,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/item/stack/crafting/armor_plate/ten,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
 "jNt" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -14802,17 +15328,23 @@
 /obj/item/shovel,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"jPG" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
+"jPE" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright2";
+	tag = "icon-verticalrightborderright2"
 	},
+/area/f13/wasteland)
+"jPG" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "jPN" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/structure/fence{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
 "jQd" = (
@@ -14823,6 +15355,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"jQq" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/item/stack/sheet/cardboard,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "jQt" = (
 /obj/machinery/washing_machine{
 	pixel_y = 7
@@ -14883,17 +15427,26 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"jRv" = (
+/obj/structure/lamp_post/quadra,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland)
 "jRQ" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "jRU" = (
-/obj/machinery/grill,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verylittleshadowright"
+/obj/structure/chair/comfy{
+	dir = 1
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "jRV" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/mug/coco,
@@ -14946,6 +15499,22 @@
 	icon_state = "dirt"
 	},
 /area/f13/legion)
+"jTQ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
+"jTR" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1";
+	tag = "icon-horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "jTX" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/button{
@@ -14957,17 +15526,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"jTY" = (
-/obj/machinery/button/door{
-	id = "prospectorshutters";
-	name = "gate shutters";
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/city)
 "jTZ" = (
 /obj/structure/closet,
 /turf/open/floor/f13{
@@ -14994,12 +15552,30 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13,
 /area/f13/building)
+"jUv" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/building)
+"jUw" = (
+/obj/structure/chair/wood/modern,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
+	},
+/area/f13/building)
 "jUS" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
+"jVg" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jVl" = (
 /obj/structure/fence/corner/wooden{
 	dir = 8
@@ -15098,6 +15674,13 @@
 "jXj" = (
 /turf/open/indestructible,
 /area/f13/tcoms)
+"jXm" = (
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench_center"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "jXu" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15107,18 +15690,21 @@
 /obj/item/stack/rods,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"jXV" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/light/small/broken,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+"jXw" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertopright";
+	tag = "icon-horizontaltopbordertopright"
 	},
-/area/f13/village)
+/area/f13/wasteland)
 "jYn" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"jYo" = (
+/obj/structure/simple_door/room,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "jYw" = (
 /obj/machinery/seed_extractor,
@@ -15147,14 +15733,22 @@
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"jZk" = (
-/obj/machinery/camera{
-	dir = 8;
-	name = "farm";
-	network = list("oasis")
+"jZg" = (
+/obj/structure/tires/two{
+	pixel_x = -5;
+	pixel_y = 6
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
 /area/f13/wasteland)
+"jZk" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "jZx" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -15168,14 +15762,25 @@
 	},
 /area/f13/wasteland)
 "jZL" = (
-/obj/structure/closet,
-/obj/item/storage/backpack/satchel/leather,
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetbrown"
+	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "jZM" = (
-/obj/structure/bed/dogbed,
-/turf/open/floor/f13/wood,
+/obj/structure/dresser,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
+"kaj" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft2";
+	tag = "icon-verticalrightborderleft2"
+	},
+/area/f13/wasteland)
 "kas" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -15236,18 +15841,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"kcc" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
-"kcw" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "clinicoutsideladder";
-	layer = 2
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
 "kcD" = (
 /obj/machinery/light{
 	dir = 1
@@ -15263,21 +15856,17 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"kcP" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
 "kcQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken (NORTHEAST)"
 	},
-/area/f13/wasteland)
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "kcX" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -15287,11 +15876,21 @@
 	},
 /area/f13/building)
 "kcY" = (
-/obj/structure/decoration/hatch{
-	dir = 8
+/obj/item/twohanded/required/kirbyplants/dead,
+/turf/open/floor/wood,
+/area/f13/building)
+"kcZ" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
 	},
-/turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/processor/chopping_block,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "kdg" = (
 /obj/structure/chair/wood/modern{
 	dir = 4;
@@ -15303,31 +15902,27 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kdi" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
-/area/f13/wasteland)
-"kdu" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/turf/open/floor/plasteel/chapel,
+/area/f13/building)
 "kdJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermaintop"
 	},
 /area/f13/wasteland)
 "kdS" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 1
+/obj/item/flag,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
 	},
-/area/f13/village)
+/area/f13/wasteland)
+"keg" = (
+/obj/item/ammo_casing/caseless{
+	dir = 10;
+	icon_state = "sS-casing";
+	tag = "icon-sS-casing (SOUTHWEST)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kex" = (
 /obj/item/clothing/head/helmet/f13/brahmincowboyhat,
 /obj/item/clothing/suit/armor/f13/brahmin_leather_duster,
@@ -15349,15 +15944,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
-"kfh" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "followershutters";
-	name = "followers shutters"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "kfo" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -15370,13 +15956,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "kfx" = (
-/obj/structure/sign/poster/prewar/poster62{
-	pixel_x = -32
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood,
+/area/f13/building)
 "kfz" = (
 /obj/structure/fence/corner/wooden{
 	dir = 4
@@ -15393,14 +15975,12 @@
 	},
 /area/f13/building)
 "kfJ" = (
-/obj/structure/fence/end{
-	dir = 8
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/light/small/broken,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "kfU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/four_barrels,
@@ -15412,6 +15992,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
+"kgd" = (
+/obj/structure/table/wood/settler,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/phone,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kgy" = (
 /obj/structure/sign/sing/ratnest,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15463,6 +16051,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"khJ" = (
+/obj/structure/bed/mattress,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
 "khU" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood{
@@ -15481,47 +16077,29 @@
 /obj/structure/chair,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
-"kin" = (
-/obj/structure/closet,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/disk/surgery/oasis,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+"kiB" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderrightbottom";
+	tag = "icon-verticalrightborderrightbottom"
+	},
+/area/f13/wasteland)
 "kiL" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
-"kiP" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/cash_legion_high,
-/obj/effect/spawner/lootdrop/f13/cash_legion_high,
-/obj/item/stack/f13Cash/random/aureus/low,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "kiW" = (
-/obj/structure/fence{
-	dir = 1
+/obj/structure/fence/corner,
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"kjF" = (
+/obj/effect/landmark/start/f13/settler,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
-"kjB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetcmo"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/wasteland)
 "kjI" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/attachments,
@@ -15538,17 +16116,19 @@
 "kjR" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"kjX" = (
+/obj/structure/table,
+/obj/structure/table,
+/obj/item/wirecutters{
+	icon_state = "cutters";
+	tag = "icon-cutters"
+	},
+/turf/open/floor/plating,
+/area/f13/caves)
 "kkD" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"kkE" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/carpet,
-/area/f13/city)
 "klp" = (
 /obj/structure/closet/fridge/standard,
 /obj/item/storage/box/ingredients/american,
@@ -15558,14 +16138,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
-"klx" = (
-/obj/structure/table,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "klA" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
@@ -15579,20 +16151,6 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/village)
-"klI" = (
-/obj/machinery/trading_machine/medical,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
-"kmn" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/machinery/door/poddoor/shutters{
-	id = "barshutters"
-	},
-/obj/structure/table/wood/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "kmv" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -15608,25 +16166,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"kmQ" = (
-/obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/condiment/yeast,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
-/area/f13/village)
-"knw" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "prospectorladder";
-	layer = 2
+"kne" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/city)
+/area/f13/wasteland)
 "koc" = (
 /obj/machinery/light{
 	dir = 1;
@@ -15635,6 +16181,14 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"kom" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "kow" = (
 /obj/machinery/processor,
@@ -15664,7 +16218,7 @@
 /area/f13/brotherhood)
 "kpd" = (
 /obj/structure/campfire/stove,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "kpe" = (
 /obj/structure/rack,
@@ -15703,12 +16257,6 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
-"kpL" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/city)
 "kpM" = (
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/desert,
@@ -15730,21 +16278,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"kqe" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "kqk" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"kqn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "kqx" = (
 /obj/effect/decal/cleanable/blood/gibs{
 	icon_state = "gibtorso"
@@ -15772,11 +16309,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
-"krd" = (
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
 "krk" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -15790,15 +16322,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"kru" = (
-/obj/structure/destructible/tribal_torch{
-	layer = 3.1;
-	pixel_y = 20
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
 "krJ" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15811,12 +16334,25 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"krR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland)
 "krS" = (
 /obj/structure/fence/wooden{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"ksp" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "ktB" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
@@ -15827,15 +16363,15 @@
 	},
 /area/f13/wasteland)
 "ktX" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/toilet{
+	dir = 4;
+	pixel_x = -1
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/structure/curtain,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/area/f13/building)
 "kur" = (
 /obj/structure/table/wood/fancy,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -15843,10 +16379,15 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "kut" = (
-/obj/structure/destructible/tribal_torch,
+/obj/structure/fence{
+	dir = 8
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+	dir = 5;
+	icon_state = "dirt"
 	},
 /area/f13/legion)
 "kuI" = (
@@ -15861,27 +16402,33 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"kuZ" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"kve" = (
+/obj/item/clothing/under/f13/tribal,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"kvr" = (
+/obj/structure/simple_door/tentflap_cloth{
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "kvB" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"kvT" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/farm)
-"kvZ" = (
-/obj/item/bedsheet/random,
-/obj/structure/bed,
-/turf/open/floor/carpet/black,
-/area/f13/city)
+"kvC" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "kwe" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2left"
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "kwi" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass,
@@ -15889,6 +16436,22 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"kws" = (
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalcorroded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
+"kwy" = (
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 12
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "kwA" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/xeno,
@@ -15920,16 +16483,14 @@
 	},
 /area/f13/wasteland)
 "kxq" = (
-/obj/item/pet_carrier{
-	pixel_x = 4;
-	pixel_y = 7
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
 	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old"
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/building)
 "kxv" = (
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/carpet/black,
@@ -15958,6 +16519,20 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"kyu" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
+	},
+/area/f13/building)
+"kyA" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
+	},
+/area/f13/wasteland)
 "kyT" = (
 /obj/structure/chair/sofa/corp/corner,
 /obj/effect/decal/cleanable/dirt,
@@ -15967,6 +16542,17 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"kzl" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"kzr" = (
+/obj/structure/table/wood/settler,
+/obj/item/flashlight/lantern,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kzs" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16010,6 +16596,11 @@
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"kzW" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/building)
 "kAa" = (
 /obj/structure/chair/wood/worn{
 	dir = 8
@@ -16049,33 +16640,10 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
-"kBr" = (
-/obj/item/clothing/suit/f13/duster,
-/obj/item/clothing/suit/f13/autumn,
-/obj/item/clothing/gloves/f13/leather,
-/obj/item/clothing/head/f13/cowboy,
-/obj/item/clothing/under/f13/cowboyb,
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/obj/item/clothing/head/collectable/police/cos{
-	name = "Chief of Police Hat"
-	},
-/obj/item/clothing/suit/armor/vest/leather,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/glasses/orange,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"kBC" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters{
-	id = "frontgateshut";
-	name = "gate shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+"kBa" = (
+/obj/structure/sign/departments/medbay,
+/turf/closed/wall/f13/supermart,
+/area/f13/building)
 "kBG" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticaldegraded"
@@ -16099,28 +16667,31 @@
 	icon_state = "verticalleftborderright2bottom"
 	},
 /area/f13/wasteland)
-"kCA" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/city)
 "kCH" = (
 /obj/structure/pondlily_small,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"kCS" = (
+/obj/structure/table/wood/settler,
+/obj/item/stack/sheet/cloth,
+/obj/item/candle/infinite,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"kDd" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters{
+	id = "frontgateshut";
+	name = "gate shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "kDj" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building)
-"kDm" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "kDx" = (
 /obj/structure/sink{
@@ -16149,9 +16720,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"kEh" = (
-/turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
 "kEi" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -16193,6 +16761,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"kFf" = (
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "kFi" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/f13/wood,
@@ -16216,6 +16788,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
+"kFW" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder";
+	tag = "icon-outerborder (EAST)"
+	},
+/area/f13/wasteland)
 "kGc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 7;
@@ -16234,10 +16813,36 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"kGI" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "kGL" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
+"kGP" = (
+/obj/item/clothing/suit/f13/duster,
+/obj/item/clothing/suit/f13/autumn,
+/obj/item/clothing/gloves/f13/leather,
+/obj/item/clothing/head/f13/cowboy,
+/obj/item/clothing/under/f13/cowboyb,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/obj/item/clothing/head/collectable/police/cos{
+	name = "Chief of Police Hat"
+	},
+/obj/item/clothing/suit/armor/vest/leather,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/glasses/orange,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kGV" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
@@ -16270,6 +16875,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"kHQ" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/decal/remains/human,
+/obj/item/clothing/suit/armor/f13/tribal,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kHU" = (
 /obj/structure/table/wood,
 /obj/item/binoculars,
@@ -16283,15 +16894,30 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"kIq" = (
+/obj/structure/chair/wood/modern{
+	dir = 8;
+	icon_state = "wooden_chair_settler"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kIs" = (
 /obj/machinery/workbench,
 /obj/item/instrument/trumpet,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"kIM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/f13/building)
 "kIZ" = (
-/obj/structure/reagent_dispensers/barrel/three,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/building)
 "kJu" = (
 /obj/structure/anvil/obtainable/basic,
 /turf/open/indestructible/ground/inside/dirt,
@@ -16302,6 +16928,16 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kJP" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/storage/backpack/satchel/leather,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "kKe" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -16329,11 +16965,12 @@
 	},
 /area/f13/legion)
 "kKZ" = (
-/obj/effect/spawner/structure/window/reinforced/indestructable,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
+/obj/structure/bonfire,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
+"kLh" = (
+/obj/structure/closet/crate/coffin,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "kLv" = (
 /obj/machinery/light/small{
@@ -16367,6 +17004,12 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"kMs" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "kMu" = (
 /obj/structure/fermenting_barrel,
 /obj/effect/decal/fakelattice{
@@ -16389,12 +17032,11 @@
 /obj/machinery/mineral/wasteland_vendor/clothing,
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
-"kNH" = (
-/obj/effect/landmark/start/f13/deputy,
-/obj/structure/chair/bench,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"kND" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "kNT" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/mortar{
@@ -16407,12 +17049,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"kNV" = (
-/obj/machinery/trading_machine/medical,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+"kOi" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/f13/followers)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "kOx" = (
 /obj/structure/sign/poster/prewar/poster86,
 /turf/closed/wall/f13/wood/house,
@@ -16430,6 +17076,21 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"kPF" = (
+/obj/structure/bed/mattress,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/building)
+"kPI" = (
+/obj/machinery/door/morgue,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"kPT" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "kPX" = (
 /obj/structure/fence/corner/wooden{
 	dir = 8
@@ -16440,31 +17101,28 @@
 	},
 /area/f13/legion)
 "kPZ" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/barricade/wooden,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/building)
+"kQe" = (
+/obj/structure/bus_door,
+/turf/open/indestructible/ground/outside/road{
+	dir = 4;
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter (EAST)"
+	},
+/area/f13/wasteland)
 "kQq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/brotherhood)
 "kQC" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
+/obj/structure/lamp_post/quadra,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"kQE" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/chapel{
-	dir = 1
-	},
-/area/f13/village)
 "kQJ" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/metal{
@@ -16473,8 +17131,12 @@
 /obj/item/stack/sheet/glass{
 	amount = 50
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"kRf" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "kRD" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -16486,16 +17148,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
 "kSt" = (
-/obj/structure/chair/wood,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
+/obj/structure/chair/bench,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"kSK" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "kTf" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16513,15 +17168,19 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"kTz" = (
+/obj/structure/fence/wooden{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "kTP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/item/restraints/legcuffs/bola,
 /obj/item/restraints/legcuffs/bola,
 /obj/item/restraints/legcuffs/bola,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "kUd" = (
 /obj/structure/barricade/wooden,
@@ -16585,6 +17244,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"kVm" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kVq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -16593,6 +17260,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
+"kVO" = (
+/obj/structure/chair/wood/modern{
+	dir = 4;
+	icon_state = "wooden_chair_settler"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kVS" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -16617,25 +17291,17 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"kXj" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre";
-	req_access_txt = "";
-	req_one_access_txt = ""
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "kXv" = (
-/obj/structure/fence{
-	dir = 8
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "prospectorladder";
+	layer = 2
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "kXK" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -16652,11 +17318,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"kYv" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "kYz" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -16692,9 +17353,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
 "kZh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/reinforced/indestructable,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/simple_door/interior,
+/turf/open/floor/wood,
 /area/f13/wasteland)
 "kZp" = (
 /obj/structure/rack,
@@ -16702,11 +17362,6 @@
 /obj/item/storage/belt/tribe_quiver,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
-"kZu" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/decoration/rag,
-/turf/closed/wall/rust,
-/area/f13/caves)
 "kZH" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -16722,16 +17377,9 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
-"lav" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = 30
-	},
-/obj/item/modular_computer/laptop/preset/civillian,
-/obj/item/flashlight/lamp,
-/turf/open/floor/plasteel/grimy,
-/area/f13/village)
+"laC" = (
+/turf/closed/wall/f13/wood/house,
+/area/f13/wasteland)
 "laZ" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -16744,6 +17392,23 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
+"lbx" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTHWEST)"
+	},
+/area/f13/wasteland)
+"lcg" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
+"lcq" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft2top";
+	tag = "icon-verticalrightborderleft2top"
+	},
+/area/f13/wasteland)
 "lda" = (
 /obj/structure/decoration/clock{
 	pixel_y = 30
@@ -16838,7 +17503,7 @@
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "lfb" = (
 /obj/structure/chair/wood/modern{
@@ -16847,6 +17512,15 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"lfu" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "lfG" = (
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -16899,16 +17573,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"lgI" = (
-/obj/structure/simple_door/metal/fence{
-	door_type = "fence_wood";
-	icon_state = "fence_wood"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "lgX" = (
 /obj/structure/table/reinforced,
 /obj/item/phone,
@@ -16920,32 +17584,31 @@
 /obj/structure/chair/wood/worn,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"lhz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+"lhk" = (
+/obj/structure/rack,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/reagent_containers/spray/plantbgone,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"lhp" = (
+/obj/structure/chair/stool/retro,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
+/area/f13/building)
 "lhA" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "lhN" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/spawner/structure/window/reinforced/indestructable,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"lil" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Store Backroom";
-	req_one_access_txt = "34"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/turf/closed/wall/rust,
+/area/f13/building)
 "liv" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -16953,7 +17616,11 @@
 	},
 /area/f13/wasteland)
 "liO" = (
-/obj/effect/spawner/structure/window/reinforced/indestructable,
+/obj/structure/simple_door/metal/dirtystore,
+/turf/open/floor/wood,
+/area/f13/building)
+"ljA" = (
+/obj/machinery/grill,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ljF" = (
@@ -16983,6 +17650,15 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland)
+"lkz" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lkE" = (
 /obj/structure/rack,
 /obj/item/seeds/chili,
@@ -17013,6 +17689,15 @@
 	icon_state = "horizontalbottomborderbottomleft"
 	},
 /area/f13/wasteland)
+"llP" = (
+/obj/structure/tires/five{
+	pixel_x = -19;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland)
 "lmc" = (
 /obj/structure/bonfire,
 /obj/item/stack/rods/ten,
@@ -17022,12 +17707,6 @@
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"lmw" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "lmN" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/dirt{
@@ -17035,9 +17714,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"lmV" = (
-/turf/open/floor/plasteel/stairs/old,
-/area/f13/city)
 "lmY" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -17056,6 +17732,9 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"lny" = (
+/turf/open/floor/wood/f13/oakbroken3,
+/area/f13/legion)
 "lnX" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -17073,20 +17752,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "loo" = (
-/obj/structure/destructible/tribal_torch{
-	layer = 3.1;
-	pixel_y = 20
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/wood,
 /area/f13/wasteland)
 "los" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
+"lox" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "loU" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/f13{
@@ -17104,17 +17785,9 @@
 	},
 /area/f13/wasteland)
 "lpd" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/reinforced/indestructable,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/item/twohanded/required/kirbyplants/dead,
+/turf/open/floor/wood,
 /area/f13/wasteland)
-"lpk" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "lpu" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/box/dice,
@@ -17177,12 +17850,6 @@
 /obj/structure/pondlily_big,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"lrf" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/building)
 "lrn" = (
 /obj/structure/chair{
 	dir = 4
@@ -17192,23 +17859,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"lrq" = (
+"lrB" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/area/f13/city)
-"lrB" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "lrG" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17219,6 +17878,13 @@
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab"
 	},
+/area/f13/wasteland)
+"lrY" = (
+/obj/structure/fence{
+	dir = 1;
+	icon_state = "straight"
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "lsg" = (
 /obj/structure/chair/booth{
@@ -17241,12 +17907,6 @@
 /obj/structure/sign/poster/contraband/pinup_funk,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
-"lsC" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Clinic"
-	},
-/turf/open/floor/plasteel/stairs/old,
-/area/f13/city)
 "lsD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -17271,6 +17931,19 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"lsW" = (
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"ltb" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plating,
+/area/f13/radiation)
 "ltl" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -17279,37 +17952,21 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
-"ltq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/city)
 "ltv" = (
 /obj/item/chair/stool/retro,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
-"ltZ" = (
-/obj/machinery/light{
-	dir = 8
+"ltD" = (
+/obj/structure/rack,
+/obj/item/pickaxe,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/obj/machinery/button/door{
-	id = "followersdeskshutters";
-	name = "desk shutters";
-	pixel_x = 6
-	},
-/obj/machinery/button/door{
-	id = "followershutters";
-	name = "door shutters";
-	pixel_x = -6
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
+/area/f13/building)
 "luc" = (
 /obj/structure/chair/left{
 	dir = 8
@@ -17325,14 +17982,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
-"lun" = (
-/obj/machinery/door/airlock/glass_large{
-	name = "Followers Clinic"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "luy" = (
 /obj/structure/table_frame/wood,
 /obj/item/crowbar/crude,
@@ -17342,19 +17991,16 @@
 	},
 /area/f13/brotherhood)
 "luD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "luI" = (
 /obj/structure/simple_door/house,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -17362,17 +18008,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"lvp" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
-"lvs" = (
-/obj/structure/chair/wood/worn{
-	dir = 1
-	},
+"lvc" = (
+/obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"lvy" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertopright";
+	tag = "icon-horizontalbottombordertopright"
+	},
+/area/f13/wasteland)
 "lvF" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -17380,17 +18025,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "lvL" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/area/f13/wasteland)
-"lvR" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/area/f13/building)
 "lvS" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/beaker/waterbottle,
@@ -17420,11 +18060,13 @@
 	},
 /area/f13/building)
 "lwd" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
+/obj/structure/simple_door/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/area/f13/farm)
+/area/f13/building)
 "lwf" = (
 /obj/effect/decal/fakelattice{
 	pixel_x = -17
@@ -17449,21 +18091,48 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/building)
-"lwv" = (
+"lwG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
+"lwJ" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"lwT" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter (WEST)"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "lxe" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2bottom"
 	},
 /area/f13/wasteland)
+"lxk" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetblue"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lxJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
@@ -17483,12 +18152,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
-"lyk" = (
-/obj/effect/landmark/start/f13/prospector,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/city)
 "lyo" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17520,19 +18183,13 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "lzV" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/turf/open/floor/f13/wood,
+/obj/machinery/smartfridge/bottlerack,
+/turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "lzW" = (
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
-/area/f13/wasteland)
+/obj/structure/simple_door/interior,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "lzZ" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
@@ -17555,7 +18212,7 @@
 /obj/structure/table/wood,
 /obj/item/smelling_salts,
 /obj/item/smelling_salts,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "lAJ" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -17563,22 +18220,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"lBv" = (
-/obj/structure/decoration/vent,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/city)
-"lBy" = (
-/obj/structure/window/fulltile/wood{
-	layer = 3
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "barwindowshutters";
-	layer = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
 "lBD" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -17607,29 +18248,25 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "lCi" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_y = 12
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 5
-	},
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32"
-	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "lCo" = (
-/obj/item/ammo_casing/shotgun/buckshot,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "interiorgate"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
+"lCs" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "lCv" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -17639,7 +18276,7 @@
 "lCw" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "lCM" = (
 /obj/machinery/light/small{
@@ -17650,16 +18287,17 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"lCO" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left";
+	tag = "icon-horizontalinnermain2left (WEST)"
+	},
+/area/f13/wasteland)
 "lDd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
-"lDi" = (
-/obj/item/clothing/suit/armor/f13/rustedcowboy,
-/obj/item/clothing/head/helmet/f13/rustedcowboyhat,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "lDv" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -17726,12 +18364,33 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"lEG" = (
+"lEx" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
 	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"lEC" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"lEG" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
+"lFe" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/item/seeds/cannabis,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lFf" = (
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/f13/wood{
@@ -17757,12 +18416,6 @@
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
-"lFI" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "lFM" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/simple_animal/hostile/mirelurk/baby,
@@ -17780,18 +18433,20 @@
 	},
 /area/f13/legion)
 "lGG" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
+	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
 "lGH" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"lGV" = (
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "lGW" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -17828,21 +18483,36 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"lHZ" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderrightbottom";
+	tag = "icon-verticalleftborderrightbottom"
+	},
+/area/f13/wasteland)
 "lIh" = (
 /obj/structure/table/optable,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/ncr)
-"lIX" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+"lIq" = (
+/obj/structure/sink{
+	pixel_y = 15
 	},
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"lJf" = (
+/obj/structure/fence/wooden{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "lJg" = (
 /obj/structure/table,
 /obj/item/paper,
@@ -17852,15 +18522,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"lJx" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/landmark/start/f13/ncrmp,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/ncr)
 "lJL" = (
 /obj/structure/bonfire,
 /turf/open/floor/f13/wood,
@@ -17878,21 +18539,27 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "lKK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
+/obj/effect/landmark/start/f13/prospector,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "lKO" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "lKV" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cargocrate,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/building)
+"lLu" = (
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "lLv" = (
 /mob/living/simple_animal/hostile/wolf,
 /turf/open/indestructible/ground/outside/ruins{
@@ -17910,6 +18577,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"lLP" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 4;
+	icon_state = "innermaincornerinner";
+	tag = "icon-innermaincornerinner (EAST)"
+	},
+/area/f13/wasteland)
 "lMn" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/autolathe/ammo,
@@ -17920,11 +18594,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"lMp" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/costumes,
-/turf/open/floor/f13/wood,
-/area/f13/village)
 "lMr" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -17940,6 +18609,15 @@
 	icon_state = "housebase"
 	},
 /area/f13/village)
+"lMB" = (
+/obj/structure/barricade/bars,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "frontgateshut";
+	name = "gate shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "lNa" = (
 /obj/structure/closet/fridge/standard,
 /turf/open/floor/f13/wood,
@@ -17965,15 +18643,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"lOp" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
 "lOz" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light{
@@ -17999,6 +18668,21 @@
 	icon_state = "horizontaltopborderbottom2"
 	},
 /area/f13/wasteland)
+"lPv" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
+"lPx" = (
+/obj/item/ammo_casing/caseless{
+	dir = 4;
+	icon_state = "sS-casing";
+	tag = "icon-sS-casing (EAST)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lPN" = (
 /obj/structure/fence/corner{
 	dir = 4;
@@ -18035,10 +18719,20 @@
 	icon_state = "verylittleshadowright"
 	},
 /area/f13/wasteland)
+"lQK" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "lRd" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"lRA" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "lRB" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -18057,12 +18751,16 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "lRT" = (
-/obj/structure/flora/tree/tall{
-	layer = 2;
-	pixel_y = 9
+/obj/machinery/button/door{
+	id = "prospectorshutters";
+	name = "gate shutters";
+	pixel_x = 32
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/building)
 "lRU" = (
 /obj/machinery/vending/cola/random,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18070,8 +18768,7 @@
 	},
 /area/f13/wasteland)
 "lRW" = (
-/obj/structure/window/fulltile/wood,
-/turf/open/floor/f13/wood,
+/turf/open/floor/holofloor/carpet,
 /area/f13/building)
 "lRX" = (
 /obj/machinery/hydroponics/soil,
@@ -18084,11 +18781,34 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"lSf" = (
+/turf/open/floor/wood/f13/oakbroken4,
+/area/f13/legion)
+"lSp" = (
+/turf/closed/wall/f13/ruins,
+/area/f13/radiation)
+"lSz" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"lSB" = (
+/obj/structure/barricade/tentclothcorner,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "lSD" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
 	icon_state = "horizontaltopborderbottom2right"
 	},
+/area/f13/wasteland)
+"lSG" = (
+/obj/effect/decal/riverbank{
+	dir = 9
+	},
+/turf/open/water,
 /area/f13/wasteland)
 "lTk" = (
 /obj/machinery/light/small/broken{
@@ -18105,13 +18825,9 @@
 	},
 /area/f13/wasteland)
 "lTx" = (
-/obj/machinery/mineral/wasteland_vendor/attachments{
-	icon_state = "weapon_idle"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
 "lTG" = (
 /obj/item/ammo_casing/caseless{
 	dir = 10;
@@ -18126,15 +18842,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"lTZ" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/white,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "lUa" = (
 /obj/structure/toilet{
 	dir = 8
@@ -18165,11 +18872,10 @@
 	},
 /area/f13/building)
 "lUg" = (
-/obj/machinery/light,
-/obj/item/flag/oasis,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2top"
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing"
 	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/wasteland)
 "lUk" = (
 /obj/structure/decoration/clock/old/active,
@@ -18211,6 +18917,14 @@
 /obj/item/clothing/under/f13/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"lVR" = (
+/obj/machinery/mineral/unloading_machine,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "lWj" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18230,9 +18944,23 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"lWJ" = (
+/obj/structure/fence/corner/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "lWZ" = (
 /obj/structure/billboard/ritas,
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"lXd" = (
+/obj/structure/tires{
+	pixel_x = -8;
+	pixel_y = 15
+	},
+/obj/structure/lamp_post/quadra,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
 /area/f13/wasteland)
 "lXl" = (
 /obj/structure/table/wood,
@@ -18254,8 +18982,18 @@
 	},
 /area/f13/wasteland)
 "lYu" = (
-/mob/living/simple_animal/chick,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	name = "prewar lounge chair"
+	},
+/turf/open/floor/wood,
+/area/f13/building)
+"lYx" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
 "lZl" = (
 /obj/effect/turf_decal/stripes/white/box,
@@ -18292,15 +19030,17 @@
 /turf/closed/wall/f13/wood,
 /area/f13/village)
 "lZY" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/item/phone,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/wood,
+/area/f13/building)
 "mar" = (
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/f13/building)
 "may" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -18310,6 +19050,14 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/village)
+"maS" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "maW" = (
 /obj/structure/closet/crate/medical/anchored,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -18330,14 +19078,15 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
-"mbD" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "gatehouseladder"
+"mbr" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop3"
+	},
+/area/f13/wasteland)
 "mco" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/plating/dirt/dark,
@@ -18347,16 +19096,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
 "mcz" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
+/mob/living/simple_animal/hostile/handy,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "mcD" = (
 /obj/structure/simple_door/house{
@@ -18370,12 +19111,12 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/wasteland)
 "mdc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "mdv" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood{
@@ -18390,15 +19131,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "mdE" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
+"mdI" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "shadowright";
+	tag = "icon-shadowright"
 	},
 /area/f13/wasteland)
 "mdM" = (
-/turf/open/floor/plasteel/barber{
-	icon_state = "platingdmg2"
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/building)
 "mdT" = (
@@ -18425,9 +19175,16 @@
 	},
 /area/f13/building)
 "mes" = (
-/obj/structure/decoration/rag,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood,
+/mob/living/simple_animal/hostile/wolf{
+	desc = "Legion mongrels are dogs owned and bred by the Houndmasters of Caesar's Legion. Mongrels are mainly used in combat and scouting missions by the Legion.";
+	faction = list("neutral");
+	health = 200;
+	maxHealth = 200;
+	name = "Lupa";
+	tame = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "meL" = (
 /obj/structure/table,
@@ -18436,11 +19193,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
-"meU" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "mfj" = (
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/ruins{
@@ -18449,11 +19201,13 @@
 	},
 /area/f13/wasteland)
 "mfq" = (
-/obj/item/flag/followers,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/boozeomat{
+	density = 0;
+	pixel_x = -32
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "mfD" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -18481,45 +19235,23 @@
 /area/f13/village)
 "mgg" = (
 /obj/machinery/autolathe,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"mgo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "mgu" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
+"mgP" = (
+/obj/machinery/grill,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland)
-"mgV" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = 30
-	},
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/village)
 "mhJ" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
-"mhL" = (
-/obj/structure/bed/roller,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
 "mia" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -18538,6 +19270,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"miL" = (
+/obj/item/flag,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/building)
 "mjg" = (
 /obj/machinery/button/door{
 	id = "badboys";
@@ -18578,10 +19316,16 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/village)
-"mkP" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+"mkV" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0";
+	tag = "icon-horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
+"mlw" = (
+/obj/structure/bookcase,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "mlD" = (
 /obj/structure/table/wood/settler,
 /obj/item/paper_bin,
@@ -18633,6 +19377,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"mmY" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/f13/radiation)
 "mnb" = (
 /mob/living/simple_animal/pet/dog/protectron,
 /obj/machinery/light/small{
@@ -18644,15 +19394,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mnv" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/chair,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "mnC" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = -3
@@ -18672,12 +19413,10 @@
 	},
 /area/f13/wasteland)
 "moo" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_y = -11
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "moA" = (
 /obj/structure/chair{
 	dir = 8;
@@ -18697,27 +19436,11 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
-"moH" = (
-/obj/structure/chair/pew/right,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "moO" = (
-/obj/structure/fence{
-	dir = 1;
-	pixel_x = -10
-	},
-/obj/structure/girder,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
-"moR" = (
-/obj/structure/decoration/hatch{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "moX" = (
 /obj/structure/closet/crate{
 	anchored = 1;
@@ -18742,10 +19465,23 @@
 /obj/machinery/door/airlock/freezer,
 /turf/open/floor/plasteel/bar,
 /area/f13/ncr)
+"mpI" = (
+/obj/structure/table/wood/settler,
+/obj/item/dildo{
+	icon_state = "dildo";
+	layer = 1.1
+	},
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mpQ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
+"mqn" = (
+/mob/living/simple_animal/hostile/stalkeryoung,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "mqp" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -18758,8 +19494,11 @@
 	},
 /area/f13/ncr)
 "mqy" = (
-/obj/machinery/mineral/wasteland_vendor/bank,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/machinery/power/solar,
+/obj/structure/cable,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
+	},
 /area/f13/wasteland)
 "mqF" = (
 /obj/machinery/mineral/wasteland_vendor/ammo,
@@ -18776,11 +19515,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mrg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
+/obj/item/instrument/eguitar{
+	anchored = 1;
+	pixel_x = 32
 	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "mri" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -18802,15 +19542,21 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"mrS" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	pixel_x = -6
+"mrQ" = (
+/obj/structure/cargocrate,
+/obj/structure/cargocrate{
+	pixel_x = 2;
+	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/reinforced/indestructable,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"mrS" = (
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_y = 3
+	},
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "mrY" = (
 /obj/structure/closet/cabinet,
 /turf/open/indestructible/ground/outside/ruins{
@@ -18868,11 +19614,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mtX" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"muh" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
+	},
+/area/f13/caves)
 "muk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -18917,18 +19665,20 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
-"mvF" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/city)
 "mvJ" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"mvK" = (
+/obj/structure/closet,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs/cable,
+/obj/item/restraints/handcuffs/cable,
+/obj/item/restraints/legcuffs/bola,
+/turf/open/floor/plating,
+/area/f13/radiation)
 "mvS" = (
 /obj/structure/chair{
 	dir = 1
@@ -18943,17 +19693,10 @@
 	},
 /area/f13/building)
 "mvV" = (
-/obj/item/flag,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
-/area/f13/wasteland)
-"mwa" = (
+/obj/structure/musician/piano,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/f13/city)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "mwc" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel/barber{
@@ -18961,6 +19704,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"mwg" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "mwp" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
@@ -18971,6 +19721,16 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mxq" = (
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "mxO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19000,6 +19760,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"myF" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	tag = "icon-wooden_chair_new (NORTH)"
+	},
+/turf/open/floor/wood/f13/oakbroken3,
+/area/f13/building)
+"mzn" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "mzs" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19017,10 +19790,10 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
-"mzC" = (
-/obj/structure/flora/ausbushes/palebush,
-/turf/open/floor/grass,
-/area/f13/city)
+"mzS" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "mzY" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -19059,6 +19832,17 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"mBA" = (
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/item/storage/bag/ore,
+/obj/item/flashlight,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "mCf" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -19066,26 +19850,17 @@
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
 "mCG" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
+/obj/structure/table/wood,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
-"mCO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerbordercorner"
-	},
-/area/f13/city)
 "mDf" = (
-/obj/structure/wreck/trash/machinepiletwo{
-	layer = 3
+/obj/structure/fence{
+	dir = 1
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2right"
+	dir = 4;
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "mDn" = (
@@ -19094,23 +19869,21 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/brotherhood)
-"mDr" = (
-/obj/structure/chair/bench,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "mEh" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "mEn" = (
-/obj/structure/lamp_post{
-	dir = 4
+/obj/structure/chair/stool/f13stool{
+	pixel_x = -8
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "mEy" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
@@ -19139,6 +19912,21 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"mFi" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
+"mFs" = (
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "mGf" = (
 /obj/structure/table/snooker{
 	dir = 6
@@ -19146,13 +19934,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"mGo" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
+"mGh" = (
+/obj/machinery/jukebox,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "mGr" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
@@ -19165,6 +19951,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"mGA" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "mGC" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
@@ -19185,17 +19977,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"mHv" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "mHy" = (
 /obj/structure/closet/cabinet,
 /obj/item/instrument/trumpet,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "mHS" = (
 /obj/machinery/vending/tool,
@@ -19210,10 +19995,6 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
-"mHY" = (
-/obj/structure/chair/comfy/black,
-/turf/open/floor/wood,
-/area/f13/village)
 "mIi" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/suspenders,
@@ -19230,13 +20011,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"mJu" = (
-/obj/structure/rack,
-/obj/item/stack/f13Cash/random/denarius/high,
-/obj/item/stack/f13Cash/random/denarius/high,
-/obj/item/stack/f13Cash/random/denarius/high,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "mJG" = (
 /obj/structure/fence{
 	dir = 4
@@ -19245,6 +20019,14 @@
 	icon_state = "verticaloutermainbottom"
 	},
 /area/f13/wasteland)
+"mJW" = (
+/obj/structure/sign/poster/prewar/poster88{
+	pixel_x = -32
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "mKe" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -19279,22 +20061,15 @@
 	icon_state = "horizontaloutermainright"
 	},
 /area/f13/wasteland)
-"mKB" = (
-/obj/item/gun/ballistic/shotgun/trench{
-	anchored = 1;
-	pixel_y = 5
+"mLa" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
 	},
-/obj/item/gun/ballistic/shotgun/hunting{
-	anchored = 1;
-	pixel_y = -3
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
 	},
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_y = 3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood/interior,
-/area/f13/city)
+/area/f13/wasteland)
 "mLj" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/machinery/light/broken,
@@ -19311,6 +20086,11 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"mLC" = (
+/obj/structure/chair/office,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mLN" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -19318,23 +20098,31 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"mMe" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+"mMn" = (
+/obj/structure/chair/stool,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/area/f13/city)
-"mMI" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/area/f13/building)
 "mMN" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/water,
-/area/f13/tunnel)
+/obj/item/gun/ballistic/shotgun/trench{
+	anchored = 1;
+	pixel_y = 5
+	},
+/obj/item/gun/ballistic/shotgun/hunting{
+	anchored = 1;
+	pixel_y = -3
+	},
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "mNi" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/pirate,
@@ -19343,18 +20131,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"mNB" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
-"mNK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "mNS" = (
 /obj/structure/chair{
 	dir = 8
@@ -19386,26 +20162,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "mPa" = (
-/obj/structure/girder/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/machinery/light/sign,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "mPk" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "shopladder"
 	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "mPw" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/structure/rack,
-/obj/item/shovel/spade,
-/obj/item/shovel,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/cultivator,
-/obj/item/storage/bag/plants,
-/obj/item/scythe,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/building)
 "mPT" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -19426,6 +20202,17 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"mRt" = (
+/obj/machinery/mineral/processing_unit{
+	input_dir = 8;
+	output_dir = 4
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "mSs" = (
 /obj/structure/decoration/rag{
 	icon_state = "flag_ncr";
@@ -19483,13 +20270,8 @@
 /obj/item/flashlight/lantern,
 /obj/item/flashlight/lantern,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"mTT" = (
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
-/area/f13/followers)
 "mUk" = (
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -19499,6 +20281,13 @@
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
+"mUw" = (
+/obj/structure/fence/wooden{
+	dir = 4;
+	icon_state = "post_wood"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "mUx" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19506,36 +20295,30 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"mUy" = (
+/obj/structure/fence/corner/wooden{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "mUO" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"mUS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/defibrillator_mount/loaded{
+"mUP" = (
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"mUU" = (
+/obj/machinery/button/door{
+	id = "shopouter";
+	name = "gate shutters";
 	pixel_y = 32
 	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
-"mUU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"mVc" = (
-/obj/structure/toilet,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/reagent_containers/food/snacks/f13/steak,
-/obj/item/twohanded/sledgehammer,
-/obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/building)
 "mVh" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -19568,7 +20351,7 @@
 /area/f13/village)
 "mVR" = (
 /obj/structure/reagent_dispensers/compostbin,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "mVV" = (
 /obj/structure/table/reinforced,
@@ -19599,21 +20382,39 @@
 /obj/item/kitchen/knife/combat/bone,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
-"mXA" = (
-/turf/closed/wall/f13/ruins,
-/area/f13/city)
+"mWG" = (
+/obj/machinery/conveyor/auto{
+	dir = 6
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
+"mWT" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottomleft";
+	tag = "icon-horizontalbottomborderbottomleft"
+	},
+/area/f13/wasteland)
+"mXy" = (
+/obj/structure/closet/cardboard,
+/obj/item/crowbar,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "mXC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/village)
 "mXF" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/matches,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/wasteland)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mYi" = (
 /obj/structure/fence{
 	dir = 4
@@ -19652,6 +20453,20 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mYF" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/matches,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
+"mZk" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0";
+	tag = "icon-verticalrightborderleft0"
+	},
+/area/f13/wasteland)
 "mZD" = (
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -19682,17 +20497,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"nax" = (
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/city)
-"naF" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/f13/city)
 "naP" = (
 /obj/structure/chair{
 	dir = 8
@@ -19732,11 +20536,17 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/bar)
+"nby" = (
+/obj/machinery/processor,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "nbD" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "nbH" = (
 /obj/structure/table,
@@ -19756,6 +20566,26 @@
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
+"ncC" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"ncU" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "ncX" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -19770,22 +20600,12 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"ndx" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "ndy" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ndT" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/grass,
-/area/f13/city)
 "ndV" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -19796,14 +20616,44 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
+"nev" = (
+/obj/structure/rack,
+/obj/item/seeds/chili,
+/obj/item/seeds/coffee,
+/obj/item/seeds/tea,
+/obj/item/seeds/xander,
+/obj/item/seeds/grass,
+/obj/item/seeds/grass,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/wheat/rice,
+/obj/item/seeds/cotton,
+/obj/item/seeds/grass,
+/obj/item/seeds/wheat,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"neD" = (
+/obj/effect/mine/stun,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "neN" = (
-/obj/structure/destructible/tribal_torch{
-	pixel_x = 10
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/wasteland)
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/structure/rack,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "neP" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19823,6 +20673,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"neX" = (
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalright"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "neZ" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
@@ -19848,16 +20706,12 @@
 "nfu" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
-"nfz" = (
-/obj/structure/table/wood/settler,
-/obj/structure/barricade/bars,
-/obj/structure/curtain{
-	color = "#845f58"
+"nfv" = (
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
+/area/f13/tunnel)
 "nfH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
@@ -19870,15 +20724,38 @@
 	},
 /area/f13/village)
 "ngg" = (
-/obj/structure/table/wood,
-/obj/structure/wreck/trash/halftire{
-	pixel_y = -21
+/obj/machinery/button/door{
+	id = "countershutters";
+	name = "counter shutters";
+	pixel_x = 6;
+	pixel_y = 30
 	},
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+/obj/machinery/button/door{
+	id = "storeshutters";
+	name = "store shutters";
+	pixel_x = -6;
+	pixel_y = 30
 	},
-/area/f13/wasteland)
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_y = 32
+	},
+/obj/structure/rack,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"ngF" = (
+/obj/structure/rack,
+/obj/item/clothing/head/hardhat,
+/obj/item/storage/bag/ore,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "ngV" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/f13/wood{
@@ -19918,6 +20795,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"nhv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2"
+	},
+/area/f13/wasteland)
 "nhz" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -19938,10 +20821,6 @@
 	},
 /turf/open/water,
 /area/f13/caves)
-"nhX" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/f13/city)
 "nip" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -19964,28 +20843,52 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"nji" = (
+/obj/item/chair/stool/retro/black,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"njC" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"njK" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "nkp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland)
-"nkq" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/chapel{
-	dir = 10
+"nkA" = (
+/obj/effect/decal/remains{
+	icon_state = "remains";
+	tag = "icon-remains"
 	},
-/area/f13/village)
+/obj/structure/chair/wood/worn{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "nla" = (
 /obj/machinery/workbench/forge,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "nlv" = (
-/obj/structure/table/wood,
-/obj/item/clothing/mask/cigarette/pipe,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nly" = (
@@ -19994,15 +20897,16 @@
 	icon_state = "verticaloutermaintop"
 	},
 /area/f13/building)
-"nlD" = (
-/obj/machinery/light/small{
-	dir = 8
+"nlG" = (
+/obj/structure/legion_extractor,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"nlL" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain2top";
+	tag = "icon-verticaloutermain2top"
 	},
-/obj/structure/chair/booth{
-	icon_state = "booth_east_middle"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/city)
+/area/f13/wasteland)
 "nlN" = (
 /obj/structure/window/fulltile/wood_window,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -20020,14 +20924,26 @@
 /obj/item/reagent_containers/food/snacks/grown/potato,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"nlU" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
 "nmq" = (
 /obj/structure/sign/poster/contraband/pinup_topless,
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
+"nms" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
+"nmU" = (
+/obj/structure/table/reinforced,
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters{
+	id = "frontgateshut";
+	name = "gate shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "nmZ" = (
 /turf/open/floor/f13{
 	dir = 1;
@@ -20035,11 +20951,12 @@
 	},
 /area/f13/brotherhood)
 "nnh" = (
-/obj/structure/wreck/trash/machinepile{
-	layer = 3
+/obj/structure/fence/corner{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
 "nnn" = (
@@ -20052,14 +20969,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"nnA" = (
-/obj/structure/lamp_post{
-	dir = 4
+"nnz" = (
+/obj/effect/spawner/lootdrop/crafts,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft1"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "noo" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -20070,31 +20986,22 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"noH" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/rollingpin,
+"noD" = (
+/obj/machinery/light/small,
+/obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/building)
+"noH" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "noK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertopleft"
 	},
 /area/f13/wasteland)
-"npl" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
-"npS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
-	},
-/area/f13/city)
 "nqb" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/ruins{
@@ -20113,25 +21020,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nqU" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
+/obj/structure/rack,
+/obj/item/book/granter/trait/chemistry,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "nrw" = (
 /obj/structure/displaycase,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nrB" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/legion)
 "nrS" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20169,16 +21069,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"ntg" = (
-/obj/structure/table/wood/settler,
-/obj/item/kitchen/knife,
-/obj/item/megaphone,
-/obj/item/flashlight/flare/torch,
-/obj/item/flashlight/flare/torch,
-/obj/item/flashlight/flare/torch,
-/obj/item/flashlight/flare/torch,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "ntl" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood,
@@ -20218,6 +21108,22 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"nuB" = (
+/obj/structure/rack,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/storage/bag/plants,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	tag = "icon-dirt"
+	},
+/area/f13/wasteland)
+"nvc" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "nvr" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20234,39 +21140,44 @@
 "nvL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"nwh" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	layer = 6;
-	pixel_x = -6;
-	pixel_y = 13
+"nvV" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/turf/open/floor/grass,
-/area/f13/city)
+/area/f13/building)
 "nwp" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/area/f13/legion)
+/area/f13/building)
 "nwu" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/reinforced/indestructable,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"nwB" = (
-/obj/structure/simple_door/house,
-/obj/machinery/door/poddoor/shutters{
-	id = "storeshutters";
-	name = "store shutters"
+/obj/item/stack/crafting/goodparts/five,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"nwG" = (
+/obj/structure/table/wood/settler,
+/obj/item/shovel,
+/obj/item/shovel{
+	pixel_x = -1;
+	pixel_y = 5
 	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "nwT" = (
 /obj/structure/closet/crate/bin,
 /turf/open/indestructible/ground/outside/dirt{
@@ -20284,18 +21195,17 @@
 /turf/closed/wall/f13/wood,
 /area/f13/village)
 "nxj" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/machinery/light/small/broken{
+	dir = 8
 	},
+/turf/open/floor/wood,
 /area/f13/wasteland)
-"nxD" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/turf/open/floor/carpet/black,
-/area/f13/city)
+"nxL" = (
+/obj/structure/fence/wooden{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "nxS" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	pixel_y = -6
@@ -20324,19 +21234,10 @@
 	},
 /area/f13/building)
 "nyZ" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3"
-	},
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/wasteland)
-"nzq" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
 "nzJ" = (
 /obj/item/seeds/poppy/broc,
 /turf/open/indestructible/ground/outside/dirt,
@@ -20373,20 +21274,10 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/tunnel)
-"nAI" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	layer = 6;
-	pixel_x = -6;
-	pixel_y = 13
-	},
-/turf/open/floor/grass,
-/area/f13/city)
 "nAR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/money_stack/legion,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "nBn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20408,25 +21299,39 @@
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/caves)
 "nBC" = (
-/obj/structure/bed/mattress,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2left";
+	tag = "icon-horizontalinnermain2left"
+	},
+/area/f13/wasteland)
+"nCj" = (
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "nCl" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"nCp" = (
+/obj/structure/chair/wood/modern{
+	dir = 8;
+	tag = "icon-wooden_chair_new (WEST)"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "nCx" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/stage_t,
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "radio"
+	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/wasteland)
 "nCS" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "nDd" = (
@@ -20464,6 +21369,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"nEa" = (
+/obj/structure/table/wood/poker,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"nEi" = (
+/obj/structure/sign/poster/prewar/poster82{
+	pixel_x = 32
+	},
+/obj/structure/chair/stool/retro,
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "nEn" = (
 /obj/structure/holohoop{
 	dir = 8
@@ -20500,37 +21419,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
-"nGh" = (
-/obj/machinery/button/door{
-	id = "countershutters";
-	name = "counter shutters";
-	pixel_x = 6;
-	pixel_y = 30
-	},
-/obj/machinery/button/door{
-	id = "storeshutters";
-	name = "store shutters";
-	pixel_x = -6;
-	pixel_y = 30
-	},
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_y = 32
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/gun/ballistic/revolver/shotgunrevolver,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier10,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "nGq" = (
 /turf/closed/wall/f13/store,
 /area/f13/wasteland)
@@ -20543,12 +21431,18 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"nHi" = (
-/obj/machinery/vending/snack,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
+"nGJ" = (
+/obj/structure/chair/wood,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"nHi" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood,
+/area/f13/building)
 "nHC" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20568,12 +21462,6 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
-"nIj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/city)
 "nIp" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
@@ -20602,6 +21490,16 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"nIJ" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "nIP" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/building)
@@ -20612,23 +21510,17 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland)
-"nJc" = (
-/obj/effect/landmark/start/f13/settler,
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
-"nJz" = (
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/floor/grass,
-/area/f13/city)
+"nJG" = (
+/obj/structure/chair/stool,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "nJM" = (
-/obj/item/clothing/head/cone{
-	anchored = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright1"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/f13/building)
 "nJW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -20640,22 +21532,20 @@
 /obj/item/clothing/mask/bandana/gold,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nLD" = (
+/obj/structure/table/wood/settler,
+/obj/item/kitchen/knife,
+/obj/item/mining_scanner,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "nLL" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
-"nLX" = (
-/obj/structure/bed,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/item/bedsheet/brown,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/ncr)
 "nMd" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/indestructible/ground/outside/desert,
@@ -20664,7 +21554,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/effect/landmark/start/f13/legionary,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "nMl" = (
 /obj/structure/window/fulltile/house,
@@ -20677,6 +21567,17 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"nNm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "clinicoutsideladder"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "nNn" = (
 /obj/item/picket_sign,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20697,24 +21598,23 @@
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"nNI" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical";
+	tag = "icon-housewindowvertical (NORTHEAST)"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/city)
 "nNU" = (
 /obj/structure/simple_door/house,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nNZ" = (
-/obj/item/flag/oasis,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright1"
-	},
-/area/f13/wasteland)
-"nOl" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/structure/table/wood,
+/obj/item/papercutter,
+/turf/open/floor/wood,
+/area/f13/building)
 "nOm" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road{
@@ -20745,13 +21645,6 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland)
-"nPq" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "nPu" = (
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/outside/desert,
@@ -20768,12 +21661,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"nPO" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/village)
+"nPP" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "nPV" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -20788,18 +21680,6 @@
 /obj/effect/turf_decal/stripes/white/full,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"nQu" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/landmark/start/f13/ncrheavytrooper,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
 "nQP" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
@@ -20811,10 +21691,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "nRc" = (
-/obj/structure/chair{
-	dir = 1
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/clinic)
 "nRr" = (
 /obj/structure/table/wood,
@@ -20822,15 +21701,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nRu" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Private"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3"
-	},
-/area/f13/wasteland)
+/turf/open/floor/wood,
+/area/f13/building)
 "nRz" = (
 /obj/structure/fence/corner/wooden{
 	dir = 8
@@ -20873,21 +21750,31 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"nSQ" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
+	},
+/area/f13/building)
+"nTc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "nTe" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
 "nTm" = (
-/obj/machinery/microwave/stove,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "nTO" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/caves)
 "nTP" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/f13/wood{
@@ -20912,22 +21799,21 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/wasteland)
-"nUj" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "cornerladder";
-	layer = 2
-	},
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32"
-	},
-/area/f13/city)
 "nUm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"nUs" = (
+/obj/structure/spider/stickyweb,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "nUF" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20935,11 +21821,17 @@
 	},
 /area/f13/wasteland)
 "nUS" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/f13/village)
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/wasteland)
 "nUT" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -20985,39 +21877,63 @@
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nWl" = (
-/obj/structure/holohoop{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "nWu" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"nYI" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/folder/blue,
-/obj/item/pen,
-/turf/open/floor/plasteel/grimy,
-/area/f13/village)
-"nYY" = (
-/obj/structure/tires/two{
-	pixel_x = -5;
-	pixel_y = 6
+"nWv" = (
+/obj/structure/table,
+/obj/item/crafting/abraxo,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleftbottom"
+/area/f13/city)
+"nXd" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"nXl" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
+"nXE" = (
+/obj/structure/table/wood/settler,
+/obj/item/flashlight/lantern,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"nYY" = (
+/obj/structure/chair/comfy{
+	dir = 4;
+	tag = "icon-comfychair (EAST)"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
+"nZd" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0";
+	tag = "icon-horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
 "nZr" = (
 /mob/living/simple_animal/hostile/wolf,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"nZw" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
+"nZs" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "nZJ" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -21029,22 +21945,27 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
+"nZT" = (
+/obj/machinery/light/lampost,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2left";
+	tag = "icon-horizontaltopbordertop2left"
+	},
+/area/f13/wasteland)
 "nZV" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
-"oat" = (
-/obj/structure/flora/tree/jungle{
-	desc = "Rumor has it that, as long as this tree stands firm, so too will the town of Oasis.";
-	name = "\improper Oasis Oak"
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -6
 	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	pixel_x = -8;
-	pixel_y = 7
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 4
 	},
-/turf/open/floor/grass,
-/area/f13/city)
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "oav" = (
 /turf/closed/wall/f13/wood,
 /area/f13/bar)
@@ -21084,27 +22005,22 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "obr" = (
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
+/obj/structure/table/wood/settler,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "obV" = (
-/obj/structure/simple_door/metal/fence,
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
-"oco" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Secret"
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
+/area/f13/building)
 "ocx" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -21116,31 +22032,34 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"ocy" = (
-/obj/structure/fence{
-	dir = 4
+"ocU" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/wasteland)
 "ocV" = (
 /obj/structure/sink{
 	pixel_y = 25
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"ocX" = (
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench";
+	tag = "icon-bench (EAST)"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "odb" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
 /area/f13/bar)
-"odc" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/f13/wood,
-/area/f13/village)
 "odh" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -21149,6 +22068,29 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"odk" = (
+/obj/structure/barricade/bars,
+/obj/structure/fence{
+	pixel_x = -16
+	},
+/obj/structure/window/reinforced/fulltile{
+	layer = 2.8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
+"odo" = (
+/obj/structure/bed,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/item/bedsheet{
+	icon_state = "sheetblue"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "odr" = (
 /obj/structure/flora/grass/wasteland{
@@ -21171,9 +22113,6 @@
 /obj/item/pickaxe,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"odS" = (
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
 "odW" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/light,
@@ -21203,19 +22142,24 @@
 /obj/structure/mirelurkegg,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
+"oeq" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	icon_state = "wooden_chair_settler"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "oeL" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ofe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6";
-	pixel_x = -28
+"ofd" = (
+/obj/structure/table/wood,
+/obj/item/paper,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
 	},
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "ofh" = (
 /obj/structure/billboard/ritas,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -21241,18 +22185,27 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"ogf" = (
+/obj/item/stack/sheet/mineral/wood/five,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ogj" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
-"ogO" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+"ogB" = (
+/obj/structure/wreck/trash/four_barrels,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/city)
+/area/f13/wasteland)
+"ohc" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/f13/doctor,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "ohk" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -21261,15 +22214,19 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ohx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/comfy/beige,
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+"ohp" = (
+/obj/structure/decoration/clock{
+	pixel_y = 30
 	},
-/area/f13/city)
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
+"ohH" = (
+/obj/structure/tires/two,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermainleft";
+	tag = "icon-horizontaloutermainleft"
+	},
+/area/f13/wasteland)
 "ohU" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/broken,
@@ -21303,37 +22260,51 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"oiz" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"oiP" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ojl" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
-"ojL" = (
-/obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/grass,
-/area/f13/city)
-"okc" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+"ojS" = (
+/obj/machinery/smartfridge/drying_rack,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"okn" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "okt" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/bar)
 "okz" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"okJ" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland)
 "okS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/decoration/shock,
@@ -21350,11 +22321,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
-"olt" = (
-/obj/effect/landmark/start/f13/preacher,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/area/f13/caves)
 "olD" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -21399,14 +22366,23 @@
 	},
 /area/f13/building)
 "omd" = (
-/obj/structure/tires/five{
-	pixel_x = -19;
-	pixel_y = -3
+/obj/structure/toilet{
+	dir = 8;
+	tag = "icon-toilet00 (WEST)"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft3"
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/wasteland)
+/area/f13/building)
+"oml" = (
+/obj/structure/table/wood/settler,
+/obj/item/storage/backpack/satchel/leather/withwallet,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "omu" = (
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/caves)
@@ -21417,6 +22393,14 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/brotherhood)
+"omV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetcmo"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "one" = (
 /obj/structure/table/wood/settler,
 /obj/item/lipstick/jade,
@@ -21424,10 +22408,12 @@
 /area/f13/bar)
 "onh" = (
 /obj/structure/table/wood,
-/obj/machinery/microwave,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
+/obj/item/soap/deluxe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "onk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -21458,14 +22444,9 @@
 	},
 /area/f13/ncr)
 "onz" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "onQ" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/trash,
@@ -21495,17 +22476,8 @@
 "ooh" = (
 /obj/structure/table/wood,
 /obj/item/roller,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"ook" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_x = 30
-	},
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/village)
 "ooq" = (
 /obj/structure/rack,
 /obj/item/seeds/xander,
@@ -21560,16 +22532,12 @@
 	},
 /area/f13/wasteland)
 "oqm" = (
-/obj/structure/mirror{
-	pixel_y = 30
+/obj/structure/table/wood,
+/obj/item/stack/cable_coil,
+/obj/item/bedsheet{
+	icon_state = "sheetcmo"
 	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/clinic)
 "oqp" = (
 /obj/structure/chair/stool{
@@ -21579,40 +22547,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "oqu" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/machinery/door/poddoor/shutters{
+	id = "barshutters"
 	},
-/obj/effect/spawner/structure/window/reinforced/indestructable,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"oqA" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 10
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13/wood,
+/obj/structure/table/wood/settler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
+"oqA" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
+	},
+/area/f13/wasteland)
 "orm" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"orB" = (
-/obj/structure/rack,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/cotton,
-/obj/item/seeds/wheat,
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/followers)
-"orO" = (
-/obj/machinery/light/sign,
-/turf/closed/wall/f13/wood/interior,
-/area/f13/city)
 "orZ" = (
 /obj/structure/table/wood/settler,
 /obj/structure/guillotine,
@@ -21621,6 +22574,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"ose" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "osj" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -21683,6 +22640,18 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"oua" = (
+/mob/living/simple_animal/hostile/gecko,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
+"oum" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "ouS" = (
 /obj/structure/chair/stool,
 /turf/open/floor/f13{
@@ -21700,18 +22669,14 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ovE" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/f13/city)
 "ovN" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical"
+/obj/machinery/camera{
+	dir = 8;
+	name = "farm";
+	network = list("oasis")
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ovO" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -21719,13 +22684,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"ovR" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "owh" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass{
@@ -21748,13 +22706,6 @@
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
-"owG" = (
-/obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "owK" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -21834,27 +22785,26 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"oAA" = (
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "oAB" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"oAS" = (
-/obj/structure/fireplace,
-/turf/open/floor/carpet/black,
-/area/f13/city)
-"oBu" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/turf/open/floor/grass,
-/area/f13/city)
 "oBQ" = (
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0";
+	tag = "icon-verticalrightborderleft0"
+	},
+/area/f13/wasteland)
+"oCb" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0";
+	tag = "icon-verticalleftborderright0"
 	},
 /area/f13/wasteland)
 "oCg" = (
@@ -21885,22 +22835,12 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
-"oDm" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood/house,
-/area/f13/city)
 "oDC" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"oDR" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "oEd" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/indestructible/ground/outside/road{
@@ -21908,13 +22848,11 @@
 	},
 /area/f13/wasteland)
 "oEF" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/stool/retro/backed{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "oEU" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -21941,6 +22879,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"oFM" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_y = -11
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "oFP" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
@@ -21962,6 +22907,21 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2"
+	},
+/area/f13/wasteland)
+"oGL" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
+	},
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/tires,
+/obj/item/flag/followers,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
 "oGS" = (
@@ -22006,10 +22966,17 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"oHO" = (
+/obj/effect/decal/waste{
+	pixel_x = -4;
+	pixel_y = -7
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "oHR" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "oHS" = (
 /obj/structure/table,
@@ -22037,12 +23004,6 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
-"oIF" = (
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "oIL" = (
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22062,12 +23023,7 @@
 	},
 /area/f13/ncr)
 "oIQ" = (
-/obj/structure/sink{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "oIR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22082,10 +23038,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"oJm" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/armor/random,
+"oJj" = (
+/obj/item/kitchen/knife,
+/obj/structure/dresser,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"oJm" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "oJp" = (
 /obj/structure/chair/office,
@@ -22106,6 +23069,21 @@
 /obj/item/kitchen/knife/butcher,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"oJS" = (
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0";
+	tag = "icon-horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland)
+"oKf" = (
+/obj/item/candle/infinite,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/airless,
+/area/f13/legion)
 "oKi" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -22114,12 +23092,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"oKy" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright2"
+"oKq" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/caves)
+"oKy" = (
+/turf/open/floor/wood/f13/oakbroken,
+/area/f13/building)
 "oKA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom3"
@@ -22131,6 +23113,10 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"oLV" = (
+/mob/living/simple_animal/hostile/raider/biker,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "oLY" = (
 /obj/structure/chair/wood/worn{
 	dir = 4
@@ -22151,10 +23137,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"oMA" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "oMC" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -22167,9 +23149,14 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"oMR" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "oMY" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "oMZ" = (
 /obj/effect/decal/cleanable/glass,
@@ -22209,29 +23196,28 @@
 /obj/item/clothing/head/helmet/f13/raidercombathelmet,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"oOG" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/chem_pile{
-	pixel_x = -10;
-	pixel_y = -1
+"oOk" = (
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/clothing/head/hardhat,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/supermart,
-/area/f13/city)
+/area/f13/building)
 "oON" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "oOZ" = (
-/obj/structure/toilet,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/area/f13/clinic)
+/area/f13/building)
 "oPB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -22239,6 +23225,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"oPJ" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "oPO" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22265,9 +23256,11 @@
 	},
 /area/f13/wasteland)
 "oQv" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood,
-/area/f13/village)
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "oQM" = (
 /obj/structure/table/booth,
 /turf/open/floor/carpet/black,
@@ -22278,19 +23271,6 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
-"oRz" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/shreds{
-	pixel_x = -6;
-	pixel_y = -12
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "oRE" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/dirt/dark,
@@ -22300,14 +23280,6 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/village)
-"oRQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/boozeomat{
-	density = 0;
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "oRS" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -22370,28 +23342,44 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"oSX" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
+	},
+/area/f13/wasteland)
+"oTj" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "oTB" = (
 /obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "oUj" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
 	},
-/area/f13/wasteland)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "oUo" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "oUy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
 "oUI" = (
@@ -22400,14 +23388,40 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"oUO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "oUR" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/r_wall/rust,
-/area/f13/caves)
+/obj/effect/landmark/start/f13/shopkeeper,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/building)
 "oUV" = (
 /obj/machinery/mineral/wasteland_vendor/special,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"oUY" = (
+/obj/structure/closet,
+/obj/item/door_key{
+	id = 2;
+	name = "wasteland jail key"
+	},
+/turf/open/floor/plating,
+/area/f13/radiation)
+"oVa" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner (NORTH)"
+	},
+/area/f13/wasteland)
 "oVb" = (
 /obj/structure/simple_door/metal/fence{
 	door_type = "fence_wood";
@@ -22440,11 +23454,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
-"oVF" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/mob/living/simple_animal/opossum/poppy,
-/turf/open/floor/grass,
-/area/f13/city)
 "oVH" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
@@ -22461,14 +23470,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"oWn" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "oWv" = (
 /obj/structure/rack,
 /obj/item/storage/bag/plants,
@@ -22487,18 +23488,22 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "oWU" = (
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/structure/table/wood/fancy,
-/obj/effect/spawner/lootdrop/three_course_meal,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"oXd" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/caves)
+/area/f13/building)
+"oXd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/building)
 "oXe" = (
 /obj/structure/rack,
 /obj/item/clothing/head/fedora,
@@ -22518,35 +23523,51 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"oXK" = (
-/obj/item/instrument/eguitar{
-	anchored = 1;
-	pixel_x = 32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"oXV" = (
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+"oXp" = (
+/obj/structure/statue/sandstone/mars,
+/turf/open/floor/carpet/airless,
 /area/f13/legion)
+"oXA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/building)
+"oXV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "oYb" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/caves)
-"oYu" = (
-/obj/structure/simple_door/tent,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
-"oYI" = (
-/obj/effect/decal/waste{
-	pixel_x = 20;
-	pixel_y = 1
+"oYd" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outermaincornerinner"
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"oYh" = (
+/obj/structure/closet,
+/obj/item/storage/backpack/satchel/leather,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
 	},
 /area/f13/wasteland)
+"oYI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/workbench,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "oYS" = (
 /obj/machinery/jukebox,
 /turf/open/floor/wood/f13/carpet,
@@ -22566,15 +23587,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
-"oZC" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "124"
-	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/followers)
 "par" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -22598,16 +23610,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pbj" = (
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/fence{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "pbr" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/farm)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood,
+/area/f13/wasteland)
 "pbX" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
@@ -22625,7 +23639,7 @@
 /area/f13/brotherhood)
 "pck" = (
 /obj/structure/chair/wood,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "pcm" = (
 /obj/structure/billboard/cola,
@@ -22638,19 +23652,10 @@
 /turf/closed/wall/f13/store,
 /area/f13/village)
 "pcP" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/turf/open/floor/plasteel/chapel{
+	dir = 9
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
-/area/f13/wasteland)
-"pcT" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
+/area/f13/building)
 "pcV" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -22658,10 +23663,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
-"pcY" = (
-/obj/structure/simple_door/glass,
-/turf/open/floor/wood,
-/area/f13/village)
 "pdl" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
@@ -22671,8 +23672,7 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/legion)
 "pdx" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/closed/wall/f13/ruins,
 /area/f13/caves)
 "pea" = (
 /obj/structure/decoration/rag{
@@ -22699,10 +23699,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "peG" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 6
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/area/f13/village)
+/area/f13/building)
+"peH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken3,
+/area/f13/legion)
 "peX" = (
 /obj/structure/mirror,
 /turf/closed/wall/f13/wood,
@@ -22718,6 +23723,19 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
+"pfc" = (
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench";
+	tag = "icon-bench (WEST)"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "pfd" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/dirt{
@@ -22803,19 +23821,21 @@
 /obj/item/reagent_containers/syringe/medx,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"phF" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "pig" = (
 /obj/structure/chair/bench,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/caves)
-"pih" = (
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_y = 3
-	},
-/turf/closed/wall/f13/wood/interior,
-/area/f13/city)
 "pim" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -22832,7 +23852,7 @@
 "piw" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/caves)
 "piy" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -22843,6 +23863,14 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"pjn" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (EAST)"
+	},
+/area/f13/wasteland)
 "pjD" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -22851,12 +23879,11 @@
 	},
 /area/f13/building)
 "pjQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/chapel{
+	dir = 5
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "pjS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -22890,6 +23917,24 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"plH" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"pme" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/syringe/medx,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "pmg" = (
 /obj/structure/weightlifter,
 /turf/open/floor/f13/wood,
@@ -22919,11 +23964,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "pnw" = (
-/obj/machinery/light/sign/oasis_sign,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom2left"
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/chapel{
+	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "pnz" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -22938,6 +23983,15 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"pnB" = (
+/obj/machinery/trading_machine/medical,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "pok" = (
 /obj/structure/rack,
 /obj/item/seeds/xander,
@@ -22961,16 +24015,6 @@
 	icon_state = "innershade"
 	},
 /area/f13/wasteland)
-"pot" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"pow" = (
-/obj/structure/flora/wasteplant/wild_punga,
-/turf/open/water,
-/area/f13/radiation)
 "poS" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -22986,7 +24030,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/effect/landmark/start/f13/decanrec,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "ppg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23023,6 +24067,12 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
+"ppN" = (
+/obj/machinery/mineral/processing_unit_console{
+	machinedir = 1
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/building)
 "pqa" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -23062,22 +24112,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"pqP" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/f13/city)
-"prs" = (
-/obj/structure/sign/poster/prewar/poster89{
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "prw" = (
 /obj/structure/rack,
 /obj/item/paper,
@@ -23151,11 +24185,12 @@
 	},
 /area/f13/ncr)
 "psR" = (
-/obj/structure/fence/corner/wooden{
-	dir = 1
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "clinicladder"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "psT" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/road{
@@ -23177,6 +24212,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ptt" = (
+/obj/structure/table/wood/fancy,
+/obj/item/candle,
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "ptP" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/desert,
@@ -23184,20 +24224,31 @@
 "pud" = (
 /turf/closed/wall/f13/wood,
 /area/f13/clinic)
-"puP" = (
-/obj/structure/rack,
-/obj/item/seeds/cannabis,
-/turf/open/floor/f13/wood,
+"puN" = (
+/obj/item/trash/sosjerky{
+	pixel_x = -6
+	},
+/obj/item/trash/sosjerky{
+	pixel_x = 1;
+	pixel_y = 10
+	},
+/obj/item/trash/sosjerky{
+	icon_state = "dr_gibb";
+	pixel_x = 4;
+	pixel_y = -3;
+	tag = "icon-dr_gibb"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"puP" = (
+/obj/structure/dresser,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "puX" = (
-/obj/structure/fence{
-	dir = 1
+/turf/open/floor/plasteel/chapel{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
+/area/f13/building)
 "pvn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -23215,6 +24266,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"pvP" = (
+/obj/item/poster/random_contraband,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"pvS" = (
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "pwc" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -23237,12 +24296,22 @@
 /area/f13/village)
 "pxf" = (
 /obj/structure/table/wood,
-/obj/item/stack/cable_coil,
-/obj/item/bedsheet{
-	icon_state = "sheetcmo"
-	},
+/obj/item/kitchen/knife,
+/obj/item/screwdriver,
+/obj/item/hatchet,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"pxs" = (
+/obj/structure/window/fulltile/wood,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/structure/fence{
+	dir = 1;
+	pixel_x = -18
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "pxw" = (
 /obj/structure/fence/pole_b,
 /obj/structure/table/wood/settler,
@@ -23261,13 +24330,15 @@
 	},
 /area/f13/building)
 "pya" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 9;
-	icon_state = "outerpavement"
+/obj/structure/simple_door/house{
+	icon_state = "glass";
+	tag = "icon-glass"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "pye" = (
 /obj/structure/debris/v3,
 /obj/structure/simple_door/bunker,
@@ -23279,6 +24350,10 @@
 	dir = 1;
 	icon_state = "outerpavementcorner"
 	},
+/area/f13/wasteland)
+"pyj" = (
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "pyk" = (
 /obj/item/radio/intercom{
@@ -23297,6 +24372,19 @@
 	icon_state = "bench"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
+"pyM" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/obj/structure/tires/five{
+	pixel_x = -19;
+	pixel_y = -3
+	},
+/obj/machinery/light/sign/oasis_sign,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
 /area/f13/wasteland)
 "pyX" = (
 /obj/structure/chair/booth{
@@ -23319,33 +24407,32 @@
 	icon_state = "dirt"
 	},
 /area/f13/legion)
-"pzm" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
-	},
-/area/f13/city)
 "pzJ" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/relaxedwear,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"pzN" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	layer = 6;
-	pixel_x = -6;
-	pixel_y = 13
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/f13/city)
+"pzQ" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"pzV" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "pAc" = (
 /obj/item/clothing/head/helmet/f13/motorcycle,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
+"pAd" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "pAg" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/fakelattice{
@@ -23356,9 +24443,6 @@
 "pAm" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
-"pAA" = (
-/turf/open/floor/wood,
-/area/f13/village)
 "pAU" = (
 /obj/structure/sink,
 /turf/open/floor/f13{
@@ -23390,7 +24474,7 @@
 /area/f13/wasteland)
 "pBM" = (
 /obj/effect/landmark/start/f13/venator,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oakbroken,
 /area/f13/legion)
 "pBO" = (
 /mob/living/simple_animal/hostile/handy/protectron,
@@ -23403,17 +24487,17 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
 "pCf" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "radio"
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/area/f13/building)
 "pCi" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "pCy" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -23421,36 +24505,18 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"pDd" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetcmo"
+"pDH" = (
+/obj/structure/toilet,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/clinic)
 "pDR" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
-"pDX" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = 30
-	},
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_x = 30
-	},
-/obj/item/flashlight/lamp,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/village)
 "pEk" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23458,16 +24524,6 @@
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
-"pEs" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "pEt" = (
 /obj/structure/window/fulltile/ruins,
 /obj/structure/curtain{
@@ -23513,35 +24569,44 @@
 /obj/structure/decoration/rag,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"pGa" = (
-/turf/closed/wall/f13/wood/interior,
-/area/f13/city)
-"pHc" = (
-/obj/structure/rack,
-/obj/item/storage/box/disks_plantgene,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+"pFS" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"pFZ" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft3";
+	tag = "icon-verticalleftborderleft3"
 	},
-/area/f13/followers)
+/area/f13/wasteland)
 "pHh" = (
 /obj/structure/sign/poster/prewar/poster94,
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
 "pHi" = (
-/obj/structure/bed,
-/obj/effect/decal/remains{
-	icon_state = "remains"
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 1;
+	output_dir = 2
 	},
-/obj/machinery/light/small{
-	dir = 1
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
 "pHm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/reinforced/indestructable,
-/turf/open/floor/grass,
-/area/f13/wasteland)
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "pHx" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -23579,6 +24644,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"pIa" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "pIi" = (
 /obj/structure/closet,
 /obj/item/clothing/under/f13/doctor,
@@ -23592,18 +24665,39 @@
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"pIy" = (
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/wasteland)
 "pIz" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
-"pIC" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+"pIB" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
 	},
-/area/f13/city)
+/area/f13/building)
+"pIK" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"pIN" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0";
+	tag = "icon-verticalleftborderright0"
+	},
+/area/f13/wasteland)
 "pIO" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -23625,21 +24719,23 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"pJt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters button";
-	pixel_y = 32;
-	req_one_access_txt = "28"
+"pJq" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/turf/open/floor/plating,
+/area/f13/caves)
 "pJQ" = (
 /obj/structure/simple_door/wood,
 /obj/structure/decoration/rag,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"pJR" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner"
+	},
+/area/f13/wasteland)
 "pJT" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23655,6 +24751,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"pKm" = (
+/obj/structure/wreck/trash/five_tires,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "pKq" = (
 /obj/structure/necropolis_gate{
 	desc = "A massive stone gateway with a very heavy stone door.";
@@ -23664,12 +24764,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pKP" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/knife,
-/obj/item/screwdriver,
-/obj/item/hatchet,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/structure/bus_door,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland)
 "pKY" = (
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/inside/mountain,
@@ -23710,13 +24809,12 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "pMf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/structure/simple_door/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "pMh" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
@@ -23737,15 +24835,13 @@
 "pMI" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland)
-"pNk" = (
-/obj/machinery/power/solar_control{
-	dir = 8
+"pNj" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottomright";
+	tag = "icon-horizontalbottomborderbottomright"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/area/f13/wasteland)
 "pNw" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -23760,6 +24856,12 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
+"pNN" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "pNP" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23775,11 +24877,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
-"pNZ" = (
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+"pNY" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom2";
+	tag = "icon-horizontalbottomborderbottom2"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "pOb" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -23794,13 +24897,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "pOo" = (
-/obj/item/reagent_containers/pill/patch/jet,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/machinery/microwave/stove,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "pOw" = (
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/machinery/iv_drip,
+/turf/open/floor/f13/wood,
 /area/f13/clinic)
 "pOC" = (
 /obj/structure/fence/post{
@@ -23816,13 +24918,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"pOL" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2left"
-	},
-/area/f13/city)
 "pOM" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -23847,11 +24942,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"pQF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "pQL" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/effect/landmark/start/f13/decan,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "pQX" = (
 /obj/structure/fence/post{
@@ -23878,7 +24982,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/effect/landmark/start/f13/recleg,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "pRo" = (
 /obj/structure/table/wood/settler,
@@ -23908,13 +25012,16 @@
 	},
 /area/f13/ncr)
 "pSk" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_x = -19;
-	pixel_y = 9
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "133"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/machinery/door/poddoor/shutters{
+	id = "clinicfrontdoor";
+	name = "clinic shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "pSn" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
@@ -23922,27 +25029,33 @@
 	},
 /area/f13/wasteland)
 "pSo" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/landmark/start/f13/barkeep,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "pSp" = (
 /obj/structure/table/wood,
 /obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"pSt" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "pSu" = (
 /obj/structure/closet{
 	pixel_y = 10
 	},
 /obj/item/restraints/handcuffs,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "pSC" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/retro/backed{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "pSE" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -23984,6 +25097,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"pUi" = (
+/obj/effect/decal/riverbank{
+	dir = 1
+	},
+/turf/open/water,
+/area/f13/wasteland)
 "pUo" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
@@ -24005,27 +25124,16 @@
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
-"pVp" = (
-/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
-	anchored = 1;
-	pixel_x = -36
-	},
-/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
-	anchored = 1;
-	pixel_x = -28
-	},
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_x = -32
-	},
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "pVF" = (
 /obj/machinery/light,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"pVI" = (
+/obj/structure/bed/dogbed,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pVT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -24060,6 +25168,12 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
+"pWw" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2";
+	tag = "icon-verticalleftborderleft2"
+	},
+/area/f13/wasteland)
 "pWx" = (
 /obj/structure/table/wood,
 /obj/item/pickaxe,
@@ -24100,13 +25214,39 @@
 	},
 /area/f13/wasteland)
 "pYa" = (
-/obj/machinery/iv_drip,
+/obj/structure/table/wood,
+/obj/item/weldingtool,
+/obj/item/crowbar,
+/obj/item/wirecutters{
+	icon_state = "cutters"
+	},
+/obj/item/reagent_containers/pill/patch/jet,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"pYb" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "pYj" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"pYF" = (
+/obj/structure/simple_door/house{
+	icon_state = "interior";
+	tag = "icon-interior"
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "pYH" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -24114,11 +25254,11 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/village)
 "pYN" = (
-/obj/item/flag/oasis,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
+/obj/structure/chair/booth{
+	dir = 4
 	},
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "pZl" = (
 /obj/structure/decoration/clock{
 	pixel_y = 21
@@ -24128,10 +25268,9 @@
 	},
 /area/f13/village)
 "qac" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
 "qaf" = (
@@ -24155,8 +25294,9 @@
 	},
 /area/f13/building)
 "qal" = (
-/turf/open/water,
-/area/f13/radiation)
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating,
+/area/f13/caves)
 "qaq" = (
 /obj/machinery/button/door{
 	id = "bosgarage";
@@ -24165,12 +25305,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "qbe" = (
-/obj/structure/table,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/legion)
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "qbl" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24178,6 +25317,13 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"qbA" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	tag = "icon-housewindow"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qbB" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
@@ -24207,6 +25353,14 @@
 /obj/effect/decal/marking,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"qcq" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "qcz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -24214,21 +25368,19 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "qcS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"qcT" = (
+/obj/structure/barricade/tentclothedge,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/farm)
-"qcT" = (
-/obj/structure/chair/comfy{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerbordercorner"
-	},
-/area/f13/city)
+/area/f13/building)
 "qcV" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -24288,14 +25440,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"qed" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood,
-/area/f13/city)
-"qer" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/followers)
+"qeh" = (
+/mob/living/simple_animal/hostile/gecko,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "qeM" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -24366,10 +25514,26 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "qhs" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/structure/table,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
+"qhD" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
+"qhE" = (
+/obj/structure/simple_door/tentflap_cloth,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
+"qie" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qij" = (
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
@@ -24381,6 +25545,9 @@
 	},
 /area/f13/farm)
 "qip" = (
+/obj/structure/fence/corner{
+	dir = 6
+	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirtcorner"
@@ -24390,10 +25557,6 @@
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/wood,
 /area/f13/village)
-"qiU" = (
-/obj/structure/chair/stool/retro,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "qiV" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13/wood,
@@ -24404,15 +25567,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
-"qjj" = (
-/obj/structure/table/optable,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/followers)
 "qjm" = (
 /obj/structure/fence{
 	dir = 4
@@ -24436,10 +25590,13 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"qjF" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+"qjZ" = (
+/obj/machinery/light/lampost,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
+	},
+/area/f13/wasteland)
 "qka" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/fakelattice{
@@ -24454,6 +25611,15 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"qkB" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "qkO" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24471,23 +25637,18 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
 "qlv" = (
-/obj/structure/table/wood,
-/obj/item/weldingtool,
-/obj/item/crowbar,
-/obj/item/wirecutters{
-	icon_state = "cutters"
-	},
-/obj/item/reagent_containers/pill/patch/jet,
+/obj/structure/rack,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "qlE" = (
-/obj/structure/decoration/hatch{
-	dir = 8
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2bottom"
-	},
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "qlW" = (
 /obj/structure/decoration/rag,
 /obj/structure/simple_door/wood,
@@ -24533,7 +25694,7 @@
 /obj/item/claymore/machete/training,
 /obj/item/claymore/machete/training,
 /obj/item/claymore/machete/training,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "qnR" = (
 /obj/effect/decal/remains{
@@ -24546,6 +25707,15 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
+"qob" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/legion)
 "qod" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -24556,11 +25726,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "qoj" = (
-/obj/machinery/mineral/wasteland_vendor/crafting{
-	icon_state = "parts_idle"
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/structure/table,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "qop" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/dirt,
@@ -24572,23 +25744,34 @@
 	},
 /area/f13/village)
 "qot" = (
-/obj/structure/simple_door/metal/fence{
-	door_type = "fence_wood";
-	icon_state = "fence_wood"
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"qov" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical";
+	tag = "icon-housewindowvertical"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"qoJ" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom2left";
+	tag = "icon-horizontalbottomborderbottom2left"
+	},
+/area/f13/wasteland)
 "qoS" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft1"
 	},
 /area/f13/wasteland)
-"qpJ" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"qpx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken4,
+/area/f13/legion)
 "qpM" = (
 /obj/machinery/mineral/wasteland_vendor/general,
 /turf/open/indestructible/ground/outside/desert,
@@ -24604,26 +25787,6 @@
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"qqK" = (
-/obj/structure/chair/stool/f13stool{
-	pixel_x = -8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"qqQ" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
-"qrw" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "qrL" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light/small{
@@ -24659,15 +25822,14 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qsL" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6";
-	pixel_x = -28
+"qsS" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2top"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "qsX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -24688,23 +25850,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "quy" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/legion)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "quV" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/knife/butcher,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qvu" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowbottom"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "qvN" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -24744,29 +25898,36 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"qwf" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "qwi" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/radiation)
-"qwp" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_x = 30
+"qwn" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = -30
-	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/village)
+/area/f13/building)
 "qwq" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/stage_tl,
-/area/f13/wasteland)
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "qwW" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"qxe" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qxn" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4;
@@ -24784,19 +25945,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"qxN" = (
-/obj/structure/closet/crate/wicker,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "qxO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
 	},
 /area/f13/tunnel)
 "qyj" = (
-/obj/item/toy/cattoy,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "qyH" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood{
@@ -24812,16 +25970,14 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
+"qyU" = (
+/obj/structure/simple_door/house,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qyZ" = (
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/legion)
-"qzr" = (
-/obj/structure/rack,
-/obj/item/storage/pill_bottle/chem_tin/radx,
-/obj/item/storage/pill_bottle/chem_tin/radx,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "qzt" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24852,11 +26008,11 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
 "qAc" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/window/fulltile/wood{
+	layer = 3
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
 "qAA" = (
 /obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/indestructible/ground/inside/mountain,
@@ -24873,21 +26029,26 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"qAS" = (
-/obj/effect/landmark/start/f13/farmer,
+"qAR" = (
+/obj/item/claymore/machete/training,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
-"qBq" = (
-/obj/structure/table/wood/fancy,
-/obj/item/candle,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/area/f13/legion)
+"qBf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "qBu" = (
 /obj/structure/closet/crate{
 	anchored = 1;
 	can_be_unanchored = 1
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "qCb" = (
 /obj/structure/closet/crate/medical,
@@ -24908,18 +26069,28 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"qCu" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "qCv" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"qCT" = (
+/obj/structure/closet/fridge/cannibal,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qCX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "qDe" = (
 /obj/item/flashlight/lamp,
@@ -24927,6 +26098,10 @@
 /obj/item/clothing/head/festive,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"qDi" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "qDs" = (
 /obj/structure/chair/stool,
 /turf/open/floor/f13/wood,
@@ -24944,27 +26119,35 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "qDM" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	pixel_x = -1;
-	pixel_y = 2
+/obj/structure/barricade/bars,
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "hole"
+	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
+"qDS" = (
+/obj/structure/table/wood/settler,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/spray/pestspray,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "qDV" = (
 /obj/item/trash/sosjerky{
 	pixel_x = -6
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"qDY" = (
-/obj/machinery/vending/medical{
-	req_access = null
-	},
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
 "qEb" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24978,12 +26161,10 @@
 	},
 /area/f13/wasteland)
 "qEj" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qEU" = (
 /obj/item/clothing/under/f13/police,
 /obj/item/clothing/head/f13/police,
@@ -25008,6 +26189,13 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"qFI" = (
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "qFM" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/machinery/light/small/broken{
@@ -25015,15 +26203,6 @@
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"qGa" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
-"qGx" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/book/bible,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "qGZ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outermaincornerinner"
@@ -25040,14 +26219,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"qHn" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
-	},
-/turf/open/floor/wood/f13/stage_tl,
-/area/f13/city)
 "qHu" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -25058,11 +26229,9 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "qHx" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/landmark/start/f13/shopkeeper,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qHL" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -25089,16 +26258,26 @@
 	},
 /area/f13/brotherhood)
 "qHZ" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_y = 12
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/building)
 "qIa" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"qIc" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/legion)
 "qIj" = (
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
@@ -25134,13 +26313,13 @@
 	},
 /area/f13/building)
 "qIE" = (
-/obj/effect/decal/waste{
-	pixel_x = -4;
-	pixel_y = -7
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
+"qJl" = (
+/obj/structure/lamp_post/quadra,
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outermaincornerinner"
+	icon_state = "verticalrightborderright2bottom"
 	},
 /area/f13/wasteland)
 "qJB" = (
@@ -25154,12 +26333,8 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "qJR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerbordercorner"
-	},
+/obj/structure/simple_door/room,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/wasteland)
 "qJZ" = (
 /obj/machinery/seed_extractor,
@@ -25167,10 +26342,16 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"qKe" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/f13/city)
+"qKz" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating,
+/area/f13/building)
+"qKL" = (
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/clinic)
 "qKU" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -25196,16 +26377,29 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"qLT" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbrokenvertical";
+	tag = "icon-housewindowbrokenvertical (NORTHEAST)"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
+"qLX" = (
+/obj/structure/simple_door/wood,
+/obj/item/lock{
+	id = 2;
+	name = "wasteland jail"
+	},
+/turf/open/floor/plating,
+/area/f13/radiation)
 "qMi" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/village)
-"qMj" = (
-/obj/structure/table/wood,
-/obj/item/lighter,
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "qMn" = (
 /obj/structure/table,
 /obj/item/healthanalyzer,
@@ -25277,10 +26471,6 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"qOd" = (
-/obj/structure/rack,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "qOm" = (
 /obj/structure/campfire/stove,
 /turf/open/floor/f13/wood{
@@ -25346,6 +26536,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
+"qPk" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "qPp" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/rat,
@@ -25358,13 +26555,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"qPs" = (
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -15
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/followers)
 "qPG" = (
 /obj/structure/sign/poster/contraband/revolver,
 /turf/closed/wall/f13/tunnel,
@@ -25373,20 +26563,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "qPQ" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"qPS" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
-"qPW" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/turf/open/floor/grass,
-/area/f13/city)
-"qQe" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/turf/open/floor/plasteel/chapel{
+	dir = 10
+	},
+/area/f13/building)
 "qQf" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/white/box,
@@ -25405,6 +26585,17 @@
 	icon_state = "verticalrightborderright2"
 	},
 /area/f13/wasteland)
+"qQp" = (
+/obj/structure/spider/stickyweb,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "qQD" = (
 /obj/machinery/deepfryer,
 /obj/machinery/light/small{
@@ -25421,6 +26612,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
+"qQN" = (
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qQQ" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -25511,14 +26706,10 @@
 	},
 /area/f13/legion)
 "qTa" = (
-/obj/structure/fence/corner{
-	dir = 1
+/turf/open/floor/plasteel/chapel{
+	dir = 6
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/legion)
+/area/f13/building)
 "qTe" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
@@ -25527,11 +26718,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"qTr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/f13/city)
 "qTt" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -25556,6 +26742,11 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"qTN" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/suit/armor/f13/leatherarmor,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qTP" = (
 /obj/effect/landmark/start/f13/Hhunter,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25572,19 +26763,21 @@
 	},
 /area/f13/wasteland)
 "qUC" = (
-/obj/structure/fence{
-	dir = 1
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavement"
+/area/f13/building)
+"qUK" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical"
 	},
-/area/f13/wasteland)
-"qUO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/floor/grass,
-/area/f13/city)
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qUZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -25596,6 +26789,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"qWg" = (
+/obj/item/trash/pistachios,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "qWp" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -25603,19 +26800,14 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"qWG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "qWQ" = (
 /obj/structure/fluff/fokoff_sign,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qWU" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/f13/wood,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/breadhard,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "qWX" = (
 /obj/structure/rack,
@@ -25630,12 +26822,28 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"qXi" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken (NORTHEAST)"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "qXk" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"qXn" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2";
+	tag = "icon-verticalleftborderright2"
+	},
+/area/f13/wasteland)
 "qXo" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
@@ -25643,6 +26851,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"qXr" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "qYD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -25653,19 +26869,12 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/f13/tunnel,
 /area/f13/wasteland)
-"qZI" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 4
-	},
-/area/f13/village)
 "qZO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/reinforced/indestructable,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife/cosmicdirty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "ram" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -25673,6 +26882,15 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"raq" = (
+/obj/effect/decal/remains/human,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "ras" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -25689,6 +26907,15 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
+"rbc" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/wood/settler,
+/obj/item/kitchen/knife,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rbe" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "hole"
@@ -25708,12 +26935,12 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "rbF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
+/obj/machinery/sleeper{
+	density = 1;
+	dir = 4
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "rbJ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -25723,15 +26950,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/legion)
-"rco" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "rcC" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -25741,6 +26959,18 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"rcL" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2right";
+	tag = "icon-horizontalinnermain2right"
+	},
+/area/f13/wasteland)
+"rcP" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left";
+	tag = "icon-horizontaloutermain2left"
+	},
+/area/f13/wasteland)
 "rcS" = (
 /obj/item/clothing/suit/armor/f13/metalarmor{
 	icon_state = "armorkit"
@@ -25760,6 +26990,10 @@
 /obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"rdd" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/f13/caves)
 "rdy" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood{
@@ -25767,9 +27001,8 @@
 	},
 /area/f13/building)
 "rdC" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rdQ" = (
 /obj/structure/decoration/clock{
@@ -25782,12 +27015,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"rdW" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
-	},
-/area/f13/wasteland)
 "rec" = (
 /turf/closed/indestructible/rock,
 /area/f13/wasteland)
@@ -25804,6 +27031,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"reo" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/f13/caves)
 "rex" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -25817,6 +27050,18 @@
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
+"reU" = (
+/obj/structure/closet/crate/bin,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
+	},
+/area/f13/wasteland)
+"rfx" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/breadhard,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "rfP" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/barber{
@@ -25824,18 +27069,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"rfR" = (
+/turf/open/floor/wood/f13/oakbroken,
+/area/f13/legion)
 "rgI" = (
-/obj/effect/lamp_post/traffic_light/left{
-	pixel_x = -14
-	},
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright3"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "rgS" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -25849,6 +27089,11 @@
 /obj/structure/rack,
 /obj/item/clothing/shoes/f13/diesel/alt,
 /obj/item/clothing/shoes/f13/diesel/alt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"rhp" = (
+/obj/structure/closet/cabinet,
+/obj/item/dildo,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rhr" = (
@@ -25882,10 +27127,10 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "rja" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/obj/structure/chair{
+	dir = 4
 	},
+/turf/open/floor/f13/wood,
 /area/f13/clinic)
 "rjD" = (
 /turf/open/indestructible/ground/outside/ruins{
@@ -25934,6 +27179,9 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"rlo" = (
+/turf/closed/wall/f13/ruins,
+/area/f13/city)
 "rls" = (
 /obj/structure/toilet,
 /obj/item/stack/f13Cash/random/ncr/low,
@@ -25996,6 +27244,12 @@
 /obj/structure/window/fulltile/ruins,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"roh" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland)
 "rot" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -26013,13 +27267,24 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "rpa" = (
-/obj/structure/fence/wooden{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/white{
+	desc = "It's a strangely clean little white rodent.";
+	name = "Algernon"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "rpu" = (
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"rpD" = (
+/obj/structure/chair,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
 "rpF" = (
 /obj/effect/turf_decal/stripes/line{
@@ -26037,6 +27302,18 @@
 	icon_state = "horizontaltopbordertop2right"
 	},
 /area/f13/wasteland)
+"rqx" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/legion)
 "rqW" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -26048,6 +27325,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"rrk" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "rrl" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -26058,6 +27339,22 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/brotherhood)
+"rrA" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
+"rrB" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "rrC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/hatch{
@@ -26079,6 +27376,11 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"rtf" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/wasteland)
 "rtl" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleplate"
@@ -26094,41 +27396,44 @@
 	},
 /turf/open/water,
 /area/f13/caves)
+"rub" = (
+/obj/item/trash/chips,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ruD" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/turbo,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "ruN" = (
-/obj/effect/decal/cleanable/generic,
+/obj/structure/sign/poster/prewar/poster61{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/city)
+/area/f13/building)
 "rvf" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2bottom"
 	},
 /area/f13/village)
-"rvr" = (
-/obj/structure/musician/piano{
-	desc = "What a wierd piano..";
-	name = "minimoog"
+"rvx" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
 	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/village)
-"rvT" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "124"
+/obj/structure/debris/v3,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermaintop"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "botany";
-	name = "Botany shutters"
+/area/f13/wasteland)
+"rvP" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "innermaincornerinner";
+	tag = "icon-innermaincornerinner (WEST)"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
+/area/f13/wasteland)
 "rwv" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/mountain,
@@ -26156,6 +27461,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"rxo" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	tag = "icon-wooden_chair_new (NORTH)"
+	},
+/obj/machinery/light/small,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "rxt" = (
 /obj/structure/sign/poster/contraband/pinup_ride,
 /turf/closed/wall/f13/wood/house,
@@ -26164,18 +27477,15 @@
 /obj/machinery/light/small/broken,
 /turf/open/water,
 /area/f13/caves)
+"rxW" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "ryc" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"rym" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/farm)
+/turf/open/floor/wood/f13/oakbroken3,
+/area/f13/building)
 "ryn" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -26190,12 +27500,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"ryO" = (
-/obj/structure/rack,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
 "ryS" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26215,12 +27519,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"rzn" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2top"
-	},
-/area/f13/city)
 "rzR" = (
 /obj/machinery/light{
 	dir = 8
@@ -26229,7 +27527,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "rzV" = (
-/mob/living/simple_animal/hostile/radroach,
+/obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "rAe" = (
@@ -26244,11 +27542,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
-"rAf" = (
-/obj/structure/chair/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "rAm" = (
 /obj/structure/table/wood,
 /obj/item/paper,
@@ -26305,9 +27598,6 @@
 	icon_state = "verticalrightborderleft2"
 	},
 /area/f13/wasteland)
-"rDd" = (
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/city)
 "rDj" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -26316,30 +27606,21 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"rDT" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/melee/chainofcommand{
-	name = "chain whip"
-	},
-/obj/item/storage/briefcase,
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "rEc" = (
-/obj/structure/bed,
-/obj/effect/decal/remains{
-	icon_state = "remains"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/bedsheet{
-	icon_state = "sheetblue"
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plating,
 /area/f13/building)
 "rEd" = (
 /obj/structure/table/wood,
 /obj/item/pda,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"rEg" = (
+/obj/item/chair/wood,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "rEi" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
@@ -26350,10 +27631,16 @@
 	pixel_x = -5;
 	pixel_y = 7
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "rEB" = (
-/obj/structure/simple_door/interior,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "rFc" = (
@@ -26363,17 +27650,20 @@
 	},
 /area/f13/village)
 "rFk" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/bed/mattress/pregame,
+/turf/open/floor/plating,
+/area/f13/radiation)
 "rFx" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"rFD" = (
+/obj/machinery/vending/snack,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/building)
 "rGl" = (
 /obj/structure/chalkboard,
 /obj/machinery/light/small/broken{
@@ -26387,20 +27677,36 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "rGC" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/tunnel)
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rGE" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"rGT" = (
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing";
+	tag = "icon-glassclosing"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
+"rHA" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/building)
 "rHE" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/obj/item/clothing/under/f13/classdress,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "rHO" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
@@ -26412,11 +27718,14 @@
 /area/f13/village)
 "rHT" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
+	dir = 8;
+	light_color = "#008000";
+	name = "light tube"
 	},
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "rIA" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -26426,16 +27735,14 @@
 /obj/structure/cross,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"rJB" = (
+/obj/item/ammo_casing/caseless,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rJO" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/reinforced/indestructable,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oakbroken,
+/area/f13/building)
 "rJT" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -26443,11 +27750,6 @@
 /obj/structure/decoration/rag,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"rJU" = (
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "rKh" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -26470,11 +27772,20 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "rLi" = (
-/obj/structure/decoration/hatch{
-	dir = 8
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
+	icon_state = "verticalleftborderright0"
+	},
+/area/f13/wasteland)
+"rLn" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerborder";
+	tag = "icon-outerborder (NORTH)"
 	},
 /area/f13/wasteland)
 "rLP" = (
@@ -26490,6 +27801,17 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innershade"
 	},
+/area/f13/wasteland)
+"rMd" = (
+/obj/item/shovel,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"rMl" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "rMq" = (
 /obj/structure/fence/corner/wooden{
@@ -26527,15 +27849,6 @@
 	icon_state = "shadowright"
 	},
 /area/f13/wasteland)
-"rNI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/city)
 "rNT" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/cowboyt,
@@ -26577,12 +27890,30 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"rPM" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
+"rOF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/prewar/poster86{
+	pixel_y = -32
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
+"rOT" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "mine"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"rPM" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Store Backroom";
+	req_one_access_txt = "34"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rPR" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -26609,19 +27940,25 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"rQE" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_2"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "rQG" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/solar,
+/obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/area/f13/wasteland)
 "rQI" = (
 /obj/structure/closet/crate/large,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "rQR" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -26629,6 +27966,11 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"rQU" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rRi" = (
 /obj/machinery/grill{
 	desc = "I am your captain. You are on guard duty.";
@@ -26636,12 +27978,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"rRo" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "rRt" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -26657,6 +27993,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"rRQ" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plating,
+/area/f13/caves)
 "rRR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleftbottom"
@@ -26666,19 +28006,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"rSc" = (
-/obj/structure/decoration/rag,
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Sheriff Office";
-	req_one_access_txt = "62"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "rSf" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood,
-/area/f13/village)
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
+	},
+/area/f13/wasteland)
 "rSq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -26703,20 +28039,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"rTt" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/building)
-"rTu" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gibleg"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/building)
 "rTG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/smartfridge/bottlerack/gardentool,
@@ -26724,11 +28046,21 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"rTM" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/suit/armor/f13/raider/yankee,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rTY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/shutters{
+	id = "countershutters";
+	name = "counter shutters"
+	},
+/obj/structure/barricade/bars,
+/obj/structure/railing,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rUp" = (
 /obj/item/kirbyplants/random{
 	pixel_y = 8
@@ -26740,24 +28072,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"rUD" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_x = -31;
-	pixel_y = -11
+"rUC" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright1";
+	tag = "icon-verticalrightborderright1"
 	},
-/obj/effect/decal/waste,
-/turf/open/water,
-/area/f13/radiation)
-"rVr" = (
-/obj/structure/sink/well,
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"rVB" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 9
-	},
-/area/f13/village)
+"rVr" = (
+/obj/structure/sacrificealtar,
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "rVK" = (
 /obj/effect/landmark/poster_spawner/prewar,
 /turf/closed/wall/f13/store,
@@ -26777,16 +28101,16 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
+"rWL" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "rWN" = (
 /obj/structure/closet/crate/bin,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"rWQ" = (
-/obj/machinery/plantgenes,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "rXa" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13/wood{
@@ -26821,10 +28145,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"rXu" = (
-/obj/structure/chair/wood,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "rXv" = (
 /obj/structure/simple_door/metal/fence{
 	door_type = "fence_wood";
@@ -26840,6 +28160,18 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"rYd" = (
+/obj/structure/closet/bus,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
+"rYF" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/obj/effect/spawner/lootdrop/clothing_high,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rYS" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26854,6 +28186,24 @@
 	icon_state = "housewood2"
 	},
 /area/f13/radiation)
+"rZx" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/f13/leatherarmor,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/light/small,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
+"rZG" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/legion)
 "rZK" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt{
@@ -26864,18 +28214,21 @@
 	},
 /area/f13/ncr)
 "saf" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/area/f13/legion)
+/area/f13/building)
 "sap" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/area/f13/legion)
+/area/f13/building)
 "say" = (
 /obj/structure/chair,
 /obj/effect/decal/remains{
@@ -26884,6 +28237,17 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"saz" = (
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/building)
 "saA" = (
@@ -26904,6 +28268,21 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"saZ" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/knife,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"sbk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "sbD" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26922,6 +28301,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"scr" = (
+/obj/structure/table,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "scB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -26935,15 +28324,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"scW" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = -1
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/city)
 "scY" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13{
@@ -26971,6 +28351,15 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/building)
+"sea" = (
+/obj/structure/table,
+/obj/item/storage/belt/medical,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "sed" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -26985,11 +28374,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"seB" = (
-/obj/structure/closet/cabinet,
-/obj/item/hand_labeler,
-/turf/open/floor/wood/f13/stage_br,
-/area/f13/city)
 "seE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hydroponics/constructable,
@@ -27015,7 +28399,7 @@
 "seY" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "sfc" = (
 /obj/structure/chair{
@@ -27027,6 +28411,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"sft" = (
+/obj/structure/sink{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "sfA" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/button{
@@ -27038,8 +28430,11 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"sfB" = (
-/turf/closed/wall/r_wall/rust,
+"sfD" = (
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/city)
 "sfI" = (
 /obj/structure/rack,
@@ -27078,11 +28473,11 @@
 	},
 /area/f13/brotherhood)
 "sgr" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerbordercorner"
+/obj/structure/chair/wood,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "sgw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hydroponics/constructable,
@@ -27100,9 +28495,7 @@
 	pixel_x = -7;
 	pixel_y = 5
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "sgL" = (
 /obj/item/mop,
@@ -27120,9 +28513,6 @@
 	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/caves)
-"shd" = (
-/turf/open/floor/plasteel/grimy,
-/area/f13/village)
 "shf" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/metal{
@@ -27131,15 +28521,48 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"shg" = (
+/obj/structure/simple_door/fakeglass,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/wasteland)
+"shn" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/floor/plating,
+/area/f13/radiation)
 "shp" = (
 /obj/machinery/light/broken,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"shu" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "shF" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/tentwall,
+/area/f13/building)
+"shT" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
+"shW" = (
+/obj/structure/table/wood,
+/obj/item/candle/infinite,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
+"sid" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "sif" = (
 /obj/structure/car/rubbish1,
@@ -27147,29 +28570,10 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"sik" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	pixel_x = -6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/f13/city)
 "sim" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"sio" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/f13/city)
-"siu" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/f13/city)
 "siE" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -27224,6 +28628,10 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"sjy" = (
+/obj/structure/chair,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "sjX" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light/small{
@@ -27252,11 +28660,12 @@
 	},
 /area/f13/building)
 "sln" = (
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
-	},
-/area/f13/wasteland)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "slr" = (
 /obj/structure/chair/wood/modern,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -27280,35 +28689,31 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"slM" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	req_one_access_txt = "25"
+"slQ" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "busladder"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2right"
+	},
+/area/f13/wasteland)
 "slT" = (
-/obj/item/clothing/head/helmet/f13/rustedcowboyhat,
-/obj/item/clothing/suit/armor/f13/rustedcowboy,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"slU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/supermart,
 /area/f13/building)
 "sme" = (
 /obj/structure/bookcase/random/fiction,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"smh" = (
-/obj/structure/table/wood,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/pen,
-/obj/item/pen,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1{
-	layer = 2.1
-	},
-/turf/open/floor/wood,
-/area/f13/village)
 "smi" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -27321,6 +28726,13 @@
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"smp" = (
+/obj/structure/simple_door/metal/fence{
+	door_type = "fence_wood";
+	icon_state = "fence_wood"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "smw" = (
 /obj/structure/chair/wood/fancy{
 	dir = 8
@@ -27348,11 +28760,14 @@
 	},
 /area/f13/ncr)
 "snA" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
 "snB" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop2"
@@ -27388,11 +28803,6 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"snQ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "snR" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -27416,6 +28826,18 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plating/tunnel,
 /area/f13/village)
+"soE" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"soK" = (
+/mob/living/simple_animal/hostile/gecko,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland)
 "soY" = (
 /obj/structure/fence{
 	dir = 4
@@ -27426,15 +28848,29 @@
 /obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/building)
+"sph" = (
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/pipe,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "spi" = (
-/obj/structure/tires{
-	pixel_x = -8;
-	pixel_y = 15
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
-	},
+/obj/structure/fluff/broken_flooring,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/wasteland)
+"spt" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical";
+	tag = "icon-housewindowbrokenvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "spx" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -27443,9 +28879,16 @@
 /turf/closed/wall/f13/wood,
 /area/f13/village)
 "spC" = (
-/obj/structure/bed/dogbed,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "spL" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -27490,27 +28933,31 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
+"srt" = (
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontal"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "srw" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "srM" = (
-/obj/structure/closet/crate/trashcart,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
+/obj/structure/window/fulltile/house,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "ssm" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
 	icon_state = "outermaincornerouter"
 	},
 /area/f13/wasteland)
-"ssC" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "stg" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/farm)
@@ -27536,20 +28983,15 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"stK" = (
+/turf/closed/wall/f13/wood/house,
+/area/f13/city)
 "suo" = (
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
-"suq" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/followers)
 "suw" = (
 /obj/item/paper_bin{
 	pixel_y = 6
@@ -27594,10 +29036,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"svJ" = (
-/obj/machinery/smartfridge/chemistry,
-/turf/closed/wall/f13/supermart,
-/area/f13/city)
 "svP" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -27610,15 +29048,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"swe" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor{
-	id = "shopouter";
-	layer = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "swi" = (
 /obj/structure/fermenting_barrel{
 	pixel_x = -5;
@@ -27661,29 +29090,36 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"swU" = (
-/obj/item/twohanded/required/kirbyplants/dead,
-/turf/open/floor/wood,
-/area/f13/village)
 "sxs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/reinforced/indestructable,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/structure/simple_door/house{
+	icon_state = "interioropening";
+	tag = "icon-interioropening"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
+"sxy" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
 "sxP" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
-"syq" = (
-/obj/machinery/door/poddoor/ert{
-	id = "bankvault";
-	name = "Vault"
+"sxT" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/city)
+/area/f13/building)
 "syr" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/legion)
@@ -27694,12 +29130,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"syG" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "syU" = (
 /obj/machinery/shower{
 	dir = 8
@@ -27713,13 +29143,6 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"szn" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
 "szy" = (
 /obj/structure/fence{
 	dir = 4
@@ -27745,6 +29168,11 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"szQ" = (
+/obj/item/clothing/head/helmet/f13/rustedcowboyhat,
+/obj/item/clothing/suit/armor/f13/rustedcowboy,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "szS" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/mop,
@@ -27765,11 +29193,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"sAL" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "sAM" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt,
@@ -27797,11 +29220,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sBQ" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft2bottom"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "sBR" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood/f13/carpet,
@@ -27836,19 +29261,30 @@
 /obj/effect/turf_decal/stripes/white/full,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"sCB" = (
-/obj/machinery/processor,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/city)
 "sCF" = (
-/obj/structure/sink/well,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
-/area/f13/farm)
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "sCK" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -27862,36 +29298,34 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/legion)
+"sDi" = (
+/turf/open/floor/wood/f13/oakbroken2,
+/area/f13/building)
 "sDj" = (
-/obj/structure/fence{
-	dir = 8
+/obj/structure/chair/booth{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "sDp" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sDr" = (
-/obj/structure/stacklifter,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
-"sDI" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken4,
+/area/f13/building)
+"sDJ" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/area/f13/city)
-"sEn" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/area/f13/building)
 "sEB" = (
 /obj/structure/sink{
 	dir = 1;
@@ -27907,19 +29341,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
-"sFy" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	termtag = "Secret"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "followersdeskshutters";
-	name = "followers shutters"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "sGm" = (
 /obj/structure/fence{
 	dir = 4
@@ -27953,13 +29374,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"sIa" = (
-/obj/structure/musician/piano{
-	desc = "What a wierd piano..";
-	name = "minimoog"
+"sHM" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner (EAST)"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/area/f13/wasteland)
 "sIf" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -28023,16 +29444,25 @@
 /obj/structure/sign/poster/contraband/pinup_shower,
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
-"sKp" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"sKG" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "sKH" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
+"sKX" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "sLi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hydroponics/constructable,
@@ -28074,14 +29504,6 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
-"sLG" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "sLV" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/decal/cleanable/blood/old,
@@ -28093,10 +29515,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"sMz" = (
-/obj/machinery/trading_machine/weapon,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "sMP" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/recharger,
@@ -28132,20 +29550,22 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"sNE" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "sNM" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
+/obj/structure/window/fulltile/wood{
+	layer = 3
 	},
-/obj/item/storage/bag/money{
-	anchored = 1;
-	pixel_x = 32
-	},
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_x = 32
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "sNT" = (
 /obj/structure/chair{
 	dir = 4
@@ -28155,10 +29575,19 @@
 	},
 /area/f13/village)
 "sOD" = (
-/obj/effect/landmark/observer_start,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/obj/structure/barricade/bars,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
+	icon_state = "verticalleftborderright0"
+	},
+/area/f13/building)
+"sOS" = (
+/obj/structure/flora/tree/tall,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "sPu" = (
@@ -28189,8 +29618,10 @@
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
 "sPJ" = (
-/obj/machinery/mineral/wasteland_vendor/mining,
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1";
+	tag = "icon-verticalinnermain1"
+	},
 /area/f13/wasteland)
 "sPK" = (
 /obj/structure/table/wood,
@@ -28202,33 +29633,18 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"sQj" = (
-/obj/machinery/smartfridge/bottlerack/gardentool,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
-"sQl" = (
-/obj/structure/chair/wood/modern{
-	dir = 8;
-	icon_state = "wooden_chair_settler"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"sQo" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "followerlabladder"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
-"sQs" = (
+"sPS" = (
 /obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plating,
+/area/f13/radiation)
+"sQo" = (
+/obj/structure/wreck/trash/machinepiletwo{
+	layer = 3
 	},
-/area/f13/village)
+/obj/item/flag/oasis,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "sQv" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -28236,13 +29652,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
 "sQC" = (
-/obj/structure/table/wood,
-/obj/item/pen/fountain,
-/obj/item/pen/fountain,
-/obj/item/pen/fountain,
-/obj/item/pen/fountain,
-/turf/open/floor/wood,
-/area/f13/village)
+/obj/structure/barricade/wooden,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "sQX" = (
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
@@ -28258,6 +29676,10 @@
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"sRJ" = (
+/obj/machinery/workbench,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sRV" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light,
@@ -28266,13 +29688,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"sSr" = (
-/obj/structure/sign/poster/prewar/poster61{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"sSc" = (
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "sSt" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/f13/wood,
@@ -28289,16 +29708,34 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/wasteland)
+"sTe" = (
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 5
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/building)
 "sTk" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/clothing_low,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"sTm" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2";
+	tag = "icon-verticalleftborderleft2"
+	},
+/area/f13/wasteland)
 "sTv" = (
 /obj/structure/closet/bus,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"sTw" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/tunnel)
 "sTC" = (
 /obj/effect/landmark/latejoin,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -28311,12 +29748,7 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "sUd" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/structure/chair/wood/worn{
-	dir = 1
-	},
+/obj/machinery/trading_machine,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sUf" = (
@@ -28326,7 +29758,7 @@
 "sUl" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/caves)
 "sUn" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -28339,9 +29771,16 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "sUr" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
+	},
+/area/f13/wasteland)
+"sUu" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/building)
 "sUv" = (
@@ -28361,6 +29800,15 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"sUT" = (
+/obj/structure/chair/wood/modern{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sUX" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 9;
@@ -28385,6 +29833,11 @@
 "sVl" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"sVs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
 "sVD" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
@@ -28415,6 +29868,10 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
+"sWy" = (
+/obj/structure/chair/stool/retro/tan,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "sWz" = (
 /obj/machinery/door/unpowered/wooddoor{
 	name = "Sergeant"
@@ -28451,24 +29908,22 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"sXy" = (
-/obj/machinery/light/small/broken{
-	dir = 4
+"sXG" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/vomit,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/turf/open/floor/wood,
-/area/f13/village)
+/area/f13/building)
 "sXJ" = (
 /obj/structure/fluff/rails{
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"sXN" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "sYe" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light{
@@ -28485,6 +29940,13 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"sYw" = (
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "sYF" = (
 /obj/machinery/light{
 	dir = 1
@@ -28510,6 +29972,18 @@
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"sZD" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2";
+	tag = "icon-horizontaltopborderbottom2"
+	},
+/area/f13/wasteland)
+"sZF" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outermaincornerouter";
+	tag = "icon-outermaincornerouter"
+	},
+/area/f13/wasteland)
 "sZQ" = (
 /obj/structure/fence/wooden{
 	dir = 1;
@@ -28530,16 +30004,26 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"tag" = (
+/obj/structure/table/wood,
+/obj/item/grown/sunflower{
+	desc = "A solis ortu usque ad occasum";
+	name = "Helianthus"
+	},
+/turf/open/floor/carpet/airless,
+/area/f13/legion)
 "tak" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innershade"
 	},
 /area/f13/wasteland)
-"tar" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"tav" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "shadowleft";
+	tag = "icon-shadowleft"
+	},
+/area/f13/wasteland)
 "taF" = (
 /obj/structure/fence{
 	dir = 4
@@ -28548,6 +30032,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
+"taG" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/auto,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "taN" = (
 /obj/structure/chair/comfy{
 	dir = 4
@@ -28632,10 +30125,19 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"tdu" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/legion)
 "tdv" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tdC" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -28665,13 +30167,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"tfn" = (
-/obj/structure/sink{
-	pixel_y = 28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+"tfc" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "tfz" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/rank/medical/doctor/purple,
@@ -28757,6 +30258,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
+"thR" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (WEST)"
+	},
+/area/f13/wasteland)
 "thW" = (
 /obj/machinery/light{
 	dir = 4
@@ -28782,33 +30290,19 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"tit" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "tiu" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tja" = (
+"tjd" = (
 /obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowleft";
-	layer = 2
+	icon_state = "housewindowvertical";
+	tag = "icon-housewindowvertical (NORTHEAST)"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "storeshutters";
-	name = "store shutters"
-	},
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
-/area/f13/city)
-"tjy" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/r_wall/rust,
-/area/f13/city)
+/area/f13/building)
 "tjB" = (
 /obj/item/ammo_casing/a50MG,
 /turf/open/indestructible/ground/outside/road{
@@ -28837,9 +30331,17 @@
 	},
 /area/f13/building)
 "tkm" = (
-/mob/living/simple_animal/hostile/handy,
+/obj/structure/table/wood,
+/obj/item/paper,
+/obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"tkF" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "tkO" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13{
@@ -28861,6 +30363,21 @@
 /obj/item/paper,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"tkZ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
+"tlg" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
 	},
 /area/f13/building)
 "tlj" = (
@@ -28922,27 +30439,17 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"tma" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = 30
+"tmm" = (
+/obj/structure/simple_door/interior,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
-/turf/open/floor/plasteel/grimy,
-/area/f13/village)
-"tmh" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 8
+/area/f13/clinic)
+"tmp" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "tmH" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
@@ -28952,9 +30459,7 @@
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
 	},
-/obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
 	icon_state = "dirt"
 	},
 /area/f13/legion)
@@ -28964,15 +30469,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"tor" = (
-/obj/structure/fence/wooden{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "toy" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/desert,
@@ -29025,8 +30521,11 @@
 	},
 /area/f13/tunnel)
 "tpA" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical"
+/obj/structure/chair/stool{
+	icon_state = "bench_center"
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
@@ -29042,17 +30541,30 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
-"tpN" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
+"tqi" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/closed/wall/f13/wood,
-/area/f13/city)
+/area/f13/building)
+"tqs" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "tqu" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tqG" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "tqN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -29089,6 +30601,13 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"trJ" = (
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2bottom";
+	tag = "icon-verticalleftborderleft2bottom"
+	},
+/area/f13/wasteland)
 "trW" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3"
@@ -29108,30 +30627,30 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "tsB" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/medical,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
-"tsF" = (
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
 "tsH" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"tsS" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/followers)
 "tsT" = (
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
+"tsW" = (
+/obj/structure/rack,
+/obj/item/shovel/spade,
+/obj/item/shovel,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/cultivator,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "tte" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -29155,6 +30674,10 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"ttE" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/f13/radiation)
 "ttU" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/f13/wood,
@@ -29163,6 +30686,12 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"tuS" = (
+/obj/structure/chair/wood/modern{
+	icon_state = "wooden_chair_settler"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tvl" = (
 /obj/effect/landmark/latejoin,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -29179,11 +30708,7 @@
 	},
 /area/f13/legion)
 "tvr" = (
-/obj/structure/wreck/trash/one_barrel,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
-	},
+/turf/open/water,
 /area/f13/wasteland)
 "tvA" = (
 /obj/structure/rack,
@@ -29212,11 +30737,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"tvP" = (
-/obj/structure/flora/grass/wasteland,
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "twq" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -29239,9 +30759,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "twP" = (
-/obj/structure/billboard/cola/pristine,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters{
+	id = "prospectorshutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/building)
 "twY" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -29252,7 +30778,7 @@
 "txb" = (
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
 "txr" = (
@@ -29305,11 +30831,8 @@
 	},
 /area/f13/village)
 "tyL" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/village)
+/turf/closed/wall/rust,
+/area/f13/wasteland)
 "tyQ" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -29342,24 +30865,27 @@
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
+"tzY" = (
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"tzZ" = (
+/obj/structure/spider/stickyweb,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "tAg" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"tAz" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/reagent_containers/medspray/sterilizine,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 25
-	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/followers)
 "tAC" = (
 /obj/structure/easel,
 /turf/open/floor/f13/wood,
@@ -29382,11 +30908,11 @@
 /turf/open/water,
 /area/f13/brotherhood)
 "tAS" = (
-/obj/effect/spawner/structure/window/reinforced/indestructable,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/wasteland)
 "tBm" = (
 /obj/structure/table/wood/settler,
@@ -29394,12 +30920,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "tBB" = (
-/obj/effect/decal/cleanable/blood/innards,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0";
+	tag = "icon-horizontalbottomborderbottom0"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "tBN" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -29417,15 +30942,13 @@
 	},
 /area/f13/ncr)
 "tCc" = (
-/obj/structure/flora/grass/wasteland{
-	pixel_x = -3
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
+/obj/machinery/power/terminal{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermainleft"
-	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/wasteland)
 "tCh" = (
 /obj/structure/car/rubbish1,
@@ -29437,10 +30960,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"tCu" = (
-/obj/item/flag/oasis,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "tCv" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2top"
@@ -29453,6 +30972,13 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/ncr)
+"tDb" = (
+/obj/structure/chair/bench,
+/obj/effect/landmark/start/f13/settler,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland)
 "tDg" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13{
@@ -29483,11 +31009,6 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/village)
-"tEp" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
 "tEr" = (
 /obj/structure/closet/crate{
 	anchored = 1;
@@ -29512,21 +31033,19 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"tFM" = (
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/structure/table/wood/fancy,
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_y = 10
+"tFr" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_y = 10
-	},
-/obj/effect/spawner/lootdrop/three_course_meal,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/legion)
+"tFK" = (
+/obj/effect/landmark/start/f13/farmer,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "tFR" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
@@ -29591,34 +31110,52 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/brotherhood)
+"tHf" = (
+/obj/structure/table,
+/obj/machinery/light/small,
+/obj/item/reagent_containers/food/drinks/flask,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "tHw" = (
 /obj/structure/table/wood,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"tIu" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Mayor's Office";
-	req_one_access_txt = "62"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"tIE" = (
+/obj/structure/chair/wood/modern,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "tIM" = (
 /obj/structure/safe,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tIO" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowvertical"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/wasteland)
 "tIP" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/legion)
+"tIY" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/legion)
 "tJe" = (
 /obj/structure/table/wood,
@@ -29626,10 +31163,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tJk" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel/chapel{
+	dir = 6
 	},
 /area/f13/building)
 "tJm" = (
@@ -29645,14 +31182,29 @@
 /turf/closed/wall/f13/wood,
 /area/f13/brotherhood)
 "tJx" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/stock_parts/cell,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "tJz" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tJG" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-2";
+	tag = "icon-0-2"
+	},
+/turf/open/floor/plating,
+/area/f13/caves)
 "tKk" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -29738,14 +31290,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "tNI" = (
-/obj/structure/destructible/tribal_torch{
-	pixel_x = 10
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/chapel{
+	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "tNX" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/desert,
@@ -29759,6 +31310,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tOf" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical";
+	tag = "icon-housewindowvertical (NORTHEAST)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tOg" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/decal/cleanable/blood/gibs/limb,
@@ -29780,11 +31338,12 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building)
 "tOP" = (
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "tOS" = (
 /obj/structure/fluff/rails{
 	dir = 4
@@ -29796,28 +31355,32 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "tPt" = (
-/obj/structure/simple_door/brokenglass,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/structure/rack,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "tPy" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain3"
 	},
 /area/f13/wasteland)
 "tPA" = (
-/obj/structure/wreck/car/bike{
-	pixel_x = -12;
-	pixel_y = 1
+/obj/structure/chair/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "tQk" = (
 /obj/structure/table/wood,
 /obj/item/stack/f13Cash/aureus,
 /obj/effect/spawner/lootdrop/three_course_meal,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "tQl" = (
 /obj/structure/chair/wood/modern{
@@ -29838,12 +31401,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"tQx" = (
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/legion)
 "tQU" = (
 /obj/structure/mirror,
 /turf/closed/wall/f13/wood,
@@ -29852,23 +31409,34 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"tRa" = (
+/turf/open/floor/wood/f13/oakbroken4,
+/area/f13/building)
 "tRc" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
-"tRX" = (
-/obj/structure/chair{
-	dir = 4
+"tRx" = (
+/obj/structure/fence/corner{
+	dir = 6
 	},
-/obj/effect/decal/remains/human,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
+"tRX" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/building)
 "tRY" = (
@@ -29896,9 +31464,17 @@
 /obj/structure/sign/poster/prewar/poster73,
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
+"tSF" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "tSQ" = (
-/obj/structure/closet,
-/obj/item/storage/box/gloves,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "tSV" = (
@@ -29908,8 +31484,19 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tTT" = (
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "tTV" = (
 /obj/structure/flora/wasteplant/wild_agave,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"tTX" = (
+/obj/structure/fence/corner,
+/obj/structure/fence{
+	dir = 1;
+	icon_state = "straight"
+	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "tUb" = (
@@ -29973,15 +31560,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tUC" = (
-/obj/structure/pondlily_small,
-/turf/open/water,
-/area/f13/caves)
-"tUH" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft1"
+/obj/item/mop{
+	icon_state = "mopbucket";
+	tag = "icon-mopbucket"
 	},
-/area/f13/wasteland)
+/obj/item/mop,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"tUH" = (
+/obj/machinery/shower{
+	dir = 8;
+	tag = "icon-shower (WEST)"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "tUM" = (
 /obj/structure/bed/roller,
 /turf/open/floor/f13{
@@ -29998,10 +31594,10 @@
 	},
 /area/f13/wasteland)
 "tUS" = (
-/obj/structure/chair/comfy/plywood,
-/obj/item/fishingrod,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "tVi" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
@@ -30025,20 +31621,49 @@
 	},
 /area/f13/wasteland)
 "tWd" = (
-/obj/structure/table/wood/settler,
-/obj/item/lighter,
-/obj/machinery/light/small/broken{
-	dir = 1
+/obj/machinery/light/small,
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters button";
+	pixel_x = -6;
+	pixel_y = -32;
+	req_one_access_txt = "28"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/village)
-"tWu" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/followers)
+/obj/machinery/button/door{
+	id = "barwindowshutters";
+	name = "bar window shutters button";
+	pixel_x = 6;
+	pixel_y = -32;
+	req_one_access_txt = "28"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
+"tWt" = (
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "tWv" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
+"tXc" = (
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "tXe" = (
@@ -30074,50 +31699,24 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "tYd" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "tYe" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
-"tYk" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/condiment/yeast,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/city)
 "tYJ" = (
 /obj/structure/chair/wood,
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"tYL" = (
-/obj/structure/table,
-/obj/item/kitchen/knife,
-/obj/item/kitchen/rollingpin,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "tYQ" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
@@ -30129,6 +31728,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"tYW" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "tZh" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_l,
@@ -30163,9 +31769,16 @@
 	},
 /area/f13/legion)
 "uar" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
 /area/f13/clinic)
+"uaJ" = (
+/obj/structure/wreck/trash/bus_door,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2left"
+	},
+/area/f13/wasteland)
 "ubd" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderrightbottom"
@@ -30184,36 +31797,46 @@
 	icon_state = "dirt"
 	},
 /area/f13/legion)
-"ubv" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/wood,
-/area/f13/village)
+"ubD" = (
+/obj/structure/simple_door/room,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "ubJ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
+"ubK" = (
+/obj/structure/table/wood/settler,
+/obj/item/paperplane,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ubS" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken"
 	},
-/area/f13/wasteland)
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
+"ucj" = (
+/obj/effect/decal/cleanable/blood/innards,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "ucs" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "ucw" = (
-/obj/structure/fence{
-	dir = 1;
-	pixel_x = -10
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
 	},
-/obj/structure/girder,
+/obj/structure/barricade/bars,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
+	icon_state = "verticalleftborderleftbottom"
 	},
 /area/f13/wasteland)
 "ucz" = (
@@ -30229,10 +31852,18 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ucJ" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/meatsalted,
+/obj/structure/window/fulltile/wood,
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"ucN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "ucQ" = (
 /obj/machinery/shower{
 	dir = 8
@@ -30250,14 +31881,8 @@
 /obj/machinery/workbench/forge,
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"udf" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "udt" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/f13/wood,
@@ -30273,7 +31898,7 @@
 /obj/item/stack/medical/suture,
 /obj/item/reagent_containers/food/snacks/grown/pungafruit,
 /obj/item/reagent_containers/food/snacks/grown/pungafruit,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "udY" = (
 /obj/structure/sign/poster/prewar/poster67{
@@ -30290,9 +31915,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "uet" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
+/obj/structure/barricade/wooden,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
 "uey" = (
@@ -30310,9 +31939,15 @@
 	},
 /area/f13/building)
 "ueL" = (
+/obj/machinery/trading_machine/weapon,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"ueN" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "ueT" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = -3
@@ -30326,6 +31961,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"ufb" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uff" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -30343,23 +31982,10 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"ufK" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Bar";
-	req_one_access_txt = "28"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "barshutters"
-	},
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_y = 32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "ufP" = (
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
+/obj/machinery/trading_machine/armor,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ugm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -30389,15 +32015,19 @@
 	},
 /area/f13/brotherhood)
 "uhi" = (
-/obj/structure/flora/wasteplant/wild_punga,
-/turf/open/water,
-/area/f13/caves)
+/turf/open/floor/plating,
+/area/f13/radiation)
 "uhk" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"uhp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "uhq" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -30424,7 +32054,7 @@
 /obj/item/clothing/suit/f13/robe_liz,
 /obj/item/clothing/suit/f13/robe_liz,
 /obj/machinery/light/small,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "uhY" = (
 /obj/structure/bonfire,
@@ -30464,6 +32094,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/legion)
+"uld" = (
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontal"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/tunnel)
 "ulf" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -30471,29 +32109,21 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"uls" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "ulu" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
-"ulC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "ulE" = (
-/obj/structure/table/wood/fancy/black,
-/obj/structure/decoration/clock/active{
-	pixel_y = 30
-	},
-/obj/item/reagent_containers/pill/patch/turbo{
-	layer = 2.4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/f13/village)
+/turf/open/floor/plasteel/stairs/old,
+/area/f13/wasteland)
 "ulH" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/desert,
@@ -30506,13 +32136,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ulU" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/legion)
+/obj/structure/rack,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
+"ulY" = (
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "umi" = (
-/obj/structure/pondlily_big,
-/turf/open/water,
-/area/f13/caves)
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/wasteland)
 "umD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -30529,11 +32169,6 @@
 /obj/item/toy/eightball,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
-"umW" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "unp" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -30541,16 +32176,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"unr" = (
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical,
-/obj/structure/closet/crate/medical/anchored,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/followers)
 "unF" = (
 /obj/machinery/light{
 	dir = 8;
@@ -30609,17 +32234,6 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
-"upg" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/structure/fence{
-	dir = 1;
-	pixel_x = -18
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "upj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30684,10 +32298,14 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
+"urm" = (
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32";
+	tag = "icon-wasteland32"
+	},
+/area/f13/wasteland)
 "urt" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/syringe/medx,
-/turf/open/floor/f13/wood,
+/turf/closed/mineral/random/low_chance,
 /area/f13/clinic)
 "uru" = (
 /obj/structure/dresser,
@@ -30702,10 +32320,10 @@
 	},
 /area/f13/ncr)
 "ury" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/wasteland)
 "urA" = (
 /obj/structure/chair/wood{
@@ -30713,13 +32331,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"urL" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	name = "prewar lounge chair"
-	},
-/turf/open/floor/wood,
-/area/f13/village)
 "urN" = (
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
@@ -30728,15 +32339,6 @@
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"urY" = (
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
 "use" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/road{
@@ -30758,12 +32360,6 @@
 	name = "concrete wall"
 	},
 /area/f13/building)
-"usO" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "usW" = (
 /obj/machinery/shower{
 	dir = 8
@@ -30785,13 +32381,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
-"uul" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/comfy,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/city)
 "uuB" = (
 /obj/structure/toilet{
 	dir = 4
@@ -30836,12 +32425,30 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"uwi" = (
+/obj/machinery/shower{
+	dir = 4;
+	tag = "icon-shower (EAST)"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "uwl" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
+	},
+/area/f13/building)
+"uwy" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
 	},
 /area/f13/building)
 "uwQ" = (
@@ -30851,6 +32458,12 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"uwZ" = (
+/obj/structure/closet/crate/trashcart{
+	name = "corpse cart"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "uxf" = (
 /obj/structure/closet/crate/large,
@@ -30890,31 +32503,28 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"uyD" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/obj/item/taperecorder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "uyM" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
 	},
 /area/f13/wasteland)
-"uyP" = (
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "uyV" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"uze" = (
+/obj/structure/fence/wooden{
+	dir = 4;
+	icon_state = "post_wood"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "uzn" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
+/area/f13/building)
 "uzs" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor2-old"
@@ -30955,16 +32565,26 @@
 /obj/structure/car,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"uAX" = (
+/obj/item/ammo_casing/shotgun/improvised,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "uBx" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_br,
 /area/f13/bar)
-"uBE" = (
-/obj/machinery/light/small/broken{
+"uBK" = (
+/obj/structure/table,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/f13/village)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "uCh" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -30974,47 +32594,43 @@
 	},
 /area/f13/wasteland)
 "uCn" = (
-/obj/structure/destructible/tribal_torch{
-	pixel_y = 20
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/building)
+"uCt" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "uCO" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "uCS" = (
-/obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2right"
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "uCT" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
+/obj/structure/chair/wood{
+	dir = 4;
+	tag = "icon-wooden_chair_settler (EAST)"
 	},
-/area/f13/village)
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "uCW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"uDp" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/reinforced/fulltile{
-	layer = 2.8
-	},
-/obj/structure/fence{
-	pixel_x = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
 "uDw" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
@@ -31056,6 +32672,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
+"uEJ" = (
+/obj/structure/rack,
+/obj/item/crafting/wonderglue,
+/obj/item/crafting/wonderglue,
+/obj/item/crafting/wonderglue,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "uEK" = (
 /obj/structure/table/wood,
 /obj/item/pda,
@@ -31087,17 +32713,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "uFp" = (
-/obj/structure/chair/stool{
-	dir = 4;
-	icon_state = "bench_center"
+/obj/structure/billboard/ritas,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/wasteland)
 "uFt" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "uFB" = (
 /obj/machinery/light/small{
@@ -31114,10 +32740,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "uFK" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/building)
 "uGc" = (
@@ -31205,11 +32832,26 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"uIJ" = (
+/obj/structure/table/wood/settler,
+/obj/item/paper,
+/obj/item/pen,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "uIK" = (
-/obj/structure/table/wood,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "uIT" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -31241,14 +32883,16 @@
 	},
 /area/f13/building)
 "uJP" = (
-/obj/structure/closet/crate/trashcart,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"uKb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/obj/structure/table/wood,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "uKq" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/f13/deathskull,
@@ -31259,11 +32903,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uKA" = (
-/obj/structure/wreck/trash/bus_door,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2left"
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Bar";
+	req_one_access_txt = "28"
 	},
-/area/f13/wasteland)
+/obj/machinery/door/poddoor/shutters{
+	id = "barshutters"
+	},
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_y = 32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uKB" = (
 /obj/structure/rack,
 /obj/item/radio,
@@ -31277,11 +32929,15 @@
 	},
 /area/f13/building)
 "uKG" = (
-/obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters button";
+	pixel_y = 32;
+	req_one_access_txt = "28"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uKJ" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -31297,6 +32953,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"uKT" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "uKY" = (
 /obj/structure/chair{
 	dir = 1
@@ -31305,6 +32968,19 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"uLh" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 10;
+	tag = "icon-sink (EAST)"
+	},
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "uLK" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/f13{
@@ -31333,12 +33009,20 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"uMU" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/closet/crate/trashcart{
+	name = "corpse cart"
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
 "uMZ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/wasteland)
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uNC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small{
@@ -31346,6 +33030,15 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"uND" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Clinic"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "uNK" = (
@@ -31376,14 +33069,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uOr" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/legion)
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uOu" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -31439,6 +33128,11 @@
 /obj/effect/holodeck_effect/cards,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"uPD" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottomright"
+	},
+/area/f13/building)
 "uPP" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
@@ -31457,13 +33151,11 @@
 /area/f13/bunker)
 "uQx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/fence/end{
-	dir = 4
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uQz" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/f13{
@@ -31474,6 +33166,14 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"uRj" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
+"uRw" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uRJ" = (
 /turf/open/floor/f13/wood,
 /area/f13/village)
@@ -31483,17 +33183,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uRN" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "exteriorgate"
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
-"uRU" = (
-/obj/machinery/light/small/broken{
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uSj" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal,
@@ -31514,8 +33211,18 @@
 	},
 /area/f13/village)
 "uSz" = (
-/obj/structure/fence/corner/wooden,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/flora/grass/wasteland{
+	pixel_x = -3
+	},
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4"
+	},
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermainleft"
+	},
 /area/f13/wasteland)
 "uSC" = (
 /obj/structure/table/wood,
@@ -31558,17 +33265,24 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "uTA" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/area/f13/clinic)
+/area/f13/city)
 "uTG" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"uTH" = (
+/obj/structure/chair/stool/retro,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uTQ" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -31586,6 +33300,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"uUd" = (
+/obj/effect/landmark/start/f13/preacher,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uUo" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -31599,18 +33317,14 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
-"uUJ" = (
-/obj/structure/destructible/tribal_torch{
-	pixel_y = 20
+"uUK" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "gatehouseladder"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
-"uUL" = (
-/obj/item/flag,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "uUS" = (
 /obj/machinery/vending/cola/random,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -31618,15 +33332,31 @@
 	},
 /area/f13/wasteland)
 "uUZ" = (
-/obj/structure/fence{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
+"uVn" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2top";
+	tag = "icon-verticalleftborderright2top"
+	},
+/area/f13/wasteland)
 "uVo" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop3"
 	},
+/area/f13/wasteland)
+"uVs" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "uVw" = (
 /obj/effect/decal/cleanable/dirt{
@@ -31648,11 +33378,13 @@
 	},
 /area/f13/building)
 "uVF" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
+/obj/structure/simple_door/house,
+/obj/machinery/door/poddoor/shutters{
+	id = "storeshutters";
+	name = "store shutters"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uVM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -31660,6 +33392,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"uWb" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2bottom";
+	tag = "icon-verticalleftborderright2bottom"
+	},
+/area/f13/wasteland)
 "uWs" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -31683,6 +33421,12 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/building)
+"uWJ" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "uWQ" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -31708,25 +33452,35 @@
 	},
 /area/f13/village)
 "uXa" = (
-/obj/structure/fence{
-	dir = 8
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright";
+	layer = 2
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/machinery/door/poddoor/shutters{
+	id = "storeshutters";
+	name = "store shutters"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"uXd" = (
+/obj/machinery/button/door{
+	id = "interiorgate";
+	name = "Interior door button";
+	pixel_x = 6;
+	pixel_y = 32
 	},
-/area/f13/legion)
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "uXj" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "uXU" = (
-/obj/structure/table/wood,
-/obj/item/papercutter,
-/turf/open/floor/wood,
-/area/f13/village)
+/turf/open/floor/plasteel/chapel{
+	dir = 8
+	},
+/area/f13/building)
 "uXV" = (
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/indestructible/ground/outside/ruins{
@@ -31771,17 +33525,29 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"uZf" = (
+/obj/structure/simple_door/metal/fence,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "uZg" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
+/obj/structure/table/wood,
+/obj/item/trash/waffles,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
 "uZj" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/obj/structure/destructible/tribal_torch{
+	layer = 3.1;
+	pixel_y = 20
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "uZl" = (
 /obj/item/radio/intercom{
 	frequency = 1891;
@@ -31795,9 +33561,19 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
+"uZv" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uZy" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"uZR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vaf" = (
 /obj/item/chair/wood,
@@ -31809,6 +33585,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"vat" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2bottom";
+	tag = "icon-verticalinnermain2bottom"
+	},
+/area/f13/wasteland)
 "vaw" = (
 /obj/structure/table,
 /obj/item/storage/backpack,
@@ -31835,6 +33617,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"vcb" = (
+/obj/structure/table/wood,
+/obj/item/instrument/guitar,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "vcg" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -31870,6 +33657,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vcV" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/water,
+/area/f13/wasteland)
 "vcY" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -31883,16 +33674,23 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"vdE" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/trophy/gold_cup,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"vdB" = (
+/obj/structure/decoration/rag,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "vdO" = (
 /obj/structure/fence{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"vei" = (
+/obj/structure/sink{
+	pixel_y = 18
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "ves" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31957,7 +33755,7 @@
 /obj/item/key/collar,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "vfs" = (
 /obj/structure/rack,
@@ -31965,37 +33763,32 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "vfu" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/closed/wall/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
+	},
+/area/f13/wasteland)
+"vfR" = (
+/obj/structure/window/fulltile/wood,
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
+"vfS" = (
+/obj/structure/wreck/trash/two_tire,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "vfU" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"vgg" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+"vgc" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 8
 	},
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "vgy" = (
 /obj/structure/table/wood,
 /obj/item/paper,
@@ -32015,6 +33808,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"vhd" = (
+/obj/structure/table/wood,
+/obj/item/trash/candle,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
 /area/f13/building)
 "vhm" = (
 /obj/effect/decal/marking{
@@ -32038,6 +33839,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"vhu" = (
+/obj/structure/bed,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "vhw" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -32060,11 +33865,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"vib" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/costumes,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "vim" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -32084,12 +33884,11 @@
 /area/f13/brotherhood)
 "viv" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
 "viD" = (
 /obj/structure/closet/crate/medical,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -32105,6 +33904,16 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"viM" = (
+/obj/structure/cargocrate,
+/obj/structure/cargocrate{
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "vjd" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -32123,6 +33932,10 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/village)
+"vjl" = (
+/obj/item/trash/f13/fancylads,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vjO" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -32140,6 +33953,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"vkb" = (
+/obj/item/mop,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "vkB" = (
 /obj/structure/chair/wood/modern,
 /obj/effect/decal/remains/human,
@@ -32163,14 +33982,14 @@
 	},
 /area/f13/village)
 "vlg" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small/broken,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+	icon_state = "darkdirtysolid"
 	},
-/area/f13/village)
+/area/f13/building)
+"vlx" = (
+/obj/structure/bonfire,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "vly" = (
 /obj/structure/debris/v3,
 /turf/open/floor/plating/dirt/dark,
@@ -32183,8 +34002,12 @@
 /area/f13/building)
 "vme" = (
 /obj/structure/simple_door/wood,
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"vmg" = (
+/obj/structure/noticeboard,
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "vmX" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -32198,7 +34021,7 @@
 	},
 /area/f13/wasteland)
 "vno" = (
-/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "vnR" = (
@@ -32215,6 +34038,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"voE" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "voF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -32224,6 +34056,10 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"voQ" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "voV" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -32232,12 +34068,28 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/farm)
+"voY" = (
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "vpa" = (
-/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/end{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
+	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"vpl" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "vpx" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -32245,6 +34097,17 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"vpH" = (
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
+"vpJ" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0";
+	tag = "icon-verticalrightborderleft0"
+	},
+/area/f13/wasteland)
 "vpM" = (
 /obj/structure/flora/rock/jungle,
 /turf/closed/indestructible/rock,
@@ -32276,13 +34139,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vrc" = (
-/obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/shovel/spade,
-/obj/item/hatchet,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/followers)
 "vrz" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -32302,6 +34158,17 @@
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"vrJ" = (
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
+"vsb" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/assembly/igniter,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vsm" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/fence/wooden{
@@ -32315,6 +34182,12 @@
 /obj/machinery/light/broken,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"vta" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "vtb" = (
 /obj/structure/fence{
 	dir = 4
@@ -32332,19 +34205,31 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "vtj" = (
-/obj/structure/cable,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken"
 	},
-/area/f13/wasteland)
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vtv" = (
-/obj/structure/chair/stool{
-	icon_state = "bench_center"
+/obj/structure/fireplace{
+	layer = 2.1;
+	level = 1;
+	pixel_y = -10
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/ash{
+	pixel_x = -11;
+	pixel_y = -7
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"vtD" = (
+/obj/structure/barricade/tentclothcorner,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
 /area/f13/building)
 "vtH" = (
 /mob/living/simple_animal/hostile/ghoul,
@@ -32355,11 +34240,12 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "vuH" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
 "vuZ" = (
@@ -32369,12 +34255,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
-"vvc" = (
-/obj/machinery/vending/snack,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/city)
 "vvi" = (
 /obj/structure/fence/corner{
 	dir = 5
@@ -32392,9 +34272,9 @@
 /turf/closed/wall/f13/wood,
 /area/f13/bar)
 "vwn" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "vwt" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/simple_animal/cow/brahmin,
@@ -32406,22 +34286,13 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
-"vwS" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "shopouter";
-	name = "gate shutters";
-	pixel_y = 32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "vxb" = (
-/obj/structure/barricade/bars,
-/obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/structure/bed/dogbed{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "vxc" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -32430,10 +34301,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"vxd" = (
-/obj/structure/sign/poster/prewar/poster85,
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
 "vxv" = (
 /obj/machinery/chem_dispenser{
 	pixel_y = 10
@@ -32448,12 +34315,6 @@
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"vyb" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
 "vye" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/desert,
@@ -32507,14 +34368,6 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"vAm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/city)
 "vAt" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib1-old"
@@ -32527,9 +34380,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vAy" = (
-/obj/structure/bed/mattress,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/wasteland)
 "vAM" = (
 /obj/machinery/vending/dinnerware,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -32538,6 +34397,15 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
+"vBp" = (
+/obj/structure/closet/crate/bin,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "vBr" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/f13/wood,
@@ -32548,15 +34416,6 @@
 	},
 /turf/open/floor/wood/f13,
 /area/f13/building)
-"vBD" = (
-/obj/structure/barricade/bars,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "bankdesk";
-	name = "counter shutters"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "vBH" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -32565,13 +34424,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"vBO" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
 "vCi" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
@@ -32595,6 +34447,14 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/brotherhood)
+"vCY" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
 "vDb" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/cleanable/oil{
@@ -32604,13 +34464,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"vDd" = (
-/obj/structure/girder,
-/obj/structure/girder,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/city)
 "vDe" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt{
@@ -32641,6 +34494,17 @@
 /obj/item/chair/stool/retro,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vFc" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"vFh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
 "vFn" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood{
@@ -32658,6 +34522,13 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"vFD" = (
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "vFL" = (
 /obj/effect/landmark/start/f13/ncroffduty,
 /turf/open/floor/f13{
@@ -32669,6 +34540,13 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
 	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"vGl" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTHEAST)"
 	},
 /area/f13/wasteland)
 "vGA" = (
@@ -32702,8 +34580,14 @@
 /area/f13/village)
 "vHe" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"vHg" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
 "vHh" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/f13{
@@ -32731,13 +34615,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"vHK" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+"vHI" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/storage/toolbox/drone,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "vHQ" = (
 /obj/structure/chair{
 	dir = 4
@@ -32753,14 +34637,29 @@
 	pixel_x = 4
 	},
 /obj/machinery/iv_drip,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"vHV" = (
+/obj/structure/chair,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vIb" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"vIe" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "vIl" = (
 /obj/item/radio/intercom{
 	frequency = 1891;
@@ -32772,14 +34671,13 @@
 	},
 /area/f13/brotherhood)
 "vIr" = (
-/obj/structure/chair/stool,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
-"vIt" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermainbottom";
+	tag = "icon-verticaloutermainbottom"
 	},
-/turf/closed/mineral/random/low_chance,
+/area/f13/wasteland)
+"vIt" = (
+/turf/open/floor/plating,
 /area/f13/caves)
 "vIv" = (
 /obj/structure/closet/fridge/standard,
@@ -32805,31 +34703,48 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"vIN" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2left";
+	tag = "icon-horizontaltopborderbottom2left"
+	},
+/area/f13/wasteland)
 "vJb" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vJq" = (
-/obj/item/storage/trash_stack,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/dogbed{
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
+"vJr" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
+	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
-"vJB" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "vJP" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"vKd" = (
+/obj/structure/car/rubbish2,
+/turf/closed/wall/mineral/wood,
+/area/f13/building)
 "vKl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "vKm" = (
 /obj/structure/window/fulltile/house/broken,
@@ -32841,23 +34756,11 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
-"vLj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
-	},
-/area/f13/city)
 "vMh" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"vMo" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "vMu" = (
 /obj/machinery/light{
 	dir = 4;
@@ -32907,20 +34810,13 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vNH" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"vOq" = (
-/obj/structure/fence/corner{
-	dir = 4
+"vNW" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/followers)
+/area/f13/wasteland)
 "vOx" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -32934,6 +34830,22 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermainbottom"
+	},
+/area/f13/wasteland)
+"vPh" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"vPi" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/wasteland)
 "vPz" = (
@@ -32952,19 +34864,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/legion)
-"vPQ" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/followers)
 "vPU" = (
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibup1"
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outermaincornerouter";
+	tag = "icon-outermaincornerouter (EAST)"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "vPY" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
@@ -32993,11 +34899,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "vQU" = (
-/obj/item/flag/oasis,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
+/obj/item/toy/cattoy,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "vRo" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
@@ -33056,6 +34960,16 @@
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vVb" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vVF" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -33076,12 +34990,19 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"vVK" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2top";
+	tag = "icon-verticalleftborderleft2top"
+	},
+/area/f13/wasteland)
 "vVR" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "vVU" = (
 /obj/machinery/hydroponics/soil{
@@ -33091,19 +35012,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"vWq" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "vWC" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -33113,9 +35021,15 @@
 /turf/open/floor/carpet/black,
 /area/f13/legion)
 "vWE" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/simple_door/house{
+	icon_state = "room";
+	tag = "icon-room"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "vWK" = (
 /obj/structure/table,
 /obj/item/storage/box/gloves,
@@ -33159,6 +35073,29 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vXM" = (
+/obj/structure/table,
+/obj/machinery/light/fo13colored/Red{
+	bulb_colour = "#008000";
+	desc = "A lighting fixture.";
+	dir = 4;
+	light_color = "#008000";
+	name = "light tube"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Secret"
+	},
+/obj/machinery/light/fo13colored/Red{
+	bulb_colour = "#008000";
+	desc = "A lighting fixture.";
+	dir = 4;
+	light_color = "#008000";
+	name = "light tube"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "vYe" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -33178,10 +35115,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"vYE" = (
-/obj/structure/window/fulltile/wood,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"vYZ" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "vZl" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor1-old"
@@ -33192,35 +35133,27 @@
 	},
 /area/f13/building)
 "vZs" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "followerladder"
-	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/followers)
-"wad" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "clinicdesk";
-	name = "counter shutters"
-	},
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
+/area/f13/wasteland)
 "wbd" = (
 /obj/structure/table/wood,
 /obj/machinery/processor/chopping_block,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"wbi" = (
-/obj/structure/chair/stool/retro,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"wbP" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "wcu" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/wooden,
@@ -33252,6 +35185,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wdA" = (
+/obj/structure/table,
+/obj/item/kitchen/fork,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "wdJ" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
@@ -33272,6 +35215,17 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"weI" = (
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench";
+	tag = "icon-bench (EAST)"
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "weJ" = (
 /obj/structure/decoration/clock{
 	pixel_y = 32
@@ -33286,27 +35240,19 @@
 	icon_state = "horizontaloutermainright"
 	},
 /area/f13/wasteland)
+"wfC" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wgf" = (
-/obj/machinery/light/sign/oasis_sign{
-	layer = 5
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/wreck/trash/five_tires{
-	pixel_x = 3;
-	pixel_y = -13
-	},
-/obj/structure/flora/grass/wasteland{
-	pixel_x = -3
-	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	layer = 2;
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermainleft"
-	},
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "wgr" = (
 /obj/machinery/mineral/wasteland_vendor/mining,
 /turf/open/indestructible/ground/inside/mountain,
@@ -33317,11 +35263,22 @@
 /obj/item/reagent_containers/syringe/medx,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wgO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"whh" = (
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "clinicfrontdoor";
+	name = "door shutters";
+	pixel_x = -6
+	},
+/obj/machinery/button/door{
+	id = "clinicdesk";
+	name = "desk shutters";
+	pixel_x = 6
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "whm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe/constructionlathe,
@@ -33342,11 +35299,18 @@
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
-"whS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
+"whU" = (
+/obj/structure/chair/stool{
 	dir = 8;
-	icon_state = "outerbordercorner"
+	icon_state = "bench";
+	tag = "icon-bench (WEST)"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/city)
 "wim" = (
@@ -33367,6 +35331,14 @@
 /obj/structure/sign/poster/ncr/keep_to_myself,
 /turf/closed/wall/f13/store,
 /area/f13/ncr)
+"wjr" = (
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "wjt" = (
 /mob/living/simple_animal/hostile/retaliate/goat/bighorn,
 /turf/open/indestructible/ground/outside/desert,
@@ -33377,10 +35349,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"wjx" = (
-/obj/machinery/biogenerator,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "wjB" = (
 /obj/structure/toilet{
 	dir = 8
@@ -33435,18 +35403,37 @@
 /obj/item/clothing/under/f13/shiny,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wld" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermaintop";
+	tag = "icon-verticalinnermaintop"
+	},
+/area/f13/wasteland)
+"wlX" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/legion)
 "wmI" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "wmJ" = (
-/obj/item/toy/beach_ball/holoball,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+/obj/item/pet_carrier{
+	pixel_x = 4;
+	pixel_y = 7
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "wmL" = (
 /obj/item/clothing/suit/armor/bulletproof,
 /turf/open/indestructible/ground/inside/mountain,
@@ -33471,22 +35458,18 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"woy" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
+"wnU" = (
+/turf/open/indestructible/ground/outside/road{
 	dir = 1;
-	icon_state = "outerpavement"
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter (NORTH)"
 	},
 /area/f13/wasteland)
-"woF" = (
-/obj/machinery/button/door{
-	id = "bankvault";
-	name = "bank blast doors";
-	pixel_x = 32;
-	req_one_access_txt = "62"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/city)
+"woy" = (
+/obj/structure/decoration/rag,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "woL" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/fence/wooden{
@@ -33539,43 +35522,25 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wpo" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	termtag = "Business"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/effect/mine/stun,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "wpx" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wqe" = (
-/obj/structure/table/wood,
-/obj/structure/wreck/trash/one_tire{
-	pixel_x = -7;
-	pixel_y = 8
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
-	},
-/area/f13/wasteland)
-"wqi" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/carpet/black,
-/area/f13/city)
-"wqs" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/white,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
+/obj/effect/decal/remains/human,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "wqO" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -33601,11 +35566,17 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "wrG" = (
-/obj/structure/wreck/trash/four_barrels,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "topshadowleft"
+/obj/structure/table/wood,
+/obj/item/melee/curator_whip{
+	desc = "It stings like hell to be hit by.";
+	name = "Slave whip"
 	},
-/area/f13/wasteland)
+/obj/item/melee/curator_whip{
+	desc = "It stings like hell to be hit by.";
+	name = "Slave whip"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "wrP" = (
 /obj/structure/table/optable,
 /turf/open/floor/f13/wood,
@@ -33618,10 +35589,6 @@
 /obj/effect/landmark/start/f13/villager,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"wsy" = (
-/obj/machinery/trading_machine,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "wsA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -33633,6 +35600,10 @@
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"wsE" = (
+/obj/structure/flora/stump,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/legion)
 "wsJ" = (
 /obj/structure/fence/corner{
 	dir = 9
@@ -33644,6 +35615,9 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
+"wsN" = (
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/clinic)
 "wtj" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalcorroded"
@@ -33656,6 +35630,20 @@
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"wtJ" = (
+/obj/effect/landmark/observer_start,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
+"wtY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
 /area/f13/building)
 "wuk" = (
 /turf/open/indestructible/ground/outside/road{
@@ -33681,13 +35669,6 @@
 /obj/item/stack/sheet/metal/twenty,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wvm" = (
-/obj/structure/table/wood,
-/obj/structure/bedsheetbin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/city)
 "wvq" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/small{
@@ -33697,6 +35678,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"wvH" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft3";
+	tag = "icon-verticalleftborderleft3"
+	},
+/area/f13/wasteland)
 "wvV" = (
 /obj/effect/landmark/start/f13/ncrlieutenant,
 /obj/effect/decal/cleanable/dirt{
@@ -33731,12 +35719,6 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
-"wxB" = (
-/obj/structure/girder,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerbordercorner"
-	},
-/area/f13/city)
 "wxI" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -33753,7 +35735,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/item/instrument/trumpet,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "wya" = (
 /obj/structure/table/wood,
@@ -33788,6 +35770,20 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"wyX" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
+"wzg" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2";
+	tag = "icon-verticalleftborderright2"
+	},
+/area/f13/wasteland)
 "wzh" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/f13/wood{
@@ -33795,16 +35791,25 @@
 	},
 /area/f13/village)
 "wzm" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/f13/wood,
+/obj/structure/simple_door/metal/fence{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "wzn" = (
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "wzw" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housebase"
+	},
 /area/f13/radiation)
 "wzK" = (
 /obj/structure/chair{
@@ -33834,13 +35839,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wAm" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "shopouter"
+"wAp" = (
+/obj/item/clothing/under/f13/female/tribal,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"wAQ" = (
+/obj/item/trash/f13/sugarbombs,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
 	},
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/wasteland)
 "wAU" = (
 /obj/structure/rack,
 /obj/item/taperecorder,
@@ -33857,6 +35866,13 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"wAZ" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "wBb" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -33881,6 +35897,10 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
+"wBA" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "wBC" = (
 /obj/structure/rack,
 /obj/item/clothing/head/crown,
@@ -33888,6 +35908,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"wBI" = (
+/obj/structure/simple_door/interior,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "wCu" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -33899,10 +35923,8 @@
 	},
 /area/f13/village)
 "wCA" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 5
-	},
-/area/f13/village)
+/turf/open/floor/wood,
+/area/f13/building)
 "wDc" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -33959,6 +35981,10 @@
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"wEJ" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "wEO" = (
 /obj/machinery/shower{
 	dir = 4
@@ -33968,36 +35994,44 @@
 	},
 /area/f13/building)
 "wER" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
-/turf/closed/wall/f13/tentwall,
-/area/f13/building)
-"wFf" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "133"
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/wasteland)
 "wFo" = (
 /obj/machinery/autolathe/ammo,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "wFp" = (
-/obj/structure/chair{
-	dir = 4
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0";
+	tag = "icon-horizontaltopbordertop0"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/wasteland)
+"wFz" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "clinicoutsideladder"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/building)
 "wFG" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
-"wFL" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/carpet/black,
-/area/f13/city)
 "wGc" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_north_middle"
@@ -34012,10 +36046,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
-"wGz" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "wGJ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
@@ -34030,17 +36060,24 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"wHu" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "133"
+"wGY" = (
+/obj/structure/chair/wood/modern{
+	dir = 8;
+	icon_state = "wooden_chair_old";
+	tag = "icon-wooden_chair_old (WEST)"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "clinicfrontdoor";
-	name = "clinic shutters"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"wHo" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/item/flag/followers,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "wHJ" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -34050,12 +36087,23 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"wHN" = (
+/turf/closed/wall/f13/wood/house/broken,
+/area/f13/wasteland)
 "wHR" = (
 /obj/structure/fluff/rails{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"wIk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "wIm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -34065,6 +36113,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"wIG" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	tag = "icon-wooden_chair_new (NORTH)"
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "wIK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderlefttop"
@@ -34100,6 +36156,13 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"wKP" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
+	},
+/area/f13/wasteland)
 "wKU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -34133,12 +36196,14 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "wLB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/power/solar_control{
+	dir = 8
 	},
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating,
-/area/f13/tunnel)
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/wasteland)
 "wLO" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/dirt,
@@ -34176,18 +36241,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
-"wMy" = (
-/obj/structure/barricade/bars,
-/obj/structure/fence{
-	pixel_x = -16
-	},
-/obj/structure/window/reinforced/fulltile{
-	layer = 2.8
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
 "wNK" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -34222,12 +36275,8 @@
 	},
 /area/f13/building)
 "wOj" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/road{
-	dir = 1;
-	icon_state = "innermaincornerouter"
-	},
-/area/f13/wasteland)
+/turf/closed/indestructible/f13/matrix,
+/area/f13/legion)
 "wOo" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/barber{
@@ -34303,22 +36352,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"wPG" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "clinicfrontdoor";
-	name = "door shutters";
-	pixel_x = -6
-	},
-/obj/machinery/button/door{
-	id = "clinicdesk";
-	name = "desk shutters";
-	pixel_x = 6
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
 "wPS" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
@@ -34343,20 +36376,31 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wQY" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wQZ" = (
 /obj/structure/sink{
-	pixel_y = 18
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/mirror{
+	pixel_x = -32
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "wRb" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small/broken,
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "wRG" = (
@@ -34378,12 +36422,9 @@
 	},
 /area/f13/wasteland)
 "wSj" = (
-/obj/machinery/light/small,
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/flora/tree/joshua,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "wSk" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/outside/desert,
@@ -34415,18 +36456,27 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"wSC" = (
-/turf/closed/wall/f13/supermart,
-/area/f13/city)
 "wSJ" = (
-/obj/structure/simple_door/wood,
+/obj/structure/decoration/clock/old/active{
+	pixel_y = 32
+	},
 /turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
 "wSP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/legion)
+"wSS" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/legion)
 "wSX" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13{
@@ -34441,12 +36491,20 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"wTU" = (
-/obj/effect/decal/cleanable/dirt,
+"wTf" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+	icon_state = "horizontalbottomborderbottom2right";
+	tag = "icon-horizontalbottomborderbottom2right"
 	},
-/area/f13/city)
+/area/f13/wasteland)
+"wTE" = (
+/obj/structure/table/wood/settler,
+/obj/machinery/microwave,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "wUc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -34468,10 +36526,24 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"wUv" = (
-/obj/structure/car/rubbish1,
-/turf/open/indestructible/ground/outside/dirt,
+"wUm" = (
+/obj/structure/chair/wood/worn{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"wUv" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "wUL" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/desert,
@@ -34483,9 +36555,11 @@
 	},
 /area/f13/wasteland)
 "wVk" = (
-/obj/machinery/smartfridge/bottlerack,
-/turf/closed/wall/r_wall/rust,
-/area/f13/city)
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "wVn" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2top"
@@ -34512,11 +36586,6 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"wWb" = (
-/obj/effect/landmark/start/f13/barkeep,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "wWh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/pusher,
@@ -34561,10 +36630,14 @@
 	},
 /area/f13/wasteland)
 "wXq" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/knife/cosmicdirty,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "wXv" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
@@ -34576,11 +36649,27 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
-"wXR" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+"wXH" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/wasteland)
+"wXK" = (
+/obj/effect/landmark/start/f13/sheriff,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"wXR" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "wXT" = (
 /obj/structure/closet/fridge/standard,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -34617,6 +36706,22 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"wYo" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
+"wYs" = (
+/obj/machinery/computer/arcade,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "wYv" = (
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
@@ -34630,20 +36735,35 @@
 	},
 /area/f13/building)
 "wZd" = (
-/obj/machinery/light/sign/oasis,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerborder"
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
+/area/f13/legion)
+"wZn" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderlefttop";
+	tag = "icon-verticalrightborderlefttop"
+	},
+/area/f13/wasteland)
+"wZG" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "wZT" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "xac" = (
-/obj/structure/barricade/bars,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/structure/table,
+/obj/item/kitchen/knife,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/legion)
 "xaj" = (
 /obj/structure/debris/v4,
 /turf/closed/wall/r_wall/rust,
@@ -34688,10 +36808,15 @@
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"xbA" = (
-/obj/structure/sign/poster/prewar/poster83,
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
+"xby" = (
+/obj/structure/simple_door/house{
+	icon_state = "interioropening";
+	tag = "icon-interioropening"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "xbK" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -34718,21 +36843,13 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
-"xcb" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "xcg" = (
-/obj/machinery/light/fo13colored/Pink{
-	name = "light tube"
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerbordercorner"
-	},
-/area/f13/wasteland)
+/area/f13/legion)
 "xcm" = (
 /obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plasteel/barber{
@@ -34750,6 +36867,16 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/village)
+"xcA" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/building)
+"xcL" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/landmark/start/f13/auxilia,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "xcQ" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/combat{
@@ -34784,33 +36911,33 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "xdD" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
-/area/f13/village)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "xdG" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/obj/item/pen,
+/obj/structure/chair/stool/retro/black,
+/mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
+"xdJ" = (
+/obj/machinery/smartfridge/chemistry,
+/turf/closed/wall/f13/supermart,
+/area/f13/building)
+"xdL" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderrighttop";
+	tag = "icon-verticalrightborderrighttop"
+	},
+/area/f13/wasteland)
 "xed" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
-"xee" = (
-/obj/effect/decal/cleanable/oil,
-/obj/item/flag/oasis{
-	density = 0;
-	pixel_y = 24
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
+"xem" = (
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "xeo" = (
 /obj/structure/table/optable,
 /obj/structure/table/optable,
@@ -34831,11 +36958,9 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/legion)
 "xeG" = (
-/obj/structure/chair{
-	dir = 8
-	},
+/obj/structure/chair/stool/retro/black,
 /turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
 "xeK" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -34875,6 +37000,10 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland)
+"xfw" = (
+/obj/item/trash/f13/cram_large,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "xfy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -34887,11 +37016,35 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/caves)
+"xfG" = (
+/obj/structure/disposalpipe/broken{
+	dir = 4
+	},
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating,
+/area/f13/building)
 "xfP" = (
 /obj/structure/bed/mattress/pregame,
 /obj/item/storage/backpack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"xfR" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
+"xfW" = (
+/obj/structure/cable{
+	icon_state = "1-10";
+	tag = "icon-1-10"
+	},
+/turf/open/floor/plating,
+/area/f13/caves)
 "xgn" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/white/box,
@@ -34914,9 +37067,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "xgC" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
-/turf/open/floor/f13/wood,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/f13/caravaneer,
+/obj/item/clothing/under/f13/caravaneer,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "xgI" = (
 /obj/effect/decal/remains{
@@ -34937,16 +37097,14 @@
 "xgX" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/caves)
-"xhd" = (
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/followers)
 "xhh" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
+"xhB" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "xhJ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "topshadowright"
@@ -34965,16 +37123,8 @@
 	},
 /area/f13/wasteland)
 "xiy" = (
-/obj/structure/sink{
-	pixel_y = 15
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
+/turf/closed/wall/f13/wood/interior,
+/area/f13/wasteland)
 "xiB" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13{
@@ -35002,11 +37152,13 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"xjP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+"xjS" = (
+/obj/structure/rack,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "xjZ" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -35053,11 +37205,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "xll" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/food/drinks/flask,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/turf/open/floor/plating,
-/area/f13/tunnel)
+/area/f13/building)
 "xlA" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -35095,14 +37250,29 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"xnh" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbrokenvertical"
+"xmW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
 /area/f13/building)
+"xne" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
+"xnh" = (
+/obj/effect/decal/riverbank{
+	dir = 6
+	},
+/turf/open/water,
+/area/f13/wasteland)
 "xnl" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -35116,15 +37286,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
-"xnr" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters{
-	id = "bankdesk";
-	name = "counter shutters"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "xnt" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -35164,22 +37325,15 @@
 	},
 /area/f13/village)
 "xor" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/ketchup,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"xos" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
 "xow" = (
 /obj/item/clothing/suit/armor/f13/slavelabor,
 /obj/item/clothing/under/f13/legslave,
 /obj/item/clothing/shoes/f13/rag,
+/obj/effect/landmark/start/f13/slave,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
@@ -35187,12 +37341,14 @@
 "xox" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"xoF" = (
-/obj/machinery/smartfridge/bottlerack,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+"xoZ" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2right";
+	tag = "icon-horizontaltopbordertop2right"
+	},
+/area/f13/wasteland)
 "xpi" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light,
@@ -35205,14 +37361,24 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xpr" = (
-/obj/structure/sign/poster/prewar/poster88{
-	pixel_x = -32
+"xpN" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/area/f13/wasteland)
+"xpW" = (
+/obj/structure/fence{
+	dir = 1;
+	icon_state = "straight"
 	},
-/area/f13/city)
+/obj/structure/fence/corner{
+	dir = 8;
+	icon_state = "corner"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "xqk" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -35315,20 +37481,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"xsD" = (
-/obj/machinery/smartfridge/chemistry,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "xsF" = (
 /obj/structure/chair/stool/retro,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
-"xsX" = (
-/obj/structure/sign/departments/medbay,
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
 "xta" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/machinery/light/small{
@@ -35341,6 +37497,10 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
 	},
+/area/f13/wasteland)
+"xtm" = (
+/obj/structure/railing,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "xtG" = (
 /obj/structure/simple_door/metal/barred,
@@ -35375,6 +37535,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"xuJ" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "xuL" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
@@ -35382,11 +37548,8 @@
 	},
 /area/f13/wasteland)
 "xuM" = (
-/obj/machinery/power/solar,
-/obj/structure/cable,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
+/obj/structure/chair/comfy/black,
+/turf/open/floor/wood,
 /area/f13/wasteland)
 "xvg" = (
 /obj/structure/bed/mattress{
@@ -35402,12 +37565,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"xvI" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/followers)
 "xvN" = (
 /obj/structure/table/wood/settler,
 /obj/item/lipstick/black,
@@ -35466,10 +37623,18 @@
 /obj/structure/table/booth,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
+"xwR" = (
+/turf/open/floor/wood/f13/oakbroken2,
+/area/f13/legion)
 "xwW" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/knife/cosmicdirty,
-/turf/open/floor/f13/wood,
+/obj/structure/chair/stool/retro,
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
+"xwZ" = (
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
 "xxf" = (
 /obj/item/storage/trash_stack,
@@ -35482,6 +37647,15 @@
 /obj/structure/chair/wood/worn,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"xxq" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "xxL" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -35490,10 +37664,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"xxV" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "xya" = (
-/turf/open/floor/plasteel/barber{
-	icon_state = "plating"
-	},
+/obj/structure/table/wood/poker,
+/turf/open/floor/holofloor/carpet,
 /area/f13/building)
 "xys" = (
 /obj/effect/decal/cleanable/dirt,
@@ -35512,10 +37689,20 @@
 /obj/structure/stone_tile/center,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xzK" = (
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "xzM" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innershade"
 	},
+/area/f13/wasteland)
+"xzU" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "xAq" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -35553,6 +37740,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"xBl" = (
+/obj/structure/chair/bench,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "xBC" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -35560,13 +37754,20 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"xBH" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "xBK" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "interiorgate"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/meatsalted,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "xBM" = (
 /obj/machinery/door/window{
 	dir = 4
@@ -35577,12 +37778,25 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"xBX" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "xCo" = (
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"xCX" = (
+/obj/machinery/vending/cola/random,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/building)
 "xDA" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/f13{
@@ -35594,9 +37808,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/f13/explorer,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
+/turf/open/floor/wood/f13/oakbroken,
 /area/f13/legion)
 "xDH" = (
 /obj/structure/table/wood,
@@ -35641,9 +37853,16 @@
 	},
 /area/f13/village)
 "xFv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/legion)
 "xFL" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/f13{
@@ -35679,6 +37898,12 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
+"xGz" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderlefttop";
+	tag = "icon-verticalleftborderlefttop"
+	},
+/area/f13/wasteland)
 "xGD" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -35710,6 +37935,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
+"xHC" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/building)
+"xHY" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "xIh" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -35771,24 +38011,39 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/wasteland)
+"xJc" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTHEAST)"
+	},
+/area/f13/wasteland)
 "xJd" = (
 /obj/structure/chair/stool,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "xJA" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "xJY" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
 	icon_state = "dirt"
 	},
 /area/f13/legion)
+"xKa" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "xKb" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -35834,18 +38089,13 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"xLh" = (
-/obj/machinery/light/small{
-	dir = 1
+"xLz" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/city)
-"xLl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/city)
+/area/f13/wasteland)
 "xLK" = (
 /obj/structure/closet/cabinet,
 /mob/living/simple_animal/hostile/ghoul,
@@ -35898,14 +38148,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"xMz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
 "xMN" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -35915,23 +38157,32 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "xMP" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavementcorner"
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_x = -32
 	},
-/area/f13/wasteland)
+/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
+	anchored = 1;
+	pixel_x = -28
+	},
+/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
+	anchored = 1;
+	pixel_x = -36
+	},
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "xNm" = (
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "xNE" = (
-/obj/structure/fluff/broken_flooring,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/village)
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "xNQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -35951,14 +38202,12 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
 "xOZ" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "124"
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
+/area/f13/wasteland)
 "xPd" = (
 /obj/structure/chair{
 	dir = 8
@@ -35969,9 +38218,9 @@
 	},
 /area/f13/building)
 "xPh" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/stage_br,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "xPn" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -36000,8 +38249,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xQu" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/f13/wood,
+/turf/closed/wall/mineral/wood,
 /area/f13/building)
 "xQz" = (
 /obj/structure/fence,
@@ -36043,12 +38291,26 @@
 	},
 /area/f13/building)
 "xSa" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/disposalpipe/broken{
-	dir = 8
+/obj/structure/wreck/trash/five_tires{
+	pixel_x = 3;
+	pixel_y = -13
 	},
-/turf/open/floor/plating,
-/area/f13/tunnel)
+/obj/structure/flora/grass/wasteland{
+	pixel_x = -3
+	},
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	layer = 2;
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermainleft"
+	},
+/area/f13/wasteland)
 "xSC" = (
 /obj/structure/closet/cardboard,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -36084,25 +38346,25 @@
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
-"xTB" = (
-/obj/machinery/chem_dispenser/drinks/beer,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "xTF" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbroken"
+/obj/structure/bonfire,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright1"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
+/area/f13/wasteland)
 "xTK" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"xTM" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "xTZ" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/road{
@@ -36110,28 +38372,42 @@
 	},
 /area/f13/wasteland)
 "xUc" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/structure/wreck/trash/machinepile,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"xUt" = (
+/obj/machinery/light/small,
+/obj/structure/rack,
+/obj/item/stack/medical/gauze/improvised,
+/obj/item/stack/medical/gauze/improvised,
+/obj/item/stack/medical/gauze/improvised,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"xUL" = (
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "xUO" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowvertical"
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2right"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "xUS" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xUW" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2right"
+/obj/structure/wreck/trash/machinepiletwo{
+	layer = 3
 	},
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "xVc" = (
 /obj/structure/decoration/rag{
@@ -36143,6 +38419,14 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
+"xVh" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -6
+	},
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "xVu" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/farm)
@@ -36175,28 +38459,29 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xWu" = (
-/obj/structure/chair,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"xWC" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "xWF" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"xWT" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "xXh" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "xXl" = (
 /obj/item/clothing/under/f13/police,
 /obj/item/clothing/head/f13/police,
@@ -36250,10 +38535,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"xXZ" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "xYN" = (
 /obj/structure/chair{
 	dir = 4
@@ -36300,11 +38581,10 @@
 	},
 /area/f13/farm)
 "yao" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "yau" = (
 /obj/structure/rack,
 /obj/item/seeds/cabbage,
@@ -36328,9 +38608,11 @@
 	},
 /area/f13/wasteland)
 "yaw" = (
-/obj/machinery/microwave/stove,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/wreck/trash/machinepile{
+	layer = 3
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "yaz" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -36355,14 +38637,8 @@
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"yaT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/city)
 "ybg" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -36370,6 +38646,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"ybi" = (
+/obj/machinery/vending/nukacolavend,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "ybq" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -36423,12 +38706,6 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/village)
-"ycD" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_south"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "ydQ" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowdestroyed"
@@ -36453,10 +38730,29 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/legion)
+"yea" = (
+/obj/structure/decoration/vent,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"yej" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (NORTH)"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
+	},
+/area/f13/building)
 "yel" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2left"
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
 "yev" = (
@@ -36491,12 +38787,6 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
-"yfI" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
-	},
-/area/f13/city)
 "yga" = (
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -36536,6 +38826,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ygP" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright3";
+	tag = "icon-verticalleftborderright3"
+	},
+/area/f13/wasteland)
 "ygY" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -36554,10 +38850,18 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"yhv" = (
-/obj/structure/decoration/clock{
-	pixel_y = 30
+"yht" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
 	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop3"
+	},
+/area/f13/wasteland)
+"yhv" = (
+/obj/structure/simple_door/brokenglass,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "yhB" = (
@@ -36579,11 +38883,41 @@
 /obj/effect/spawner/lootdrop/three_course_meal,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
+"yiv" = (
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "yiF" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/legion)
+"yiJ" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/building)
+"yiM" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Sheriff Office";
+	req_one_access_txt = "62"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"yiU" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "yjt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/booth,
@@ -36613,6 +38947,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"ykw" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outermaincornerouter";
+	tag = "icon-outermaincornerouter (EAST)"
+	},
+/area/f13/wasteland)
 "ykx" = (
 /obj/item/clothing/head/ushanka,
 /obj/structure/displaycase,
@@ -36628,12 +38970,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "ykD" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/costumes,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "ykH" = (
 /obj/structure/table/wood/settler,
 /obj/item/lipstick/purple,
@@ -36643,6 +38984,25 @@
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland)
+"yla" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike,
+/obj/structure/decoration/hatch{
+	dir = 1;
+	layer = 2.5
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"ylA" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
 	},
 /area/f13/wasteland)
 "ylC" = (
@@ -36670,18 +39030,15 @@
 "ylR" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oakbroken3,
 /area/f13/legion)
 "ymd" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/flag/oasis{
-	density = 0;
-	pixel_x = 1;
-	pixel_y = 28
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/area/f13/wasteland)
 "ymi" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt,
@@ -37159,7 +39516,7 @@ gcK
 gcK
 gcK
 gcK
-ktB
+gcK
 gcK
 gcK
 gcK
@@ -37416,7 +39773,7 @@ gcK
 gcK
 gcK
 gcK
-ktB
+gcK
 gcK
 gcK
 gcK
@@ -37673,7 +40030,7 @@ gcK
 gcK
 gcK
 gcK
-ktB
+gcK
 gcK
 gcK
 gcK
@@ -37911,8 +40268,7 @@ unI
 hbW
 gmX
 gmX
-koD
-dMW
+sBk
 gcK
 gcK
 gcK
@@ -37924,16 +40280,17 @@ gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-ktB
-gcK
-gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -38168,25 +40525,12 @@ unI
 hbW
 gmX
 snB
-koD
-dMW
+wwM
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
 ktB
 gcK
 gcK
@@ -38195,6 +40539,19 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 gcK
@@ -38425,29 +40782,29 @@ unI
 hbW
 gmX
 gmX
-aXu
-dMW
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+koD
 gcK
 gcK
 gcK
 gcK
 ktB
+ktB
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -38532,8 +40889,8 @@ kzs
 sNC
 kzs
 xGv
-dAX
-lJx
+kzs
+sed
 sHu
 xEc
 xEc
@@ -38684,23 +41041,16 @@ erY
 gmX
 koD
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
 ktB
 gcK
 gcK
@@ -38709,6 +41059,9 @@ gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -38728,13 +41081,17 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -38941,23 +41298,7 @@ cdc
 snB
 koD
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
 ktB
 gcK
 gcK
@@ -38967,6 +41308,19 @@ gcK
 gcK
 gcK
 gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -38984,14 +41338,17 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -39196,20 +41553,14 @@ pBv
 dXy
 cdc
 snB
-bfu
-dMW
+koD
+gcK
+ktB
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ggK
+hBr
 gcK
 gcK
 gcK
@@ -39222,6 +41573,11 @@ gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -39239,16 +41595,17 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -39453,20 +41810,14 @@ ajD
 lSD
 cdc
 snB
-sBk
+koD
 gcK
+ktB
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+hBr
+ggK
+ggK
+ggK
 gcK
 gcK
 gcK
@@ -39479,6 +41830,12 @@ gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -39495,17 +41852,17 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -39710,7 +42067,32 @@ jIB
 hbW
 apk
 apk
-wwM
+koD
+gcK
+ktB
+gcK
+ggK
+ggK
+qTN
+ggK
+kHQ
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -39727,42 +42109,17 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -39969,6 +42326,30 @@ gmX
 cdc
 koD
 gcK
+ktB
+hBr
+ggK
+ggK
+nHC
+ggK
+ggK
+hBr
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -39985,41 +42366,17 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -40226,22 +42583,30 @@ gmX
 cdc
 koD
 gcK
+ktB
+ggK
+lFe
+ggK
+ggK
+ggK
+ggK
+ggK
 gcK
 gcK
 gcK
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 ktB
 gcK
 gcK
@@ -40258,25 +42623,17 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -40483,17 +42840,15 @@ cdc
 cdc
 koD
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ggK
+ggK
+ggK
+rOT
+ggK
+ggK
+xKr
+ggK
 gcK
 gcK
 gcK
@@ -40501,6 +42856,22 @@ gcK
 gcK
 ktB
 gcK
+ktB
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -40509,31 +42880,17 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -40740,24 +43097,38 @@ cdc
 gmX
 koD
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+iPY
+ggK
+nHC
+ggK
+ggK
+wnA
+wnA
+wnA
+hBr
 gcK
 gcK
 gcK
 gcK
 ktB
 gcK
+ktB
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -40766,31 +43137,17 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -40997,28 +43354,38 @@ erY
 ajy
 koD
 gcK
+ktB
+ggK
+ggK
+ggK
+ggK
+ggK
+wnA
+ggK
+ggK
+ggK
+ggK
 gcK
 gcK
 gcK
+ktB
 gcK
+ktB
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+ktB
+ktB
+ktB
 ktB
 gcK
 gcK
 gcK
 gcK
 gcK
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -41027,27 +43394,17 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -41254,26 +43611,38 @@ erY
 gmX
 koD
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ggK
+ggK
+ggK
+ggK
+ggK
+hBr
+ggK
+ggK
+xcA
+xcA
+xcA
+dCV
 gcK
 ktB
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+ktB
+ktB
+ktB
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -41282,29 +43651,17 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -41511,26 +43868,32 @@ erY
 gmX
 koD
 gcK
+ktB
+hBr
+ggK
+ggK
+rTM
+ggK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+dCV
+pMh
+pMh
+dCV
 gcK
 ktB
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+ktB
+ktB
+ktB
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -41543,25 +43906,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -41766,28 +44123,34 @@ jIB
 hbW
 erY
 gmX
-bfu
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+koD
 gcK
 ktB
 gcK
 gcK
 gcK
+hBr
+gcK
+gcK
+gcK
+gcK
+dCV
+yiJ
+pMh
+dCV
+gcK
+ktB
+ktB
+ktB
+ktB
+gbL
+gbL
+gbL
+ktB
+ktB
+ktB
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -41800,25 +44163,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fVn
-fVn
-fVn
-fVn
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -42023,27 +44380,34 @@ ofX
 qnS
 dFQ
 gmX
-wwM
+koD
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
+ktB
 ktB
 gcK
 gcK
+dCV
+dCV
+dCV
+pQF
+wyX
+dCV
+dCV
+dCV
+gcK
+gcK
+ktB
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -42056,30 +44420,23 @@ gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fVn
-olt
-xcb
-hHz
-gDl
-fVn
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -42284,23 +44641,30 @@ koD
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
 ktB
 gcK
 gcK
+dCV
+qQp
+lLu
+lLu
+oOZ
+lLu
+qXr
+dCV
+gcK
+gcK
+ktB
+ktB
+ktB
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -42313,30 +44677,23 @@ gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fVn
-ntg
-hHz
-hHz
-hHz
-fVn
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -42538,28 +44895,33 @@ dXy
 cdc
 snB
 koD
-foN
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+dCV
+dCV
+dCV
+dCV
+dCV
+lLu
+ltD
+lLu
+oOZ
+ngF
+oOZ
+dCV
+dCV
+dCV
+dCV
+dCV
 ktB
 gcK
 gcK
 gcK
 gcK
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -42574,26 +44936,21 @@ gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fVn
-eCJ
-hHz
-hHz
-qpJ
-fVn
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -42795,28 +45152,33 @@ tCh
 cdc
 snB
 koD
-dMW
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+dCV
+saz
+lLu
+vYZ
+dCV
+oOZ
+bpB
+eGu
+wtY
+oOk
+oOZ
+dCV
+sXG
+lLu
+kGI
+dCV
 ktB
 gcK
 gcK
 gcK
 gcK
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -42831,26 +45193,21 @@ gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fVn
-fVn
-hHz
-hHz
-hHz
-fVn
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -43052,28 +45409,33 @@ hbW
 bJB
 gmX
 koD
-dMW
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+dCV
+scr
+oOZ
+oOZ
+wyX
+aYu
+lLu
+oOZ
+lLu
+oOZ
+lLu
+wyX
+lLu
+lLu
+bLa
+dCV
 ktB
 gcK
 gcK
 gcK
 gcK
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -43088,26 +45450,21 @@ gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fVn
-fVn
-meU
-hHz
-olt
-fVn
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -43308,63 +45665,63 @@ pBv
 dXy
 cdc
 snB
-bfu
-dMW
+koD
+gcK
+ktB
+ktB
+ktB
+dCV
+sea
+wbP
+pme
+dCV
+sDJ
+oOk
+kGI
+neD
+mBA
+qXr
+dCV
+nIJ
+jdK
+jAK
+dCV
+ktB
+ktB
+ktB
+ktB
+gcK
+gbL
+gbL
 gcK
 gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
-gcK
-gcK
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fVn
-fVn
-hHz
-hHz
-hHz
-fVn
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -43565,63 +45922,63 @@ ajD
 lSD
 wGJ
 snB
-sBk
-dMW
+koD
+gcK
+ktB
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+jcn
+jcn
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+ktB
+gcK
+gcK
+ktB
+ktB
 gcK
 gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
-gcK
-gcK
-brH
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-brH
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fVn
-fVn
-fVn
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fVn
-fVn
-fVn
-hHz
-ghG
-fVn
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -43822,63 +46179,63 @@ jIB
 hbW
 wGJ
 apk
-wwM
-dMW
-jJb
-fyf
+koD
+gcK
+ktB
+dCV
+lLu
+oOZ
+sxT
+wjr
+dCV
+oOZ
+tzZ
+lLu
+lLu
+oOZ
+oOZ
+xmW
+oOZ
+dCV
+vBp
+oOZ
+xWC
+xWC
+dCV
+ktB
+gcK
+gcK
+ktB
+ktB
 gcK
 gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
-brH
-sfB
-gXz
-rNI
-lBv
-sCB
-lwv
-sfB
-brH
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fVn
-hHz
-hHR
-hPV
-fVn
-fVn
-fVn
-fVn
-fVn
-fVn
-fVn
-fVn
-fVn
-gWh
-fVn
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -43916,11 +46273,11 @@ tXe
 nPy
 nPZ
 sGG
-rhr
-rhr
-rhr
-rhr
-rhr
+cpK
+uok
+atX
+atX
+uok
 cpK
 cpK
 bTf
@@ -44071,7 +46428,7 @@ fyf
 fyf
 fyf
 gcK
-nGq
+gts
 fyf
 fyf
 kGc
@@ -44080,9 +46437,48 @@ hbW
 erY
 ubg
 koD
-dMW
-fyf
-sqA
+gcK
+ktB
+dCV
+lVR
+dCV
+sDJ
+lLu
+dCV
+oOZ
+oOZ
+raq
+lLu
+oOZ
+oOZ
+oOZ
+emZ
+dCV
+cwW
+oOZ
+eLd
+wdA
+dCV
+ktB
+gcK
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -44090,52 +46486,13 @@ gcK
 gcK
 gcK
 gcK
-brH
-sfB
-bRP
-pNZ
-pNZ
-huU
-iQK
-sfB
-brH
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fVn
-fVn
-fVn
-fVn
-fVn
-hHz
-fVn
-hYe
-fVn
-ilI
-xcb
-ilI
-xcb
-ilI
-xcb
-ilI
-hHz
-hHz
-hHz
-fVn
-fVn
-gcK
-gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -44173,11 +46530,11 @@ tNa
 cpK
 lvS
 eJe
-rhr
-cNF
-jiR
-wjR
-rhr
+cpK
+uok
+atX
+atX
+uok
 cpK
 cpK
 elT
@@ -44337,9 +46694,48 @@ hbW
 wGJ
 snB
 koD
-dMW
-fyf
-fyf
+gcK
+ktB
+dCV
+mxq
+oUO
+oOZ
+oOZ
+jcn
+wtY
+cKp
+lLu
+lLu
+lLu
+wtY
+kJP
+jTQ
+jcn
+neD
+wtY
+xWC
+mMn
+dCV
+ktB
+gcK
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -44347,52 +46743,13 @@ gcK
 gcK
 gcK
 gcK
-brH
-sfB
-tYk
-pNZ
-huU
-iQK
-pNZ
-sfB
-brH
-gcK
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-fVn
-fSE
-xcb
-hHz
-fVn
-hHz
-hHR
-ilq
-fVn
-ish
-hHz
-ish
-hHz
-ish
-hHz
-ish
-hHz
-hHz
-hHz
-hHz
-sIa
-fVn
 gcK
 gcK
+gcK
+gcK
+gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -44430,11 +46787,11 @@ tXe
 cpK
 jSN
 eJe
-rhr
-iuE
-szG
-wjR
-raV
+cpK
+uok
+atX
+atX
+uok
 cpK
 cpK
 rRi
@@ -44594,62 +46951,62 @@ hbW
 wGJ
 snB
 koD
-dMW
-fyf
-fyf
+gcK
+ktB
+dCV
+mRt
+ppN
+lLu
+oOZ
+jcn
+lLu
+jTQ
+lLu
+oOZ
+aYu
+oOZ
+bHF
+oOZ
+jcn
+aYu
+wtY
+oOZ
+oOZ
+dCV
+ktB
+gcK
+gcK
+ktB
+ktB
 gcK
 gcK
 gcK
-trF
-trF
-trF
-trF
-brH
-sfB
-baS
-fZu
-cwg
-pNZ
-iQK
-sfB
-brH
-brH
-brH
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-brH
-fVn
-fXY
-fXY
-hHz
-fVn
-hHz
-fVn
-fVn
-fVn
-moH
-hHz
-moH
-hHz
-moH
-hHz
-moH
-hHz
-hHz
-qBq
-hHz
-sQl
-fVn
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -44687,11 +47044,11 @@ cpK
 cpK
 cpK
 eJe
-rhr
-wjR
-juV
-wjR
-rhr
+cpK
+uok
+atX
+atX
+uok
 cpK
 cpK
 cpK
@@ -44850,63 +47207,63 @@ jIB
 hbW
 cdc
 snB
-sBk
-dMW
-jJb
-fyf
-fyf
+koD
+gcK
+ktB
+dCV
+mxq
+oUO
+sTe
+wpo
+dCV
+oOZ
+oOZ
+oOZ
+lLu
+lLu
+oOZ
+vYZ
+gnj
+dCV
+oOZ
+raq
+oOZ
+phF
+dCV
+ktB
 gcK
 gcK
-brH
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-bhl
-sfB
-sfB
-sfB
-sfB
-sfB
-mXA
-mXA
-mXA
-mXA
-mXA
-mXA
-mXA
-mXA
-sfB
-brH
-fVn
-fXY
-fXY
-hHz
-gWh
-ghG
-hHz
-hHz
-hHz
-hHz
-hHz
-hHz
-hHz
-hHz
-hHz
-hHz
-hHz
-hHz
-qGx
-hHz
-hHz
-tCu
-fVn
+ktB
+ktB
 gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -44944,11 +47301,11 @@ sCz
 sCz
 sCz
 qLO
-rhr
-wjR
-nLX
-uug
-rhr
+cpK
+cpK
+cpK
+hUW
+cpK
 cpK
 cpK
 cpK
@@ -45107,63 +47464,63 @@ ofX
 hbW
 dFQ
 gmX
-wwM
-dMW
-fyf
-fyf
-tNX
+koD
+gcK
+ktB
+dCV
+mWG
+pHi
+taG
+wtY
+dCV
+oOZ
+eGu
+okn
+oOZ
+oOZ
+jdK
+oOZ
+lLu
+dCV
+wtY
+wYo
+bSE
+pYb
+dCV
+ktB
 gcK
 gcK
-brH
-sfB
-pGa
-pGa
-pGa
-pGa
-pGa
-pGa
-pGa
-sfB
-hHz
-sfB
-hHz
-lGV
-kvZ
-sfB
-mXA
-sXN
-cNH
-dLg
-tmh
-doF
-eGo
-mXA
-sfB
-brH
-fVn
-fXY
-fXY
-hHz
-fVn
-fVn
-fVn
-fVn
-fVn
-ilI
-hHz
-ilI
-hHz
-ilI
-hHz
-ilI
-hHz
-hHz
-qBq
-hHz
-hHz
-fVn
+ktB
+ktB
 gcK
 gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -45202,7 +47559,7 @@ ezX
 rhr
 rhr
 ezX
-raV
+rhr
 ezX
 ezX
 ezX
@@ -45356,7 +47713,7 @@ igz
 igz
 igz
 igz
-nGq
+gts
 igz
 igz
 hgX
@@ -45364,63 +47721,63 @@ unI
 hbW
 cdc
 vnc
-koD
-dMW
-fXP
-fyf
-fyf
+bfu
+gcK
+ktB
+dCV
+dCV
+dCV
+dCV
+wyX
+dCV
+dCV
+dLO
+dLO
+cly
+cly
+dLO
+dLO
+dCV
+dCV
+wyX
+dCV
+dCV
+dCV
+dCV
+ktB
 gcK
 gcK
-brH
-sfB
-pGa
-bJe
-bOG
-ciw
-vgg
-bZq
-qPS
-bhl
-hHz
-sfB
-cGw
-lGV
-nxD
-sfB
-mXA
-sXN
-xjP
-iGN
-iGN
-iGN
-iGN
-mXA
-sfB
-brH
-fVn
-fSE
-ghG
-hHz
-fVn
+ktB
+ktB
 gcK
 gcK
 gcK
-fVn
-ish
-hHz
-ish
-hHz
-ish
-hHz
-ish
-hHz
-hHz
-hHz
-hHz
-hHz
-fVn
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -45453,7 +47810,7 @@ sgz
 sgz
 koD
 ezX
-jNs
+qQf
 mfN
 qQf
 qQf
@@ -45607,7 +47964,7 @@ pmt
 hbW
 gmX
 qbl
-nGq
+gts
 ybI
 ybI
 dkP
@@ -45621,60 +47978,60 @@ onk
 hbW
 cdc
 snB
-koD
-dMW
-fyf
-iFr
+wwM
+gcK
+ktB
+ktB
+ktB
+dCV
+tkZ
+oOZ
+tkZ
+dCV
+dLO
+muh
+muh
+muh
+muh
+dLO
+dCV
+cwW
+oOZ
+nvV
+dCV
+ktB
+ktB
+ktB
+gcK
+gcK
+ktB
+ktB
 gcK
 gcK
 gcK
-brH
-wVk
-oRQ
-qPS
-qPS
-qPS
-qPS
-qPS
-qPS
-sfB
-hHz
-vJB
-hHz
-cGw
-cGw
-sfB
-mXA
-vHK
-cNH
-mXA
-mXA
-mXA
-mXA
-mXA
-sfB
-brH
-fVn
-fVn
-fVn
-fVn
-fVn
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
-fVn
-moH
-ghG
-moH
-ghG
-moH
-ghG
-moH
-hHz
-hHz
-hHz
-fVn
-fVn
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -45879,57 +48236,57 @@ erY
 lZP
 snB
 koD
-dMW
-fyf
-fyf
 gcK
 gcK
 gcK
-brH
-wVk
-qPS
-qPS
-qPS
-csY
-kqn
-wWb
-ajX
-sfB
-hHz
-sfB
-sKp
-hHz
-qOd
-sfB
-mXA
-mXA
-iGN
-iGN
-iGN
-cNH
-cNH
-mXA
-sfB
-brH
-pGa
-pGa
-pGa
-pGa
-pGa
-pGa
+ktB
+dCV
+tJx
+oOZ
+dCV
+dCV
+dLO
+muh
+muh
+muh
+muh
+dLO
+dCV
+dCV
+oOZ
+nUs
+dCV
+ktB
+ktB
+ktB
+gcK
+gcK
+ktB
+ktB
 gcK
 gcK
 gcK
-fVn
-fVn
-fVn
-fVn
-fVn
-fVn
-fVn
-hHz
-hHz
-fVn
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -46136,45 +48493,27 @@ cdc
 bJB
 gmX
 koD
-dMW
-fyf
-fyf
 gcK
 gcK
 gcK
-brH
-sfB
-lvp
-kqn
-kqn
-kqn
-kqn
-dmq
-pGa
-sfB
-sEn
-sfB
-gLx
-nOl
-qOd
-sfB
-mXA
-mXA
-iGN
-cNH
-bzZ
-uKb
-cNH
-mXA
-sfB
-brH
-brH
-pGa
-gim
-aVq
-scW
-pGa
-brH
+ktB
+dCV
+tPt
+dCV
+dCV
+dLO
+dLO
+muh
+muh
+muh
+muh
+dLO
+dLO
+dCV
+dCV
+nvV
+dCV
+ktB
 gcK
 gcK
 gcK
@@ -46183,10 +48522,28 @@ gcK
 gcK
 gcK
 gcK
-fVn
-hHz
-hHz
-fVn
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -46393,62 +48750,62 @@ erY
 cdc
 snB
 koD
-dMW
-fyf
-fyf
 gcK
 gcK
 gcK
-brH
-sfB
-xTB
-kqn
-wWb
-kqn
-kqn
-sLG
-kqn
-sfB
-hHz
-sfB
-sfB
-sfB
-sfB
-sfB
-mXA
-mXA
-gPX
-mXA
-mkP
-hTh
-ofe
-mXA
-sfB
-brH
-brH
-pGa
-gjM
-aVq
-aVq
-pGa
-brH
+gcK
+dCV
+dCV
+dCV
+gcK
+gcK
+wKP
+wKP
+bvq
+wKP
+wKP
 gcK
 gcK
 gcK
-iGP
-fyf
-fyf
-ghx
-ghx
-mgo
-fyf
-fyf
-qHx
-fyf
+dCV
+dCV
+dCV
+ktB
 gcK
 gcK
 gcK
-csk
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 ktB
@@ -46492,7 +48849,7 @@ ohV
 pfb
 uVw
 xdt
-nQu
+rPR
 ezX
 cpK
 cpK
@@ -46635,7 +48992,7 @@ ees
 ees
 ees
 ees
-nGq
+gts
 ees
 ees
 ees
@@ -46650,62 +49007,62 @@ hbW
 uVo
 snB
 koD
-dMW
-fyf
+vfu
 gcK
 gcK
 gcK
 gcK
-brH
-sfB
-pGa
-kmn
-kmn
-kmn
-kmn
-pGa
-ufK
-sfB
-vJB
-sfB
-cXb
-pVp
-kvZ
-sfB
-mXA
-mXA
-nax
-mXA
-mXA
-mXA
-mXA
-mXA
-sfB
-brH
-brH
-pGa
-gtY
-aVq
-aVq
-pGa
-brH
-brH
-brH
 gcK
-iMi
-fyf
-ghx
-ghx
-qOV
-mgu
-cWG
-mgu
-cWG
-fyf
-fyf
-fyf
-csk
-csk
+gcK
+gcK
+gcK
+gcK
+wKP
+wKP
+wKP
+wKP
+gcK
+gcK
+gcK
+vfu
+vfu
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 ktB
@@ -46788,7 +49145,7 @@ koD
 dMW
 fyf
 fyf
-fyf
+lWZ
 fyf
 fyf
 tBN
@@ -46898,7 +49255,7 @@ ptf
 ptf
 ptf
 ptf
-nGq
+gts
 ptf
 ptf
 kwK
@@ -46906,64 +49263,64 @@ ofX
 iZa
 apk
 apk
-koD
-dMW
+fLc
+fQc
+hqQ
+fQc
+fQc
+fQc
+fQc
+fQc
+fQc
+pWw
+pWw
+cSF
+geR
+fQc
+fQc
+fQc
+fQc
+fQc
+fQc
+fQc
+eGo
+fNz
+fyf
+gxK
+fyf
+stK
+gbL
+gbL
+gbL
 gcK
 gcK
-brH
-brH
-brH
-brH
-sfB
-pGa
-qiU
-wbi
-qiU
-qiU
-pGa
-pJt
-hHz
-hHz
-sfB
-cGw
-lGV
-nxD
-sfB
-mXA
-ogO
-nax
-kCA
-gqE
-kCA
-pIC
-mXA
-pGa
-pGa
-pGa
-pGa
-pGa
-gJI
-pGa
-pGa
-pGa
-pGa
-brH
 gcK
-iGP
-fyf
-ghx
-fyf
-tBN
-mrS
-mrS
-oqu
-mrS
-rHT
-ghx
-fyf
-tUC
-csk
-umi
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -47006,7 +49363,7 @@ onx
 pfb
 uVw
 xdt
-nQu
+rPR
 rhr
 cpK
 cpK
@@ -47163,64 +49520,64 @@ unI
 hbW
 erY
 ubg
-koD
+pIN
+pIN
+pIN
+pIN
+pIN
+pIN
+pIN
+pIN
+pIN
+pIN
+pIN
+qXn
+wzg
+pIN
+eFL
+pIN
+pIN
+pIN
+wzg
+tav
+tBB
 dMW
-gcK
-gcK
-brH
-ayJ
-ayJ
-ayJ
-pGa
-pGa
-nPq
-cGw
-hHz
-cGw
-cGw
-cGw
-hHz
-hHz
-vJB
-hHz
-hHz
-cGw
-sfB
-mXA
-kpL
-lyk
-xLl
-jtu
-aHz
-xLl
-mXA
-pGa
-gzD
-tYL
-dSd
-bFY
-lGV
-bgz
-nlD
-hHD
-pGa
-brH
-gcK
-iMi
+bBm
 fyf
-yiF
-vuH
-kKZ
-mwa
-mzC
-ovE
-qKe
-rJO
-bpD
 fyf
-csk
-csk
-csk
+xJA
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -47420,64 +49777,64 @@ unI
 hbW
 wGJ
 snB
-koD
-dMW
-gcK
-gcK
-brH
-aGv
-aVq
-aVq
-vJB
-hHz
-hHz
-cGw
-hHz
-hHz
-hHz
-hHz
-hHz
-hHz
-sfB
-sKp
-cGw
-qOd
-sfB
-mXA
-knw
-jTY
-aJZ
-fAP
-fAP
-xLl
-mXA
-pGa
-eAS
-hHz
-iMV
-hHz
-lGV
-lGV
-lGV
-bzr
-pGa
-brH
-gcK
-iXz
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+fAN
+fAN
+fAN
+jTR
+aac
+aac
+aac
+fAN
+fAN
+lCO
+aGO
+pNY
+fNz
 fyf
-jiP
-jAf
-kZh
-mzC
-nAI
-oBu
-naF
-nJz
-tAS
 fyf
-tUS
-tUC
-csk
+fyf
+xJA
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -47677,64 +50034,64 @@ unI
 qvQ
 apk
 abN
-koD
-dMW
-gcK
-gcK
-brH
-aHN
-aHN
-aHN
-pGa
-pGa
-hHz
-ndx
-cGw
-mHv
-cGw
-cGw
-hHz
-fVH
-sfB
-gLx
-nOl
-qOd
-sfB
-mXA
-mXA
-mXA
-mXA
-aDl
-aDl
-mXA
-mXA
-fVn
-fVn
-baY
-hHz
-hHz
-lGV
-pGa
-pGa
-pGa
-pGa
-brH
-gcK
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+ehN
+aac
+aac
+lCO
+beE
+lcq
+kaj
+gkv
+oBQ
+oBQ
+oBQ
+mdI
+wTf
+fNz
 fyf
 fyf
-jlB
-mvv
-lhN
-naF
-nJz
-nhX
-mzC
-mwa
-tAS
-fyf
-ueL
-csk
-csk
+pzQ
+xJA
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -47934,64 +50291,64 @@ unI
 hbW
 erY
 gmX
-koD
-dMW
+geM
+ees
+hDr
+ees
+ees
+pKP
+ees
+muk
+nZd
+lCO
+lCO
+rLn
+dqk
+gqj
+rUC
+dqk
+dqk
+jPE
+jPE
+rlo
+rlo
+rlo
+rlo
+sfD
+rlo
+stK
+gbL
+gbL
+gbL
 gcK
 gcK
-brH
-brH
-blX
-blX
-bDb
-hZo
-cGw
-tit
-eUp
-wgO
-hHz
-bKE
-sfB
-sfB
-sfB
-kkE
-kkE
-sfB
-cmI
-lKG
-ryc
-jME
-jME
-bet
-bet
-mPa
-bet
-wzn
-slM
-hHz
-hHz
-hHz
-lGV
-lGV
-nxD
-fvt
-pGa
-brH
 gcK
-fyf
-fyf
-jlB
-mvv
-liO
-ndT
-oat
-oVF
-qPW
-sik
-tAS
-ghx
-ueL
-csk
-csk
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -48074,7 +50431,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+qTY
 fyf
 jJb
 fyf
@@ -48174,16 +50531,16 @@ fyf
 fyf
 fyf
 fyf
-fyf
-siJ
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
+uqa
+uqa
+uqa
+uqa
+uqa
+uqa
+uqa
+uxC
+uxC
+gts
 fyf
 fyf
 kGc
@@ -48192,63 +50549,63 @@ hbW
 erY
 gmX
 koD
-dMW
-fyf
+vfu
+hFz
+vfu
+vfu
+vfu
+sUr
+exn
+nZd
+aac
+erY
+pNY
+vfu
+wKP
+vfu
+wKP
+rlo
+rlo
+rlo
+rlo
+nCj
+cXP
+nXl
+acI
+rlo
+bjo
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
-brH
-sfB
-pGa
-qqK
-hHz
-cFJ
-gxk
-cFJ
-hHz
-kSK
-cwF
-fVn
-fVn
-wxB
-faI
-vDd
-sDI
-pRv
-pRv
-pRv
-ybI
-ybI
-ybI
-oUj
-xcg
-aDs
-fVn
-fsQ
-iNR
-dwx
-lGV
-lGV
-iVd
-kvZ
-pGa
-brH
-mTd
-jWO
-fyf
-dHq
-jNj
-lpd
-nhX
-ojL
-pqP
-qTr
-sio
-tAS
-fyf
-ufP
-csk
-csk
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -48431,17 +50788,17 @@ fyf
 fyf
 fyf
 fyf
+uqa
+dCU
+rpu
+rpu
+buo
+uqa
+cfd
 fyf
+dCx
+eid
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
 fyf
 kGc
 unI
@@ -48449,63 +50806,63 @@ hbW
 erY
 gmX
 koD
-dMW
-rVr
-fyf
+sUX
+stK
+vfu
+sUr
+vfu
+wKP
+xoZ
+nZd
+iIc
+lCO
+pNY
+vfu
+vfu
+wKP
+oSX
+rlo
+nXl
+gYL
+nWv
+acI
+xne
+acI
+acI
+rlo
+bjo
+gbL
+gbL
+gbL
 gcK
 gcK
-brH
-sfB
-pGa
-bqC
-hHz
-cGw
-hHz
-cGw
-cGw
-cGw
-inc
-fVn
-gOs
-uKA
-wrG
-idu
-idu
-fjC
-idu
-erY
-erY
-cdc
-eyg
-wGJ
-aXu
-fVn
-pGa
-pGa
-pGa
-pGa
-pGa
-pGa
-pGa
-pGa
-pGa
-brH
 gcK
-fyf
-fyf
-dHq
-jPG
-kZh
-nwh
-nJz
-pzN
-qUO
-siu
-tAS
-fyf
-tUS
-csk
-csk
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -48688,17 +51045,17 @@ fyf
 fyf
 fyf
 fyf
+uqa
+dCU
+rpu
+rpu
+rpu
+yjG
+cgy
 fyf
 fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+eid
+bBm
 fyf
 kGc
 unI
@@ -48707,62 +51064,62 @@ erY
 ubg
 koD
 dMW
-fyf
-fyf
-lPT
+stK
+wKP
+sUr
+sUr
+uFp
+mkV
+nZd
+fAN
+aGO
+pNY
+wKP
+wKP
+wKP
+vfu
+rlo
+nXl
+acI
+acI
+lQK
+tmp
+rlo
+xby
+rlo
+rlo
+gbL
+gbL
+gbL
 gcK
-brH
-sfB
-pGa
-mKB
-tar
-cGw
-cGw
-cGw
-cGw
-cGw
-ruN
-iGt
-cpK
-ajD
-hbW
-erY
-erY
-wGJ
-nnh
-cvO
-ehP
-aCn
-wGJ
-cdc
-koD
-fVn
-jeX
-fDx
-iGd
-gBT
-pGa
-bVq
-lrq
-scW
-pGa
-brH
 gcK
-fyf
-fyf
-nlO
-kcQ
-mcz
-nwu
-liO
-pHm
-qZO
-sxs
-hCg
-fyf
-csk
-csk
-umi
+gcK
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -48945,17 +51302,17 @@ fyf
 fyf
 fyf
 fyf
+uqa
+anc
+rpu
+nSQ
+plt
+uqa
+chK
+dkE
+cfd
+eid
 fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 fyf
 kGc
 unI
@@ -48964,62 +51321,62 @@ erY
 uVo
 koD
 dMW
-fyf
-tFR
-lPT
+hLs
+sHM
+sUr
+wKP
+vfu
+wFp
+nZd
+fAN
+hIY
+pNY
+ybi
+rlo
+rlo
+rlo
+rlo
+iEQ
+acI
+evz
+iVc
+acI
+rlo
+vrJ
+vrJ
+rlo
+gbL
+gbL
+gbL
 gcK
-brH
-sfB
-sfB
-orO
-eNs
-ycD
-cGw
-hHz
-cGw
-cAW
-ycD
-fVn
-cpK
-ajD
-hbW
-erY
-erY
-lZP
-eTJ
-cdc
-wGJ
-wGJ
-ehP
-wGJ
-fmO
-cXB
-hHz
-fQE
-iGd
-dSd
-pGa
-gim
-aVq
-aVq
-pGa
-brH
 gcK
-fyf
-fyf
-fyf
-ghx
-mdc
-nxj
-onz
-pMf
-rbF
-cTp
-fyf
-fyf
-csk
-csk
-csk
+gcK
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -49198,20 +51555,20 @@ fyf
 fyf
 siJ
 fyf
+qTY
 fyf
 fyf
 fyf
+uqa
+rpu
+rpu
+qfV
+rpu
+aLF
 fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+dCx
+cgy
+eid
 fyf
 fyf
 kGc
@@ -49221,62 +51578,62 @@ erY
 gmX
 koD
 dMW
-tFR
+xJA
+dGR
+sHM
+sUr
+sUr
+mkV
+nZd
+rcL
+rcL
+pNY
+reU
+rlo
+wYs
+vrJ
+rlo
+rlo
+vpl
+rlo
+rlo
+bAJ
+rlo
+sKX
+fPP
+rlo
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
-brH
-brH
-sfB
-pGa
-vNH
-wgO
-cGw
-cGw
-cGw
-wgO
-gLx
-vYE
-cpK
-nyZ
-fVZ
-wGJ
-cdc
-wGJ
-wqe
-bIV
-dza
-etg
-eIg
-cdc
-fru
-cXB
-hHz
-hHz
-hHz
-hHz
-pGa
-pGa
-hlQ
-pGa
-pGa
-brH
+gbL
+gbL
 gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-pSo
-fyf
-ghx
-fyf
-fyf
-tUC
-csk
-csk
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gcK
 gcK
 ktB
 "}
@@ -49459,16 +51816,16 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fyf
+uqa
+avO
+rpu
+rpu
+bwF
+uqa
+cjG
+cgy
+chK
+uqa
 fyf
 fyf
 kGc
@@ -49477,62 +51834,62 @@ dXy
 erY
 gmX
 koD
-aeZ
-tFR
-gcK
-gcK
-gcK
-gcK
-brH
-sfB
-pGa
-hoX
-amq
-hHz
-hHz
-oXK
-iSH
-amq
-fVn
-rRt
-dhB
-hbW
-wGJ
-dmL
-rdW
-mXF
-rdW
-uVo
-etg
-eJr
-wGJ
-fMj
-cXB
-hHz
-prs
-hHz
-hHz
-slM
-lGV
-lGV
-nxD
-pGa
-brH
-gcK
+dMW
+xJA
 fyf
-fyf
-fyf
-fyf
+dGR
+sHM
+wKP
+mkV
+nZd
+rYd
+erY
+wTf
+vfu
+rlo
+eOY
+vrJ
+uBK
+vrJ
+nms
+uBK
+bQU
+vrJ
+rlo
+vkb
+uEJ
+rlo
+gcK
+ktB
 gcK
 gcK
 gcK
-mTd
+gcK
+gbL
+gbL
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
 gcK
-csk
-csk
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -49716,16 +52073,16 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
+uqa
+uqa
+aLF
+yjG
+uqa
+uqa
+uqa
+aLF
+uqa
+uqa
 fyf
 fyf
 kGc
@@ -49735,63 +52092,63 @@ erY
 gmX
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
-gcK
-brH
-sfB
-pGa
-pGa
-ymd
-cGw
-pGa
-pih
-pGa
-pGa
-fVn
-cpK
-nRu
-hbW
-iRE
-uet
-adD
-ngg
-rdW
-cdc
-etg
-eJr
-wGJ
-koD
-fVn
-gCu
-fVn
-slM
-pGa
-pGa
-xLh
-lGV
-snQ
-pGa
-brH
-brH
-mvv
+xJA
 fyf
-dqc
-mTd
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+fyf
+dGR
+sHM
+mkV
+fTj
+erY
+erY
+wTf
+hrs
+qXi
+vrJ
+tkF
+drK
+vrJ
+fLR
+vrJ
+vrJ
+vrJ
+rlo
+bvV
+aPr
+rlo
 gcK
 ktB
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gcK
+gcK
 ktB
 "}
 (52,1,1) = {"
@@ -49973,18 +52330,18 @@ uxC
 uxC
 uxC
 uxC
-uxC
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+uqa
+rpu
+rpu
+rpu
+uqa
+bZU
+rpu
+kyu
+qfV
+uqa
 fyf
 fyf
-tFR
-tFR
-qvN
 kGc
 unI
 hbW
@@ -49992,61 +52349,61 @@ erY
 gmX
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
-gcK
-brH
-sfB
-sfB
-sfB
-lBy
-lBy
-sfB
-sfB
-sfB
-sfB
-sfB
-cpK
-mDf
-xhJ
-kaM
-kaM
-kaM
-jRU
+xJA
+stK
+stK
+pYF
+stK
+mkV
+hGx
 erY
-cdc
-wkd
-eVh
-wGJ
-koD
-tpN
-tpN
-fVn
-wzn
-fVn
-fVn
-cXB
-cXB
-fVn
-fVn
-sfB
-oMA
-fQt
-mvv
-mvv
-sfB
-jEd
-jEd
-sfB
-sfB
-sfB
-sfB
-sfB
-brH
+erY
+tBB
+jKq
+xfR
+vrJ
+tkF
+nCj
+nCj
+anK
+iMl
+drK
+vrJ
+rlo
+rlo
+rlo
+rlo
+gcK
+ktB
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -50230,80 +52587,80 @@ fyf
 fyf
 fyf
 fyf
+uqa
+aFw
+qfV
+rpu
+vde
+rpu
+cpJ
+dHX
+rpu
+uqa
 fyf
-gcK
-gcK
-gcK
-gcK
 fyf
-fyf
-fyf
-fyf
-trW
-qwq
-fHx
 kGc
-rPM
+unI
 uOF
 erY
 ubg
 koD
-jkJ
-brH
-brH
-brH
-brH
-brH
-brH
-sfB
-sfB
-sfB
-xac
-vxb
-sfB
-tCc
-wgf
-ssm
-tVV
-spi
-sIf
-ees
-dNT
-gQv
-muk
-hbW
-wGJ
-gmX
-geM
-gQv
-jZE
-sVF
-dkg
-kfx
-aDs
-uaf
-uaf
-fVn
-moO
-ucw
-fVn
-fVn
-lKV
-cpK
-dkg
-dkg
-dkg
-lrB
-bet
-bet
-cpK
-uaf
-cpK
-cpK
-sfB
-brH
+dMW
+stK
+stK
+qFI
+qFI
+stK
+stK
+nZd
+aac
+erY
+qoJ
+wKP
+mFs
+fLR
+vrJ
+tkF
+tkF
+tkF
+tkF
+tkF
+vrJ
+clO
+acI
+jkY
+rlo
+gcK
+ktB
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
 gcK
 gcK
 ktB
@@ -50487,80 +52844,80 @@ fyf
 fyf
 fyf
 fyf
+uqa
+aug
+rpu
+rpu
+uqa
+uqa
+cIm
+cIm
+rpu
+uqa
 fyf
 fyf
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-tFR
-nCx
-azk
 kGc
-xUW
+ofX
 uOF
 erY
 snB
-fLc
-dkP
-dkP
-lUg
-brH
-sJw
-jFb
-fEW
-ybI
-pYN
-sfB
-ybI
-ybI
-sfB
-dqf
-omd
-nYY
-wIK
-sJw
-sTa
-ybI
-ybI
-ybI
-aun
-hbW
-wGJ
-gmX
-fLc
-sJw
-jps
-hkW
-jps
-nnA
-sJw
-tUH
-jps
-sJw
-ybI
-ybI
-ybI
-ybI
-mEn
-ybI
-ybI
-ybI
-nkp
-lrB
-bet
-cNE
-atX
-cNE
-oUy
-cpK
-sfB
-brH
+koD
+dMW
+stK
+iZE
+ncU
+qcq
+uTA
+stK
+nZd
+aac
+nBC
+pNY
+vfu
+eKz
+vrJ
+nms
+vrJ
+vrJ
+vrJ
+vrJ
+nms
+fLR
+rlo
+cek
+uLh
+rlo
+gcK
+ktB
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -50744,80 +53101,80 @@ fyf
 fyf
 fyf
 fyf
+uqa
+uqa
+rpu
+kyu
+uqa
+vUF
+rpu
+rpu
+dKt
+uqa
 fyf
 fyf
-fyf
-fyf
-fyf
-uey
-fyf
-fyf
-fyf
-tFR
-nCx
-azk
 kGc
-rPM
+unI
 uOF
 ubg
 uVo
-idu
-idu
-rLi
-qsL
-ehN
-hOl
-sgz
-sgz
-sgz
-sgz
-uRN
-hOl
-qlE
-xBK
-sQX
-pWN
-plq
-rkr
-hOl
-sQX
-sQX
-sQX
-sQX
-kcY
-sQX
-sQX
-sQX
-sQX
-sQX
-hOl
-hOl
-dop
-xFv
-xFv
-moR
-xFv
-sQX
-qDM
-sQX
-wGJ
-uMZ
-wGJ
-cdc
-gWo
-wOj
-srM
-lrB
-def
-hEa
-jEX
-cNE
-fZm
-cpK
-sfB
-brH
+koD
+dMW
+stK
+jpd
+qFI
+rrB
+tHf
+stK
+fTj
+aac
+fAN
+pNY
+vfu
+xfR
+weI
+nCj
+ocX
+vrJ
+vrJ
+ocX
+nCj
+weI
+rlo
+rlo
+rlo
+rlo
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -51002,79 +53359,79 @@ sqA
 fyf
 fyf
 fyf
+uqa
+rpu
+olW
+uqa
+vUF
+nSQ
+qfV
+rpu
+uqa
 fyf
-uey
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tFR
-nCx
-azk
 kGc
-rPM
+unI
 uOF
 dmL
 snB
-ehN
-ehN
-ehN
-sgz
-ehN
-vMU
-hOl
-hOl
-hOl
-hOl
-cPg
-sQX
-sQX
-hnq
-sQX
-sQX
-hOl
-hOl
-hOl
-sQX
-xFv
-xFv
-uMZ
-uMZ
-uMZ
-sOD
-wGJ
-sQX
-wGJ
-wGJ
-wGJ
-wGJ
-wGJ
-uMZ
-xFv
-eEC
-xFv
-sQX
-sQX
-sQX
-apk
-cdc
-cdc
-pfl
-hWq
-srM
-lrB
-uCW
-uaf
-bFJ
-fZm
-fZm
-cpK
-sfB
-brH
+koD
+dMW
+stK
+stK
+fGC
+qhs
+stK
+stK
+sZD
+fAN
+fAN
+pNY
+vfu
+rlo
+eFs
+nCj
+pfc
+vrJ
+vrJ
+whU
+nCj
+eFs
+rlo
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -51258,80 +53615,80 @@ fyf
 fyf
 fyf
 fyf
-hAC
-hAC
 fyf
-hAC
+uqa
+aQN
+blH
+uqa
+vUF
+rpu
+rpu
+cSH
+uqa
 fyf
 fyf
-hAC
-fyf
-uey
-fyf
-nCx
-azk
 kGc
-rPM
+unI
 uOF
 xEs
 apk
-kaM
-hOl
-hOl
-hOl
-hOl
-ehN
-ehN
-ehN
-sQX
-sQX
-hnq
-sQX
-sQX
-cPg
-sQX
-sQX
-xFv
-xFv
-xFv
-aAO
-xFv
-jrX
-jrX
-uVo
-snB
-wGJ
-wGJ
-sQX
-sQX
-sQX
-sQX
-wGJ
-wGJ
-wGJ
-wGJ
-sQX
-sQX
-sQX
-xFv
-xFv
-sQX
-apk
-aAk
-iyo
-abi
 koD
-kfJ
-loo
-uCW
-bFJ
-egb
-cNE
-cpK
-sfB
-brH
+dMW
+fyf
+stK
+nNI
+nNI
+stK
+stK
+snB
+ioQ
+fAN
+wTf
+vfu
+rlo
+rlo
+rlo
+rlo
+rlo
+rlo
+rlo
+rlo
+rlo
+rlo
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -51516,79 +53873,79 @@ fyf
 fyf
 fyf
 fyf
+uqa
+uqa
+uqa
+uqa
+aLF
+itJ
+aLF
+uqa
+uqa
 fyf
 fyf
-uey
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-nCx
-azk
 kGc
-rPM
+unI
 uOF
 erY
 gmX
-wZd
-ees
-dNT
-gHP
-brH
-dNT
-dNT
-bwo
-dNT
-nNZ
-sfB
-kBC
-kBC
-sfB
-eUQ
-iLc
-nNZ
-fqS
-aHZ
-eRC
-nJM
-rgI
-ees
-ees
-ees
-gQv
-gQv
-gQv
-jZE
-ees
-oTB
-ees
-ees
-ees
-ees
-fsm
-jZE
-ees
-lGG
-lGG
-lGG
-lGG
-oKy
-oKy
-itI
-aTE
-uCW
-uCW
-uCW
-uCW
-pjQ
-pjQ
-mqy
-sfB
-brH
+koD
+dMW
+fyf
 gcK
 gcK
+gcK
+gcK
+gcK
+snB
+gWo
+eMD
+hzb
+jMC
+fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -51775,77 +54132,77 @@ igz
 bEw
 hAC
 fyf
-hAC
-hAC
-hAC
+fyf
+fyf
+tBN
+mvv
+bpD
 fyf
 fyf
 fyf
 fyf
-dKR
-xPh
 kGc
-kwe
+pBv
 xVc
 erY
 gmX
 koD
-sUX
-brH
-brH
-brH
-brH
-brH
-brH
-sfB
-sfB
-sfB
-fyo
-cNH
-cNH
-iGN
-iLc
-iLc
-upg
-upg
-fVn
-fVn
-fVn
-tPA
-gdY
-cpK
-bet
-sgr
-mrg
-mrg
-mrg
-mrg
-nkp
-bFJ
-bFJ
-bFJ
-bFJ
-vQU
-gdY
-bFJ
-dkg
-dkg
-dkg
-cam
-uaf
-cam
-mzs
-uaf
-uaf
-uaf
-uaf
-cam
-cam
-sPJ
-sfB
-brH
+dMW
+fyf
 gcK
 gcK
+gcK
+gcK
+gcK
+aac
+pfl
+fyf
+fyf
+fyf
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -52034,11 +54391,11 @@ fyf
 fyf
 fyf
 fyf
-uey
+nlO
+mfD
+hCg
 fyf
-hAC
-fyf
-fyf
+upX
 fyf
 fyf
 kGc
@@ -52048,61 +54405,61 @@ erY
 gmX
 koD
 dMW
-bsb
-dba
-eov
-hjP
-aDk
-brH
-brH
-brH
-sfB
-hjb
-ilc
-iGN
-iGN
-flP
-iGN
-cNH
-cNH
-csl
-mbD
-fVn
-iIG
-uCW
-uCW
-rRt
-wSC
-uDp
-wMy
-wMy
-wMy
-wSC
-hVd
-fZm
-pjQ
-pjQ
-cpK
-dkg
-neN
-uaf
-dfx
-bet
-bet
-iBT
-cpK
-uaf
-uaf
-cam
-snA
-cam
-cpK
-bet
-cpK
-sfB
-brH
+fyf
+fyf
 gcK
 gcK
+gcK
+gcK
+aac
+pfl
+fyf
+uey
+fyf
+uVs
+fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -52289,11 +54646,11 @@ cpK
 dMW
 fyf
 fyf
-uey
 fyf
-hAC
 fyf
-uey
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -52303,63 +54660,63 @@ jIB
 agH
 erY
 gmX
-bfu
+koD
 dMW
-bsb
-ipj
-qqQ
-qqQ
-qqQ
-qAS
-bFl
-brH
-sfB
-ovR
-hTS
-uyD
-ssC
-iLc
-fVn
-fVn
-fVn
-flP
-fVn
-fVn
-aDs
-nkp
-uCW
-wSC
-wSC
-bfq
-krd
-krd
-szn
-wSC
-cvE
-oON
-oUy
-lEG
-cpK
-lvL
-tOP
-uok
-mar
-cpK
-mUU
-rTY
-cNE
-cNE
-uQx
-uaf
-bet
-bet
-cpK
-jPN
-cpK
-sfB
-brH
+fyf
+fyf
 gcK
 gcK
+gcK
+gcK
+aac
+pWN
+aRW
+fyf
+fyf
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -52544,79 +54901,79 @@ sQX
 koD
 cpK
 dMW
+sqA
+fyf
+fyf
+bBm
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-lWZ
-fyf
+sqA
 kGc
 ofX
 qnS
 dFQ
 gmX
-wwM
+koD
 dMW
-bsb
-ipj
-qAS
-qqQ
-qqQ
-qqQ
-nZw
-brH
-sfB
-iLc
-iLc
-iLc
-iLc
-iLc
-fVn
-kBr
-fVn
-cGw
-kNH
-ibs
-lCi
-sBk
-uCW
-cQU
-wSC
-cBB
-gVE
-gVE
-vBO
-wSC
-wSC
-cQU
-wSC
-dkg
-cpK
-lvL
-tOP
-hqC
-wSP
-lEG
-qwq
-fHx
-lEG
-lEG
-iBv
-cRH
-qoj
-lTx
-cpK
-dkg
-cpK
-sfB
-brH
+bBm
+fyf
 gcK
 gcK
+gcK
+gcK
+aac
+aac
+pWN
+oCi
+ssm
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -52804,11 +55161,11 @@ dMW
 fyf
 fyf
 fyf
-uey
-nPu
-uey
 fyf
-uey
+qOV
+cWG
+wDc
+fyf
 fyf
 fyf
 fyf
@@ -52819,61 +55176,61 @@ cdc
 vnc
 koD
 dMW
-bsb
-bsb
-sQj
-xXZ
-qqQ
-wGz
-wjx
-brH
-sfB
-tjy
-sfB
-sfB
-sfB
-sfB
-fVn
-sSr
-xcb
-cGw
-kNH
-gOs
-cWB
-qJR
-uCW
-lsC
-krd
-yaT
-yaT
-yaT
-aTI
-wSC
-klx
-hwn
-wSC
-dkg
-bet
-lvL
-sln
-uok
-mar
-bet
-dKR
-xPh
-aYp
-aYp
-iLc
-iLc
-iLc
-iLc
-mGo
-jEX
-cpK
-sfB
-brH
+fyf
+fyf
+fyf
 gcK
 gcK
+gcK
+aac
+aac
+snB
+koD
+nPX
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -53062,9 +55419,9 @@ fyf
 uey
 fyf
 fyf
-fyf
-fyf
-fyf
+tBN
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -53075,62 +55432,62 @@ dXy
 cdc
 snB
 koD
-jkJ
-igz
-bsb
-bsb
-bsb
-oYu
-bsb
-bsb
-brH
-brH
-eAK
-brH
-brH
-brH
-sfB
-xoF
-fOe
-lvR
-hHz
-hHz
-rSc
-uCW
-pjQ
-oON
-wSC
-wSC
-mUS
-gVE
-gVE
-yaT
-wHu
-kcc
-cNH
-wSC
-dkg
-fZm
-uok
-mar
-uok
-mar
-bet
-bet
-woy
-ghx
-ghx
-lmV
-iiH
-qWG
-iLc
-kru
-nzq
-cpK
-sfB
-brH
+dMW
+fyf
+fyf
+fyf
 gcK
 gcK
+gcK
+snB
+gWo
+eMD
+hzb
+jMC
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -53317,14 +55674,14 @@ uaf
 dMW
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+uqa
+drN
+uqa
+itJ
+uqa
+uqa
+uqa
+uqa
 fyf
 kGc
 unI
@@ -53332,62 +55689,62 @@ rQh
 uTG
 snB
 koD
-uCW
-nPg
-onk
-bsb
-fKt
-qqQ
-qxN
-bsb
-bWF
-gNB
-iSE
-fyf
-lYu
-brH
-sfB
-fVn
-gBj
-oRz
-cGw
-hYR
-vWq
-pjQ
-bet
-bet
-wSC
-klI
-krd
-krd
-krd
-krd
-wSC
-mNK
-cNH
-wSC
-boj
-fZm
-rTY
-rTY
-pya
-ubS
-ubS
-ptf
-edA
+dMW
 fyf
 fyf
-iLc
-iLc
-gIA
-iLc
-ryO
-aUc
-odS
-sfB
-brH
+fyf
+fyf
 gcK
 gcK
+uVo
+pfl
+fyf
+fyf
+fyf
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -53574,14 +55931,14 @@ uaf
 dMW
 fyf
 fyf
-uey
-fyf
-fyf
-fyf
-lRT
-uey
-fyf
-fyf
+uqa
+bOH
+pVI
+rpu
+rpu
+rkZ
+rpu
+drN
 fyf
 kGc
 unI
@@ -53589,62 +55946,62 @@ hbW
 bJB
 gmX
 koD
-uCW
-pBv
-psR
-uSz
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-lgI
-fyf
-tdv
-brH
-sfB
-fVn
-fVn
-fVn
-fVn
-fVn
-fVn
-fVn
-uCn
-sgr
-wSC
-wSC
-wSC
-wad
-wad
-wSC
-wSC
-iGN
-cNH
-wSC
-bet
-fZm
-cpK
-cpK
 dMW
 fyf
-qOV
-cWG
-cWG
-lKK
-iLc
-iLc
-iLc
-gIA
-iLc
-iLc
-iNX
-sfB
-sfB
-brH
+fyf
+fyf
+fyf
 gcK
 gcK
+lvy
+uit
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -53831,77 +56188,77 @@ gdY
 dMW
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-uey
+uqa
+rpu
+rpu
+rpu
+rpu
+qfV
+rpu
+uqa
 fyf
 kGc
 pBv
 dXy
 cdc
 snB
-bfu
-uCW
-ajD
-lPT
-gNB
-rjH
-mvv
-rjH
-rjH
-mvv
-pIn
-iSE
-lYu
-tdv
-brH
-sfB
-npS
-npS
-mdE
-frx
-vJq
-cam
-cpK
-bet
-ltq
-kcw
-wSC
-jLV
-krd
-krd
-xpr
-wFf
-iGN
-cNH
-wSC
-bet
-bet
-bet
-bet
+koD
 dMW
 fyf
-tBN
-mvv
-gGt
-uKG
-iLc
-wqs
-lTZ
-gIA
-qWG
-iLc
-aUc
-sfB
-brH
-brH
+fyf
+bBm
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+doo
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -54088,77 +56445,77 @@ cpK
 dMW
 hAC
 fyf
-hAC
-nPu
-fyf
-fyf
-fyf
-uey
-fyf
-fyf
+uqa
+itJ
+uqa
+uqa
+bxl
+rpu
+rpu
+itJ
 fyf
 kGc
 ajD
 lSD
 uVo
-snB
-sBk
-uCW
-ajD
-uIK
-rjH
-rjH
-rjH
-rjH
-rjH
-mvv
-mvv
-fTW
-tor
-rpa
-brH
-sfB
-iLc
-lil
-iLc
-iLc
-iLc
-cJZ
-vpa
-rTY
-whS
-dIN
-wSC
-wSC
-wPG
-iIz
-oco
-wSC
-iGN
-cNH
-wSC
-bet
-fZm
-tNI
-bet
-gCN
-iLc
-dTY
-dTY
-iLc
-gGt
-iLc
-qWG
-gIA
-qWG
-qWG
-iLc
-aUc
-sfB
-brH
+apk
+koD
+dMW
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+bBm
+fyf
+fyf
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -54345,77 +56702,77 @@ cpK
 dMW
 fyf
 fyf
-fyf
-fyf
-uey
-fyf
-hAC
-fyf
-hAC
-hAC
+uqa
+rpu
+ijl
+uqa
+rpu
+nSQ
+rpu
+uqa
 fyf
 kGc
 jIB
 hbW
 apk
-apk
-wwM
-uCW
-jIB
-pSC
-rjH
-rjH
-rjH
-rjH
-rjH
-rjH
-rjH
-oIF
-geM
-dNT
-brH
-sfB
-iLc
-hHz
-hHz
-azj
-iLc
-iLc
-iLc
-iLc
-vvc
-aUc
-wSC
-kin
-wSC
-svJ
-wSC
-wSC
-tfn
-cNH
-wSC
-bet
-sNM
-iLc
-iGt
-iLc
-iLc
-qHn
-fuc
-iLc
-uJP
-iLc
-xWT
-gIA
-qWG
-djk
-iLc
-pzm
-sfB
-brH
+ehN
+koD
+dMW
+fyf
+fyf
+fyf
+fyf
+uVs
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -54601,78 +56958,78 @@ koD
 cpK
 dMW
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-uey
+aYY
+uqa
+bOH
+nZs
+uqa
+rpu
+tJe
+rpu
+drN
 fyf
 kGc
 ofX
 dIR
-erY
-arb
+ehN
+ubg
 koD
-uCW
-ajD
-uIK
-rjH
-rjH
-rjH
-rjH
-rjH
-rjH
-rjH
-oIF
-oKA
-uCW
-wAm
-sfB
-iLc
-vwS
-hHz
-hHz
-iLc
-wsy
-sMz
-iLc
-xee
-aUc
-wSC
-cNH
-gCq
-iGN
-iGN
-cOi
-cNH
-sAL
-wSC
-pjQ
-iLc
-iLc
-hHz
-cGw
-xnr
-rDd
-hxk
-iLc
-iLc
-iLc
-gIA
-hxU
-gRs
-gof
-iLc
-cTc
-sfB
-brH
+dMW
+fyf
+pis
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+wjt
+uVs
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -54859,14 +57216,14 @@ cpK
 dMW
 fyf
 fyf
-hAC
-fyf
-fyf
-fyf
-uey
-hAC
-hAC
-fyf
+uqa
+drN
+uqa
+uqa
+uqa
+uqa
+uqa
+uqa
 fyf
 kGc
 unI
@@ -54874,62 +57231,62 @@ dXy
 wGJ
 snB
 koD
-uCW
-ajD
-lPT
-bWF
-jZk
-mvv
-mvv
-rjH
-rjH
-mvv
-oIF
-wwM
-uCW
-wAm
-swe
-hHz
-hHz
-ihm
-hHz
-lil
-hHz
-hHz
-nwB
-vyb
-qGa
-wSC
-ulC
-wSC
-wSC
-iGN
-iGN
-cNH
-etN
-wSC
-pjQ
-cpL
-rXu
-hHz
-cGw
-vBD
-rDd
-cai
-iLc
-vdE
-iLc
-gIA
-cZT
-bmr
-qWG
-iLc
-fSz
-sfB
-brH
+dMW
+fyf
+qOV
+cWG
+cWG
+cWG
+cWG
+cWG
+lfu
+cWG
+cWG
+ghx
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -55062,7 +57419,7 @@ fyf
 fyf
 fyf
 fyf
-uey
+fyf
 fyf
 fyf
 fyf
@@ -55131,62 +57488,62 @@ dXy
 wGJ
 uVo
 koD
-uCW
-ofX
-uSz
-agX
-lPT
-gfR
-lPT
-agX
-agX
-agX
-uSz
-koD
-uCW
-wAm
-swe
-hHz
-hHz
-hHz
-hHz
-iLc
-rRo
-hHz
-iLc
-vyb
-fFT
-wSC
-cNH
-qjF
-oOG
-cNH
-iGN
-iGN
-iGN
-wSC
-fFT
-ddR
-rAf
-cGw
-cGw
-vBD
-mvF
-jfV
-htQ
-hHz
-fVn
-iVn
-iLc
-iLc
-nfz
-fVn
-cTc
-sfB
-brH
+dMW
+fyf
+tBN
+mvv
+oCW
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+bpD
+vfS
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -55327,9 +57684,9 @@ fyf
 fyf
 fyf
 fyf
-fbH
-mfD
-hCg
+tBN
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -55388,62 +57745,62 @@ rQh
 apk
 snB
 koD
-uCW
-sIf
-ees
-dNT
-gQv
-gQv
-ees
-ees
-ees
-ees
-gQv
-sVF
-uCW
-wAm
-sfB
-oDm
-oiz
-hHz
-hHz
-cwB
-hHz
-mDr
-tja
-dwS
-qGa
-wSC
-hET
-vMo
-dLa
-pDd
-eDT
-kjB
-lDd
-wSC
-fFT
-jmz
-rAf
-ekp
-cGw
-vBD
-rDd
-seB
-iLc
-udf
-fVn
-lGV
-wqi
-hpY
-hpY
-fVn
-cTc
-sfB
-brH
-brH
+dMW
+fyf
+jsX
+nji
+mvv
+mvv
+mvv
+mvv
+pKm
+mvv
+mvv
+bpD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -55581,12 +57938,12 @@ fyf
 fyf
 fyf
 fyf
+hAC
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
+tBN
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -55644,63 +58001,63 @@ onk
 hbW
 ehN
 gmX
-fLc
-ybI
-sJw
-ybI
-ybI
-hkW
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-nkp
-brH
-sfB
-oDm
-bmg
-hHz
-ihm
-cwB
-hHz
-mDr
-bEP
-nJc
-qGa
-wSC
-wSC
-wSC
-wSC
-wSC
-wSC
-wSC
-wSC
-wSC
-qGa
-iLc
-iLc
-iLc
-iLc
-iLc
-syq
-iLc
-iLc
-hHz
-fVn
-lGV
-lGV
-lGV
-ePw
-fVn
-iiG
-sfB
-sfB
-brH
+koD
+dMW
+fyf
+jyl
+sYX
+sYX
+abi
+abi
+abi
+sYX
+sYX
+qyU
+sYX
+sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -55829,24 +58186,24 @@ wDc
 fyf
 fyf
 fyf
+sND
+fyf
+fyf
+fyf
+qTY
+hAC
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
+tBN
+mvv
+bpD
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-trW
 fyf
 fyf
 fyf
@@ -55901,63 +58258,63 @@ tUb
 ehN
 ehN
 ehN
-aJb
-aJb
-aJb
-tUb
-idu
-ehN
-idu
-ehN
-ehN
-ehN
-hBN
-idu
-nFL
-pnw
-brH
-sfB
-oDm
-nGh
-hHz
-hHz
-iLc
-hHz
-mDr
-iLc
-dyH
-qGa
-vyb
-vyb
-aVC
-yfI
-ijm
-qGa
-vLj
-vLj
-vLj
-qGa
-dTY
-sfB
-sfB
-sfB
-sfB
-cjU
-sfB
-iLc
-hHz
-fVn
-oAS
-lGV
-lGV
-qMj
-fVn
-cTc
-gET
-sfB
-brH
+koD
+dMW
+fyf
+tBN
+sYX
+qie
+rpu
+eZr
+rpu
+rpu
+xjA
+rpu
+rpu
+sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+pis
+fyf
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -56091,7 +58448,6 @@ fyf
 fyf
 fyf
 fyf
-hAC
 fyf
 fyf
 fyf
@@ -56099,8 +58455,9 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
+tBN
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -56158,63 +58515,63 @@ ehN
 ehN
 ehN
 ehN
-ehN
-ehN
-sgz
-ehN
-rbe
-ehN
-rbe
-ehN
-ehN
-hOl
-sgz
-ehN
-gmX
-sBk
-eAK
-tjy
-oDm
-gok
-cwO
-hHz
-lil
-hHz
-mDr
-iLc
-qGa
-qGa
-fVn
-kYv
-slM
-fVn
-fVn
-fFT
-qGa
-nIj
-mMe
-qGa
-iLc
-sfB
-mJu
-cSO
-esE
-cNH
-sfB
-iLc
-udf
-fVn
-lGV
-lGV
-lGV
-lGV
-fVn
-cTc
-cTc
-sfB
-brH
+koD
+dMW
+sYX
+sYX
+sYX
+uCO
+uWJ
+wIk
+hUm
+rpu
+jpr
+ebK
+rpu
+sYX
+sYX
+sYX
+sYX
+sYX
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 ktB
@@ -56350,16 +58707,16 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-qTY
-fyf
-fyf
-fyf
-fyf
 hAC
+hAC
+fyf
+fyf
+ulH
+tBN
+mvv
+bpD
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -56415,61 +58772,61 @@ qoS
 ehN
 ehN
 ehN
-kaM
-kaM
-kaM
-kaM
-kaM
-kaM
-kaM
-kaM
-kaM
-abd
-qoS
-kaM
-huu
-wwM
-brH
-sfB
-oDm
-cRk
-hHz
-hHz
-iLc
-deb
-cGw
-oDm
-odS
-nIj
-fVn
-kqe
-hHz
-gDl
-fVn
-ohx
-wvm
-fxf
-mMe
-qGa
-dTY
-sfB
-iGN
-cNH
-cNH
-cYT
-sfB
-iLc
-hHz
-tIu
-lGV
-usO
-usO
-agP
-fVn
-tvP
-cTc
-sfB
-brH
+koD
+dMW
+sYX
+jzC
+njC
+qsS
+uCO
+wSJ
+rpu
+fLJ
+gvW
+kVO
+rpu
+uCO
+dqD
+cNJ
+gon
+sYX
+fyf
+fyf
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -56604,20 +58961,20 @@ fyf
 fyf
 fyf
 fyf
+tlD
+uxC
+uxC
+uxC
+uxC
+sUv
 fyf
 fyf
-uey
-uey
-fyf
-hAC
-fyf
+tBN
+mvv
+bpD
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sND
 fyf
 fyf
 fyf
@@ -56649,11 +59006,11 @@ fsm
 fsm
 gQv
 jZE
-muk
-hbW
-erY
-gmX
-geM
+jZE
+jZE
+jZE
+ees
+ees
 ees
 ees
 ees
@@ -56672,61 +59029,61 @@ muk
 qnS
 erY
 ubg
-geM
-dNT
-dNT
-dNT
-dNT
-dNT
-dNT
-dNT
-dNT
-dNT
-dNT
-dNT
-dNT
-sVF
-brH
-sfB
-oDm
-iLc
-iLc
-oDm
-oDm
-dgt
-dpS
-iLc
-qGa
-qGa
-fVn
-rRo
-hHz
-hHz
-fVn
-uul
-vAm
-nIj
-okc
-qGa
-iLc
-sfB
-kiP
-cSO
-bmu
-uyP
-sfB
-iLc
-hHz
-fVn
-lGV
-rDT
-lFI
-fEg
-fVn
-beG
-edO
-sfB
-brH
+koD
+dMW
+sYX
+jQq
+njK
+mZD
+uZg
+xdG
+tuS
+gvW
+gvW
+rpu
+klA
+sDp
+xzK
+xzK
+oPJ
+sYX
+fyf
+wjt
+fyf
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -56858,20 +59215,20 @@ mvv
 doX
 cWG
 cWG
-cWG
-cWG
 wDc
 fyf
 fyf
-hAC
-uey
-fyf
-fyf
-fyf
-fyf
-uey
-fyf
-hAC
+thG
+adD
+cWG
+cWG
+cWG
+cWB
+cWG
+cWG
+daU
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -56905,13 +59262,13 @@ ptf
 ptf
 ptf
 ptf
-gNA
-unI
-hbW
-erY
-gmX
-koD
-sUX
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
 ptf
 ptf
 ptf
@@ -56930,60 +59287,60 @@ dXy
 cdc
 snB
 koD
-xsX
-rco
-fvi
-qvu
-gKG
-gKG
-gKG
-gKG
-gKG
-gKG
-gKG
-gKG
-gKG
-brH
-sfB
-sfB
-sfB
-sfB
-sfB
-iLc
-iLc
-iLc
-aUc
-qGa
-vyb
-fVn
-mtX
-hHz
-meU
-fVn
-xos
-kcP
-qcT
-rzn
-cOg
-iLc
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-iLc
-tIu
-fVn
-lGV
-lGV
-jkj
-wFL
-fVn
-cTc
-cTc
-sfB
-brH
+dMW
+abi
+saZ
+nnz
+mZD
+vhd
+xeG
+ogf
+ubK
+gvW
+oeq
+plt
+uCO
+uCO
+uCO
+uCO
+sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -57115,24 +59472,24 @@ xGH
 mvv
 mvv
 mvv
+bpD
+fyf
+fyf
+thG
+tBN
+mvv
+mvv
+mvv
+daM
+mvv
+mvv
 mvv
 mvv
 bpD
 fyf
-hAC
-fyf
-nPu
-fyf
-uey
-fyf
-fyf
-hAC
 fyf
 fyf
 fyf
-fyf
-fyf
-hAC
 fyf
 fyf
 fyf
@@ -57155,92 +59512,92 @@ fyf
 fyf
 sVO
 uxC
+fyf
+fyf
 uxC
-uxC
-uxC
+laC
+pIa
+wXH
+pIa
+laC
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 sYX
-xUO
-fGS
-xUO
-sYX
-unI
-dXy
-cdc
-snB
-koD
-dMW
-sYX
-xnh
-xnh
-ovN
+spt
+spt
+tjd
 sYX
 uxC
 uxC
 uxC
 uxC
 wEo
-fyf
-fyf
 kGc
-ajD
-lSD
-uVo
+unI
+bbR
+cdc
 snB
 koD
-dGZ
-dyO
-dDF
-dDF
-gmW
-ltZ
-rJU
-rJU
-rJU
-rJU
-rJU
-rJU
-gKG
-gKG
-gKG
-gKG
-gKG
-gKG
-sfB
-dau
-qGa
-vyb
-vyb
-wTU
-vyb
-fVn
-fVn
-fVn
-fVn
-fVn
-tEp
-tEp
-pOL
-nUj
-gzG
-iLc
-iLc
-iLc
-iLc
-iLc
-iLc
-iLc
-iLc
-cTc
-fVn
-gFV
-woF
-lGV
-gne
-fVn
-uUJ
-sfB
-sfB
-brH
+dMW
+sYX
+kcZ
+mZD
+mZD
+viv
+xeG
+rpu
+gvW
+gvW
+rpu
+rpu
+uCO
+rQU
+oYd
+bzU
+sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -57372,20 +59729,20 @@ nlO
 mfD
 mfD
 mfD
-mfD
-mfD
 hCg
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+thG
+aep
+mvv
+aBH
+mfD
+dbh
+mfD
+mfD
+xGH
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -57415,89 +59772,89 @@ fyf
 fyf
 fyf
 fyf
-kGD
+fGl
 bgk
-rkZ
+kFf
 pCi
-gmR
+qwf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGD
+oJj
+rkZ
+nPP
+cPI
+fyf
+fyf
+fyf
+fyf
+xJA
+kGc
 unI
 dXy
 cdc
 snB
 koD
 dMW
-kGD
-xwW
-rkZ
-pCi
-gmR
+sYX
+hbG
+crd
+fBO
+mZD
+rpu
+sid
+rub
+rpu
+jpr
+rpu
+sDp
+rpu
+rpu
+gvW
+abi
 fyf
 fyf
 fyf
 fyf
-thG
 fyf
-fyf
-kGc
-jIB
-hbW
-apk
-apk
-mfq
-oWn
-dUk
-dDF
-dDF
-sFy
-xJA
-rJU
-rJU
-rJU
-rJU
-rJU
-sQo
-xsD
-bqw
-bqw
-cmF
-unr
-gKG
-sfB
-fVn
-fVn
-fVn
-slM
-kYv
-fVn
-qed
-qed
-qed
-qed
-qed
-iSV
-qGa
-whS
-fmX
-mCO
-fFT
-fFT
-fFT
-fFT
-fFT
-aZn
-ocy
-hhK
-cTc
-tpN
-tpN
-tpN
-tpN
-tpN
-tpN
-cTc
-sfB
-brH
-brH
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -57631,25 +59988,19 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-fyf
-hAC
-fyf
-fyf
-uey
-qOV
-wDc
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+uHT
+thG
+tBN
+mvv
+bKs
+sYX
+sYX
+abi
+sYX
+sYX
+wpx
+sYX
+sYX
 fyf
 fyf
 fyf
@@ -57662,6 +60013,12 @@ fyf
 fyf
 fyf
 fyf
+uqa
+uqa
+uqa
+uqa
+uqa
+uqa
 fyf
 fyf
 fyf
@@ -57672,88 +60029,88 @@ fyf
 fyf
 fyf
 fyf
-gmR
+laC
 yao
+xXh
+jmY
+laC
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+cPI
 rpu
 rpu
+wfC
 kGD
+fyf
+fyf
+fyf
+fyf
+xJA
+kGc
 unI
 lSD
 cdc
 snB
 koD
 dMW
-gmR
+sYX
+fKJ
+aHE
+hDe
+mZD
+rpu
+sew
 rpu
 rpu
-gKP
-kGD
+rpu
+jhp
+uCO
+rhp
+qfV
+gvW
+sYX
 fyf
 fyf
 fyf
 fyf
-thG
 fyf
-fyf
-kGc
-ofX
-qnS
-erY
-ubg
-koD
-gKG
-hxn
-dDF
-dDF
-hPL
-rJU
-rJU
-rJU
-rJU
-rJU
-ahK
-oDR
-eip
-euL
-bqw
-bqw
-euL
-gKG
-sfB
-meU
-chX
-fVn
-hHz
-cGw
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-tjy
-sfB
-sfB
-sfB
-cTc
-cTc
-bER
-arx
-cTc
-cTc
-cTc
-cTc
-sfB
-brH
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -57889,18 +60246,18 @@ fyf
 sND
 fyf
 fyf
-uey
-fyf
-fyf
-hAC
-fyf
-hAC
-fyf
-fyf
-fyf
-fyf
+thG
 nlO
+mfD
 hCg
+sYX
+def
+dzf
+csO
+uCO
+rpu
+rpu
+sYX
 fyf
 fyf
 fyf
@@ -57913,12 +60270,12 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+uqa
+jZk
+jZk
+nYY
+jZk
+uqa
 fyf
 fyf
 fyf
@@ -57929,11 +60286,30 @@ fyf
 fyf
 fyf
 fyf
-sYX
+wBI
 xXh
-rpu
+uRj
 oqA
+laC
+fyf
+fyf
+oFM
+fyf
+fyf
+fyf
+fyf
+fyf
 sYX
+haN
+rpu
+rpu
+sYX
+fyf
+fyf
+fyf
+fyf
+xJA
+kGc
 unI
 hbW
 apk
@@ -57941,76 +60317,57 @@ apk
 koD
 dMW
 sYX
-gVd
-rpu
-rpu
+uCO
+uCO
+uCO
+uCO
+uCO
+uCO
+uCO
+jpr
+uCO
+uCO
+uCO
+uCO
+uCO
+uCO
 sYX
 fyf
 fyf
 fyf
 fyf
-thG
 fyf
-fyf
-kGc
-unI
-dXy
-wGJ
-snB
-koD
-lun
-dDF
-dDF
-dDF
-gKG
-gKG
-cKN
-qDY
-cKN
-jvA
-gKG
-gKG
-gKG
-qjj
-bqw
-bqw
-alM
-gKG
-sfB
-hHz
-hHz
-fVn
-hHz
-ghE
-sfB
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-sfB
-tjy
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-brH
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+ktB
+ktB
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -58146,51 +60503,70 @@ fyf
 fyf
 fyf
 fyf
-hAC
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-hAC
-fyf
-hAC
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
 sYX
-uCO
+wpx
+sYX
+sYX
+sYX
+urA
+qfV
 rpu
 uCO
+rpu
+aug
 sYX
+sYX
+sYX
+sYX
+sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kcQ
+jZk
+mdM
+obr
+pCf
+uqa
+fyf
+fyf
+fyf
+fyf
+fyf
+laC
+laC
+wHN
+laC
+laC
+laC
+lcg
+xXh
+hZs
+lPv
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+sYX
+uCO
+uCO
+vde
+sYX
+fyf
+fyf
+fyf
+fyf
+xJA
+kGc
 unI
 hbW
 erY
@@ -58198,49 +60574,42 @@ ubg
 koD
 dMW
 sYX
+kgd
+rpu
+pvP
+rpu
+jhp
+rpu
 uCO
+rpu
+rpu
+fcA
 uCO
-sDp
+mpI
+oYd
+iAz
 sYX
 fyf
 fyf
+doo
+uVs
 fyf
-fyf
-thG
-fyf
-fyf
-kGc
-unI
-dXy
-wGJ
-uVo
-koD
-dDF
-dDF
-dDF
-dDF
-akY
-mTT
-dDF
-dDF
-dDF
-dDF
-bcF
-dDF
-gKG
-tAz
-bqw
-bqw
-avx
-gKG
-sfB
-umW
-cGw
-ePh
-cGw
-ghE
-sfB
-brH
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+ktB
+ktB
+gbL
 gcK
 gcK
 gcK
@@ -58248,26 +60617,14 @@ gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
-gcK
-gcK
-gcK
-rGC
-wLB
-rGC
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
 gcK
 gcK
 gcK
@@ -58403,101 +60760,113 @@ fyf
 fyf
 fyf
 fyf
-qOV
-wDc
-fyf
-hAC
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-yjG
-rpu
-klA
-rpu
 sYX
+rpu
+rpu
+cht
+uCO
+deQ
+rpu
+dJY
+uCO
+ehP
+rpu
+uCO
+uZy
+rpu
+uZy
+sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kcQ
+lvL
+uCO
+uCO
+uCO
+uqa
+fyf
+fyf
+fyf
+fyf
+fyf
+laC
+pIy
+vPi
+xiy
+kPT
+ubD
+rtf
+xXh
+kFf
+fGl
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+sYX
+aYG
+cLk
+rpu
+yjG
+fyf
+fyf
+fyf
+fyf
+xJA
+kGc
 unI
 hbW
 ubg
 snB
 koD
-djh
+dMW
 sYX
-aYG
+kzr
+jpr
 rpu
 rpu
-yjG
+xfw
+rpu
+uCO
+klA
+rpu
+sRJ
+uCO
+rYF
+rpu
+rpu
+abi
 fyf
 fyf
 fyf
 fyf
-thG
 fyf
-fyf
-kGc
-pBv
-dXy
-cdc
-snB
-koD
-gKG
-mnv
-dDF
-dDF
-kfh
-mTT
-dDF
-dDF
-dDF
-dDF
-dDF
-dDF
-gKG
-xhd
-xhd
-xhd
-xhd
-gKG
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-sfB
-brH
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+ktB
+ktB
+gbL
 gcK
 gcK
 gcK
@@ -58505,24 +60874,12 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-rGC
-xll
-rGC
-rGC
-rGC
-rGC
-rGC
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -58660,57 +61017,59 @@ fyf
 fyf
 fyf
 fyf
-nlO
-hCg
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-hAC
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
 sYX
-sYX
-tKZ
-sYX
-sYX
-sYX
-oeL
+agX
+sKH
+nfp
+uCO
+dfx
 rpu
-hFM
-fqa
-unI
-uVF
-dmL
-uVo
-koD
-dMW
+ccF
+uCO
+rpu
+vXh
+uCO
+rpu
+eHB
+vXh
+sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+uqa
+jZk
+lwd
+jZk
+pHm
+uqa
+fyf
+fyf
+fyf
+fyf
+fyf
+laC
+hQS
+vZs
+xiy
+aim
+ubD
+xXh
+fGA
+wUm
+lPv
+fyf
+fyf
+uey
+qOV
+cWG
+hpm
+cWG
+wDc
 kGD
 hFM
 rpu
@@ -58721,40 +61080,50 @@ sYX
 tKZ
 tKZ
 sYX
-fyf
-fyf
 kGc
-ajD
-lSD
+unI
+hbW
+dmL
 uVo
-snB
-mfq
-dGZ
-dUk
-dDF
-dDF
-vxd
-urY
-xMz
-xMz
-xMz
-fgI
-dDF
-dDF
-oZC
-bqw
-bqw
-bqw
-bqw
-gKG
-brH
-brH
-brH
-brH
-brH
-brH
-brH
-brH
+koD
+dMW
+sYX
+uCO
+uCO
+uCO
+vsb
+rpu
+rpu
+uCO
+rpu
+rpu
+plt
+uCO
+uCO
+sDp
+uCO
+sYX
+fyf
+wjt
+fyf
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+ktB
+ktB
+gbL
 gcK
 gcK
 gcK
@@ -58762,18 +61131,6 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-rGC
-xll
-deQ
-dlb
-tYd
-pOo
-rGC
 gcK
 gcK
 gcK
@@ -58916,121 +61273,121 @@ fyf
 fyf
 fyf
 fyf
-uey
 fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sYX
-xiy
-wEO
+abi
+rpu
+rpu
+cBb
 uCO
-vib
+uCO
+sDp
+uCO
+uCO
+sDp
+uCO
+uCO
+uZy
+aug
+uZy
+sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+uqa
+jZk
+uCO
+obV
+jZk
+uqa
+fyf
+fyf
+fyf
+fyf
+fyf
+laC
+xiy
+shg
+xiy
+xiy
+xiy
+ohp
+xXh
+mlw
+laC
+fyf
+fyf
+qOV
+daU
+mvv
+haP
+ffw
+bpD
+cPI
+jVg
+jlB
+rpu
 wtp
-rpu
-rpu
-rkZ
-kGD
+guh
+sYX
+lIq
+uwi
+sYX
+kGc
 unI
 hbW
 apk
 snB
 koD
 dMW
-gmR
-rdC
-lvs
+sYX
+kCS
+oeq
+uCO
+vtv
 rpu
-wtp
-guh
-sYX
-eLe
-wEO
+rpu
+jpr
+rpu
+vjl
+rpu
+sDp
+rpu
+rpu
+rpu
 sYX
 fyf
 fyf
-kGc
-jIB
-hbW
-apk
-apk
-koD
-oWn
-kNV
-dDF
-dDF
-xbA
-gTC
-tsF
-tsF
-tsF
-pcT
-dDF
-dDF
-gKG
-mNB
-mNB
-mNB
-mNB
-gKG
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
+vaA
 gcK
+uAs
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-rGC
-xll
-deQ
-pOo
-dlb
-ilh
-rGC
+vaA
 gcK
 gcK
 gcK
@@ -59174,120 +61531,120 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-qOV
-cWG
-cWG
-cWG
-wDc
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 sYX
-gCU
-aPg
-uCO
-puP
-wtp
+arb
 rpu
+cKC
+uCO
+rpu
+rpu
+rpu
+rpu
+rpu
+rpu
+sDp
+rpu
+vXh
+eHB
+sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+uqa
+lwd
+uqa
+uCO
+pMf
+uqa
+fyf
+fyf
+fyf
+fyf
+fyf
+wHN
+dFM
+xXh
+oYh
+puP
+xiy
+xXh
 iMc
-rMz
-fqa
+mlw
+laC
+fyf
+fyf
+tBN
+mvv
+mvv
+aBH
+mfD
+hCg
+kGD
+jVg
+nkA
+rpu
+wtp
+bjy
+sYX
+dhC
+omd
+sYX
+kGc
 unI
 hbW
 fuU
 apk
 koD
 dMW
-kGD
-rdC
-sUd
+sYX
+kIq
 rpu
-wtp
-bjy
-sYX
-dhC
-gCU
-sYX
+sDp
+rpu
+qfV
+kVO
+uCO
+rpu
+sKH
+jpr
+uCO
+bxl
+qfV
+klA
+abi
 fyf
 fyf
-kGc
-ofX
-qnS
-erY
-ubg
-koD
-gKG
-gKG
-enp
-rvT
-gKG
-lOp
-gLH
-mhL
-gLH
-grj
-dDF
-dDF
-gKG
-bHr
-bHr
-bHr
-bHr
-gKG
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+vaA
+ggK
 rGC
-xll
-rGC
-rGC
-rGC
-rGC
-rGC
+uAs
+vaA
 gcK
 gcK
 gcK
@@ -59431,51 +61788,70 @@ fyf
 fyf
 fyf
 fyf
+sYX
+aun
+aug
+rpu
+sDp
+qfV
+vXh
+gvW
+egb
+dzf
+rpu
+uCO
+bxl
+rpu
+rpu
+sYX
 fyf
 fyf
 fyf
 fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-bpD
 fyf
 sND
 fyf
 fyf
 fyf
 fyf
+uqa
+okz
+dhC
+uqa
 fyf
 fyf
 fyf
 fyf
 fyf
+wHN
+xXh
+xXh
+xXh
+xXh
+bzV
+xXh
+xXh
+xXh
+laC
 fyf
 fyf
-fyf
-hAC
-hAC
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+tBN
+mvv
+mvv
+bpD
 fyf
 fyf
 sYX
-uCO
-jgq
-uCO
-uCO
-uCO
-aYG
+rMz
+aug
 rpu
-tzk
 sYX
+sYX
+sYX
+jgq
+sYX
+sYX
+kGc
 unI
 box
 erY
@@ -59483,68 +61859,49 @@ gmX
 koD
 dMW
 sYX
-rMz
+lkz
+rpu
+uCO
+rpu
+tuS
+oAA
+uCO
 rpu
 rpu
-sYX
-sYX
-sYX
-jgq
-sYX
+rpu
+uCO
+msy
+rpu
+bkj
 sYX
 fyf
 fyf
-kGc
-unI
-hbW
-erY
-gmX
-koD
-gKG
-rWQ
-rJU
-rJU
-gKG
-gKG
-gKG
-gKG
-gKG
-gKG
-dDF
-dDF
-gKG
-rJU
-rJU
-rJU
-rJU
-gKG
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+vaA
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-rGC
-xll
-rGC
-gcK
-gcK
-gcK
-gcK
+vaA
 gcK
 gcK
 gcK
@@ -59688,51 +62045,70 @@ fyf
 fyf
 fyf
 fyf
-fyf
-uey
-fyf
-uey
-fyf
-tBN
-mvv
-mvv
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-nPu
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-fyf
-fyf
-nPu
-fyf
-fyf
-fyf
-fyf
-fyf
-tKZ
-cIh
-rpu
-jZL
-csO
-uCO
-rpu
-foz
-tzk
 sYX
+azk
+rpu
+ntB
+uCO
+dgG
+vUF
+dKR
+gvW
+vXh
+sLm
+uCO
+uZy
+rpu
+uZy
+sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+xJA
+fyf
+uqa
+omd
+jbw
+uqa
+fyf
+fyf
+fyf
+fyf
+fyf
+laC
+cIh
+rMl
+jZL
+fyI
+xiy
+xXh
+aRc
+xXh
+laC
+fyf
+fyf
+nlO
+mfD
+mfD
+hCg
+fyf
+fyf
+sYX
+rpu
+rpu
+jcl
+sYX
+biJ
+sKH
+rpu
+qhD
+sYX
+kGc
 unI
 lSD
 erY
@@ -59740,53 +62116,23 @@ gmX
 koD
 dMW
 sYX
-rpu
-rpu
-foz
 sYX
-jcl
-csO
-rpu
-oJm
+sYX
+sYX
+sYX
+kom
+sYX
+sYX
+kom
+wpx
+kom
+sYX
+sYX
+kVm
+sYX
 sYX
 fyf
 fyf
-nJW
-rAt
-grp
-wKo
-erY
-koD
-gKG
-pHc
-rJU
-rJU
-cKN
-dDF
-dDF
-bcF
-dDF
-dDF
-dDF
-dDF
-kXj
-rJU
-rJU
-rJU
-rJU
-gKG
-gcK
-gcK
-gcK
-gcK
-fyf
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
 fyf
 fyf
 gcK
@@ -59795,13 +62141,24 @@ gcK
 gcK
 gcK
 gcK
-rGC
-xll
-rGC
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+vaA
 gcK
 gcK
 gcK
-gcK
+vaA
 gcK
 gcK
 gcK
@@ -59943,107 +62300,96 @@ uey
 qOV
 cWG
 hpm
-cWG
 wDc
 fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-aBH
-hCg
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-qTY
-fyf
-fyf
-tKZ
+sYX
+uCO
+uCO
+uCO
+uCO
 rpu
+vUF
+gvW
+gvW
+dzf
 rpu
-rpu
-rpu
-sDp
-rpu
-rpu
-rpu
-yjG
-unI
-hbW
-erY
-lZY
-koD
-dMW
-yjG
-rpu
-rpu
-rpu
-sDp
-rpu
-rpu
-rpu
-rpu
+uCO
+uCO
+uCO
+uCO
 sYX
 fyf
 fyf
 fyf
 fyf
 fyf
-mEL
-eMD
+fyf
+fyf
+fyf
+kiW
+uxC
+uqa
+uqa
+uqa
+uqa
+fyf
+fyf
+fyf
+fyf
+fyf
+laC
+laC
+wXH
+pIa
+laC
+laC
+wXH
+pIa
+laC
+laC
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+sYX
+rpu
+rpu
+rpu
+yjG
+rpu
+rpu
+rpu
+rpu
+vde
+kGc
+unI
+hbW
+erY
+soK
 koD
-gKG
-syG
-rJU
-hbK
-gKG
-dDF
-dDF
-dDF
-dDF
-dDF
-dDF
-dDF
-gKG
-npl
-oDR
-oDR
-oDR
-gKG
+dMW
+ifs
+tBN
+pIn
+mvv
+mvv
+mvv
+mvv
+mvv
+ljA
+mvv
+mvv
+mvv
+mvv
+wAQ
+ifs
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-eHB
 fyf
 fyf
 gcK
@@ -60052,9 +62398,20 @@ gcK
 gcK
 gcK
 gcK
-rGC
-xSa
-rGC
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -60200,35 +62557,53 @@ qOV
 daU
 mvv
 haP
-wUv
 bpD
 fyf
-fyf
-fyf
-fyf
-fyf
-nlO
-mfD
-mfD
-hCg
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+aAk
+qfV
+rpu
+sDp
+rpu
+rpu
+rpu
+rpu
+rpu
+ehV
+uCO
+etg
+rpu
+eLe
+sYX
 fyf
 fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+tBN
+mvv
+mvv
+mvv
+mvv
+oHO
+mvv
+vGl
+wDc
 sND
 fyf
 fyf
@@ -60238,67 +62613,37 @@ fyf
 fyf
 fyf
 sYX
-aWF
-ccF
-msy
-clL
-uCO
-rpu
-rpu
+rkZ
+rkZ
 rpu
 sYX
+rkZ
+fGj
+aug
+rpu
+sYX
+kGc
 unI
-yel
+hzq
 dFQ
 gmX
 koD
-obr
-sYX
-rkZ
-rkZ
-rpu
-sYX
-ccF
-rpu
-rpu
-ccF
-sYX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hzb
-gKG
-gKG
 xOZ
-gKG
-gKG
-rco
-rco
-rco
-qvu
-gKG
-lhz
-lhz
-gKG
-gKG
-gKG
-gKG
-gKG
-gKG
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+ifs
+tBN
+mvv
+mvv
+vwn
+hxO
+ymi
+aNZ
+mvv
+sSc
+rjH
+mvv
+rjH
+bpD
+ifs
 fyf
 fyf
 fyf
@@ -60308,14 +62653,26 @@ gcK
 gcK
 gcK
 gcK
-bcM
-rGC
-mMN
-rGC
-gYu
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+vaA
+gcK
+gcK
+gcK
+vaA
 gcK
 gcK
 gcK
@@ -60457,127 +62814,127 @@ tBN
 mvv
 mvv
 aBH
-mfD
 hCg
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 sYX
+aAO
+aug
+cNE
+uCO
+uCO
+uCO
+uCO
+uCO
+sDp
+uCO
+uCO
+eyg
+aug
+eEK
 sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+upX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+nlO
 fGS
-xUO
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+bpD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+sYX
+iYP
+qov
+spt
 sYX
 sYX
-fGS
-xUO
-xUO
+spt
+spt
 sYX
+sYX
+kGc
 unI
 dXy
 cdc
 vnc
 koD
 dMW
-sYX
-xUO
-tIO
-xnh
-sYX
-sYX
-xnh
-xnh
-sYX
-sYX
+ifs
+nlO
+mfD
+mfD
+mfD
+xpN
+nXE
+aNZ
+mvv
+mvv
+mvv
+iAm
+mvv
+bpD
+ifs
 fyf
+uVs
 fyf
+bBm
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-suq
-qPs
-tWu
-xvI
-vrc
-dkd
-orB
-vPQ
-qer
-gKG
-vZs
-hAN
-gKG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-gSt
-igz
-igz
-igz
-igz
-igz
-igz
 gcK
 gcK
 gcK
 gcK
-bcM
-qal
-csk
-pow
-csk
-qal
-qal
-qal
-ehV
-qal
 gcK
 gcK
-csk
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+vaA
+gcK
+gcK
+gcK
+vaA
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -60716,6 +63073,22 @@ mvv
 bpD
 fyf
 fyf
+sYX
+aAR
+rpu
+cPg
+uCO
+rpu
+vUF
+dZT
+dzf
+rpu
+sLm
+uCO
+eyI
+rpu
+eTJ
+sYX
 fyf
 fyf
 fyf
@@ -60732,6 +63105,20 @@ fyf
 fyf
 fyf
 fyf
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+mvv
+mvv
+mvv
+mvv
+xJc
+wDc
 fyf
 fyf
 fyf
@@ -60741,17 +63128,6 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
 fyf
 fyf
 fyf
@@ -60767,79 +63143,60 @@ cdc
 snB
 koD
 dMW
+ifs
+sYX
+sYX
+sYX
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-suq
-tWu
-tWu
-tWu
-tWu
-tWu
-tWu
-tWu
-hHr
-gKG
-gKG
-gKG
-gKG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-wIK
-hkW
-sTa
-sTa
-sJw
-ybI
-ybI
-xbR
-sJw
-rRR
-tBN
+xuJ
+ymi
+aNZ
 mvv
-dGL
-bKs
-fck
-qal
-pow
-qal
-ilM
-csk
-csk
-csk
-qal
-csk
+vtH
+xBl
+vlx
+gaZ
+bpD
+ifs
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
 gcK
 gcK
+gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+vaA
+gcK
+gcK
+gcK
+vaA
+pdx
+pdx
+pdx
+pdx
+pdx
+pdx
+pdx
+pdx
+pdx
+pdx
 gcK
 gcK
 gcK
@@ -60973,7 +63330,22 @@ mfD
 hCg
 fyf
 fyf
-uey
+sYX
+rpu
+rpu
+urA
+uCO
+rpu
+rpu
+rpu
+vXh
+rpu
+rpu
+sDp
+rpu
+qfV
+etg
+sYX
 fyf
 fyf
 fyf
@@ -60986,7 +63358,25 @@ fyf
 fyf
 fyf
 fyf
-hAC
+fyf
+fyf
+fyf
+fyf
+gts
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+gts
+lSG
+xnh
+fCW
+mvv
+mvv
+vGl
+wDc
 fyf
 fyf
 fyf
@@ -61003,100 +63393,67 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-vxC
-sYX
-sYX
-sYX
-sYX
-sYX
-xnh
-xUO
-sYX
-sYX
+kGc
 unI
-uCS
-lZP
+dXy
+cdc
 snB
 koD
 dMW
+ifs
+sYX
+ojS
+rpu
 fyf
-tNX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-suq
-bRq
-bRq
-bRq
-bRq
-bRq
-bRq
-bRq
-bRq
-crA
+tBN
+mvv
+mvv
+mvv
+rjH
+mvv
+mzn
+mvv
+bpD
+ifs
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hCs
-rnx
-aJb
-aJb
-aJb
-tUb
-idu
-hBN
-aJb
-fJv
-nlO
-xGH
-gVp
-fck
-fck
-csk
-qal
-qal
-qal
-csk
-csk
-qal
-pow
-csk
 gcK
 gcK
-csk
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+vaA
+gcK
+gcK
+gcK
+qal
+uhi
+uhi
+uhi
+vIt
+reo
+vIt
+rdd
+uhi
+hFi
+pdx
 gcK
 gcK
 gcK
@@ -61230,130 +63587,130 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 sYX
-xiy
-jKV
-sDp
+aFF
 rpu
+vXh
+uCO
+dhB
+rpu
+sKH
+aug
+rpu
+ejD
+uCO
+eEC
+rpu
+etg
+sYX
+fyf
+fyf
+fyf
+fyf
+nPu
+fyf
+fyf
+fyf
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+dCV
+itU
+yea
+nby
+hkL
+dCV
+gts
+fQr
 gKP
-xXh
-pCi
-kGD
+xnh
+oHO
+mvv
+mvv
+vGl
+cWG
+cWG
+wDc
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+rsE
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
-hbW
-bJB
-gmX
+dXy
+cdc
+snB
 koD
 dMW
+ifs
+sYX
+ose
+rpu
 fyf
-fyf
-fyf
-wrg
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-suq
-tWu
-tWu
-tWu
-tWu
-bXC
-tWu
-tWu
-tWu
-crA
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-mEL
-wKo
-dmL
-sgz
-kjQ
-ehN
-fvz
-hOl
-kjQ
-pWN
-uPP
-tBN
+xHY
 mvv
-fck
-fck
-fck
-bcx
-bcM
-csk
-csk
-fck
-csk
-csk
-qal
-qal
-csk
-csk
-gYu
+qWg
+mvv
+qDi
+mvv
+rjH
+mvv
+bpD
+ifs
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+vaA
+gcK
+gcK
+gcK
+vaA
+afp
+fck
+pdx
+sPS
+uhi
+ltb
+rdd
+rRQ
+uhi
+pdx
 gcK
 gcK
 gcK
@@ -61487,87 +63844,22 @@ jJb
 qOV
 gjB
 fyf
-fyf
-fyf
-rtR
-fyf
-toy
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-fyf
-fyf
-fyf
 sYX
-gCU
-usW
+aUb
+rpu
+cRH
 uCO
-fqi
+dlb
 rpu
 rpu
-bgk
-gmR
-unI
-qnS
-erY
-gmX
-koD
-dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-suq
-bRq
-bRq
-bRq
-bRq
-bRq
-bRq
-bRq
-bRq
-crA
-fyf
-fyf
+qfV
+rpu
+esj
+uCO
+eEK
+rpu
+eEK
+sYX
 fyf
 fyf
 fyf
@@ -61576,41 +63868,106 @@ fyf
 sND
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rlN
-btW
-btW
-fvz
-qNB
-kaM
-kaM
-fvz
-gWo
-uit
-tBN
-mvv
-dGL
-fck
-kIZ
+gts
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+yla
+aRz
+vta
+vta
+dCV
+gts
+fqi
+tvr
+gKP
+xnh
 mvv
 ofL
 mvv
-odZ
-dGL
-csk
-qal
-rUD
-qal
-qal
-qal
-csk
+mvv
+mvv
+vGl
+wDc
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+rsE
+fyf
+qeh
+kGc
+unI
+dCk
+lZP
+snB
+koD
+dMW
+ifs
+sYX
+sYX
+sYX
+fyf
+nlO
+mfD
+mfD
+anu
+mfD
+mfD
+mfD
+mfD
+hCg
+ifs
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+vaA
+gcK
+gcK
+gcK
+vaA
+lSp
+pdx
+pdx
+kjX
+vIt
+iAX
+rdd
+vIt
+ltb
+pdx
 gcK
 gcK
 gcK
@@ -61744,130 +64101,130 @@ fyf
 nlO
 hCg
 fyf
-fyf
-fyf
-fyf
-olZ
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sVO
-uxC
 sYX
-tKZ
-tKZ
 sYX
+sYX
+sYX
+sYX
+sYX
+dHq
+dHq
+sYX
+wpx
+sYX
+sYX
+sYX
+dHq
+sYX
+sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+gts
+dCV
+uCO
+uCO
+uCO
+uCO
+uCO
+uCO
+uCO
+dCV
+aLo
+vta
+vta
+aRz
+dCV
+gts
 fQr
-rpu
-rpu
-rpu
-kGD
+tvr
+cHH
+gKP
+eiJ
+xnh
+mvv
+mvv
+rQE
+mvv
+vGl
+wDc
+upX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 dXy
-dFQ
+bJB
 gmX
 koD
 dMW
-fyf
-fyf
-twP
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-vOq
-tsS
-tsS
-tsS
-tsS
-tsS
-tsS
-tsS
-tsS
-cuz
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-ars
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ubd
-fyf
-nlO
-xGH
-rFk
-mvv
-moo
-odZ
-mvv
-mvv
-mvv
-bcM
-csk
-csk
-qal
-qal
-csk
-qal
+inI
+lrY
+lrY
+lrY
+lrY
+lrY
+lrY
+lrY
+lrY
+lrY
+lrY
+lrY
+xpW
+lrY
+tTX
+lrY
+lrY
+lrY
+lrY
+lrY
+lrY
+lrY
+lrY
 gcK
 gcK
+gcK
+gcK
+gcK
+pyj
+tXc
+ylA
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+vaA
+gcK
+gcK
+fyf
+vaA
+tJG
+gld
+vIt
+bPU
+xfW
+vIt
+ttE
+mTd
+qLX
+pdx
 gcK
 gcK
 gcK
@@ -62025,6 +64382,34 @@ fyf
 fyf
 fyf
 fyf
+gts
+dCV
+uCO
+onh
+pOo
+qZO
+sCF
+tUS
+mgu
+mgu
+mgu
+lEx
+aRz
+eGt
+dCV
+gts
+fQr
+tvr
+tvr
+tvr
+tvr
+gKP
+eiJ
+xnh
+mvv
+mvv
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -62035,21 +64420,12 @@ fyf
 fyf
 fyf
 fyf
-thG
 fyf
-fyf
-fyf
-fyf
-sYX
-rkZ
-lvs
-rpu
-rpu
-sYX
+kGc
 unI
 dXy
-cdc
-snB
+erY
+gmX
 koD
 dMW
 fyf
@@ -62064,6 +64440,7 @@ fyf
 fyf
 fyf
 fyf
+xJA
 fyf
 fyf
 fyf
@@ -62077,54 +64454,34 @@ fyf
 fyf
 fyf
 fyf
+xJA
+cOW
+hqC
+cgA
+mvv
+mvv
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+vaA
+gcK
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-nJW
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-edA
-fyf
-fyf
-nlO
-mfD
-mfD
-mfD
-mfD
-mfD
-mfD
-xGH
+kve
+vaA
+ckf
 rFk
-bcM
-csk
-csk
-csk
 uhi
-csk
-csk
-csk
+ltb
+mmY
+uhi
+shn
+vIt
+uhi
+pdx
 gcK
 gcK
 gcK
@@ -62278,35 +64635,54 @@ fyf
 fyf
 fyf
 fyf
-qTY
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-gmR
-rMz
+gts
+lzV
+mfq
+mgu
+mgu
+mgu
+mgu
+mgu
+mgu
+dCV
+mgu
+aRz
+aRz
 rpu
-rpu
-rpu
-yjG
+dCV
+gts
+gts
+fQr
+tvr
+tvr
+tvr
+cHH
+tvr
+pUi
+akJ
+mvv
+ofL
+bpD
+uHT
+fyf
+fyf
+fyf
+sYX
+sYX
+tOf
+sYX
+tOf
+sYX
+sYX
+kGc
 unI
 dXy
-cdc
-snB
+dFQ
+gmX
 koD
 dMW
 fyf
@@ -62316,6 +64692,12 @@ fyf
 fyf
 fyf
 fyf
+doo
+fyf
+fyf
+uVs
+fyf
+xJA
 fyf
 fyf
 fyf
@@ -62329,61 +64711,36 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-qOV
-cWG
-wDc
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-nlO
-xGH
+xJA
+nuB
 mvv
 mvv
-bcM
+mvv
 mvv
 gcK
-hUV
-eWk
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+vaA
+wAp
+tFR
+tFR
+vaA
 pdx
-hBr
-hBr
+pdx
+pdx
+pdx
+pdx
+pdx
+vIt
+czA
+uhi
+pdx
+gcK
+gcK
 gcK
 ktB
 "}
@@ -62534,34 +64891,53 @@ fyf
 fyf
 fyf
 fyf
+qTY
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
+gts
+lzV
+mgu
+mgu
+mgu
+rpa
+onz
+pSo
+uJP
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+gts
+fQr
+tvr
+tvr
+tvr
+tvr
+tvr
+gKP
+xnh
+mvv
+mvv
+bpD
 fyf
 fyf
 fyf
 fyf
 sYX
-uCO
-uCO
+uZv
+kuZ
+xjA
+rpu
+lPx
 sDp
-sYX
-sYX
+kGc
 unI
-lSD
+dXy
 cdc
 snB
 koD
@@ -62578,70 +64954,51 @@ fyf
 fyf
 fyf
 fyf
+xJA
+fyf
+fyf
+fyf
+ijv
+fyf
+ijv
+fyf
+ijv
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-tBN
+xJA
+ocU
+mvv
+mvv
+mvv
+mvv
 mvv
 bpD
+xJA
+fyf
+fyf
+gcK
+gcK
+vaA
+tFR
+tFR
+fyf
+vaA
+vaA
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-odZ
-mvv
+pdx
 vIt
-kZu
+vIt
+uhi
+pdx
 gcK
 gcK
 gcK
-gcK
-gpC
 ktB
 "}
 (102,1,1) = {"
@@ -62796,56 +65153,65 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-xTF
-csO
-pot
-rpu
-sYX
+gts
+dCV
+moo
+onz
+onz
+onz
+onz
+tWd
+uCO
+dCV
+iWW
+rvx
+slQ
+cpK
+xhB
+dCV
+fQr
 tvr
+cHH
+vcV
+tvr
+tvr
+tvr
+tvr
+pUi
+mvv
+mvv
+vGl
+wDc
+fyf
+fyf
+fyf
+cuv
+rJB
+rpu
+rpu
+gXY
+cSH
+sYX
+kGc
 unI
-hbW
-apk
-apk
+dXy
+cdc
+gmX
 koD
 dMW
 fyf
-dva
 fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-sqA
+bBm
+doo
+uVs
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-sqA
+fyf
+xJA
 fyf
 fyf
 fyf
@@ -62859,43 +65225,34 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
+xJA
+cuZ
 mvv
+mvv
+rjH
+rjH
+rjH
 bpD
+xJA
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-nlO
-mfD
-mfD
-mfD
-mfD
 gcK
-dfR
-gcK
-gcK
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+pdx
+vIt
+vIt
+oUY
+pdx
 gcK
 gcK
 gcK
@@ -63050,34 +65407,53 @@ fyf
 fyf
 fyf
 fyf
-nPu
 fyf
 fyf
 fyf
+gts
+dCV
+moO
+onz
+pSo
+onz
+onz
+tYd
+onz
+dCV
+fBs
+kdJ
+vpH
+rRt
+cpK
+dCV
+xfG
+dCV
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+nGq
+bpD
 fyf
-hAC
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-vug
+sYX
+jnV
 rpu
+keg
+bHo
 rpu
-rpu
-kGD
+sYX
 kGc
 unI
-hbW
-erY
-ubg
+dXy
+cdc
+gmX
 koD
 dMW
 fyf
@@ -63092,67 +65468,48 @@ fyf
 fyf
 fyf
 fyf
+xJA
 fyf
 fyf
 fyf
+ijv
 fyf
+ijv
 fyf
+ijv
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dWt
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
+lPT
+uqa
+uqa
+uqa
+uqa
+uqa
 mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+mvv
+mvv
+mvv
+mvv
+vGl
+iEn
+pjn
 fyf
 gcK
-dpN
-gcK
-gcK
+sZF
+jhB
+eSC
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+pdx
+pJq
+vIt
+uhi
+pdx
 gcK
 gcK
 gcK
@@ -63308,88 +65665,67 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-sYX
-rpu
-rpu
-taN
-gmR
-kGc
-unI
-hbW
-ubg
-snB
-koD
-dMW
-fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
+nGq
+nGq
+gts
+dCV
+uCO
+oqu
+oqu
+oqu
+oqu
+uCO
+uKA
+dCV
+dCV
+dCV
+cpK
+cpK
+gdY
+dCV
+hdi
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+nGq
 bpD
 fyf
 fyf
 fyf
+cuv
+rpu
+dqo
+aXy
+cSH
+gXY
+sYX
+kGc
+unI
+dXy
+cdc
+gmX
+tBB
+jkJ
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+sYX
+sYX
+sYX
+sYX
+sYX
+xJA
 fyf
 fyf
 fyf
@@ -63398,18 +65734,39 @@ fyf
 fyf
 fyf
 fyf
+kLh
+uqa
+cSH
+rpu
+xBH
+ufb
+drN
+mvv
+tzY
+mvv
+mvv
+mvv
+mvv
+daM
+doX
+ghx
+sZF
+oVa
+bEy
+rvP
+eSC
 fyf
+urm
 fyf
+pis
 fyf
+rsE
 fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-hBr
-gcK
-gcK
+pdx
+vIt
+vIt
+uhi
+pdx
 gcK
 gcK
 gcK
@@ -63559,114 +65916,114 @@ pXq
 xVu
 fyf
 fyf
+uey
+qOV
+cWG
+hpm
+wDc
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-gZD
+nGq
+dCV
+dCV
+dCV
+mrg
+oEF
+pSC
+oEF
+oEF
+uCO
+uKG
+xwW
+xwW
+dCV
+gdY
+cpK
+cah
+iBv
 rEc
-buO
-dpO
+uqa
+lRA
+lhk
+tsW
+nev
+oIQ
+uqa
+uTH
+xxV
+dCV
+nGq
+bpD
+fyf
+fyf
+fyf
+sYX
+vHV
+dqw
+rpu
+rpu
+irP
 sYX
 kGc
 unI
-hbW
+rQh
 cdc
-dmL
-koD
-dMW
+gmX
+tBB
+vfu
+sUr
+sUr
+sUr
+sUr
+wKP
+bvq
+sUr
+tKZ
+bwb
+xxq
+dhC
+sYX
+xJA
 fyf
-uey
+ijv
 fyf
+ijv
 fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+ijv
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dTv
 uqa
-lRW
+vVb
+rpu
+rpu
+evc
 uqa
-itJ
-uqa
-uqa
-uqa
-uqa
+mvv
+mvv
+rjH
+rjH
+rjH
+lbx
+ncC
+xGH
+aGh
+huA
+sUr
+mkV
+dro
+rvP
+kQe
 fyf
 fyf
-rVr
-fyf
-fyf
-fyf
-trW
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-eKs
-gcK
-gcK
+pdx
+uhi
+uhi
+mvK
+pdx
 gcK
 gcK
 gcK
@@ -63816,63 +66173,73 @@ boN
 azC
 fyf
 fyf
+qOV
+daU
+mvv
+mvv
+bpD
+fyf
+nGq
+dCV
+ktX
+uCO
+mrS
+oJm
+rdC
+ryc
+rdC
+rdC
+rdC
+xya
+xya
+hsk
+dkg
+dkg
+dkg
+dCV
+rEc
+oFP
+dkf
+oIQ
+oIQ
+oIQ
+oIQ
+ceL
+oIQ
+uTH
+dCV
+nGq
+bpD
+fyf
+fyf
 sND
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-vxC
-uxC
-uxC
-uxC
-uxC
 sYX
 sYX
 sYX
+vde
 sYX
 sYX
-ehD
+sYX
+kGc
 unI
 hbW
 apk
-apk
-koD
-dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gmX
+tBB
+wKP
+wKP
+sUr
+uAX
+wAZ
+akO
+lox
+wKP
+tKZ
+gEY
+omd
+gkS
+sYX
+xJA
 fyf
 fyf
 fyf
@@ -63882,48 +66249,38 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-dWt
-fyf
-fyf
-dWt
-fyf
-fyf
-fyf
-fyf
-fyf
-dTv
 uqa
-bxl
-jZM
+oTj
+nSQ
 rpu
-rpu
-xgC
-rpu
-lRW
+xUt
+uqa
+mfD
+mfD
+mfD
+mfD
+mfD
+hCg
+xJA
+ocU
+aGh
+huA
+sUr
+mkV
+nZd
+erY
+rvP
+mWT
+ohH
+vPU
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-oFP
-oFP
-oFP
-gcK
-gcK
-eKs
-gcK
-gcK
+pdx
+pdx
+pdx
+pdx
+pdx
 gcK
 gcK
 gcK
@@ -64073,112 +66430,112 @@ fbq
 azC
 fyf
 fyf
+tBN
+mvv
+mvv
+gfR
+hCg
+fyf
+nGq
+dCV
+kwe
+lzW
+oIQ
+oIQ
+rdC
+oIQ
+oIQ
+oIQ
+oIQ
+xya
+xya
+hsk
+eyp
+cam
+dkg
+dCV
+rEc
+oFP
+xxV
+oIQ
+oIQ
+tFK
+nlG
+uqa
+oIQ
+oIQ
+dCV
+nGq
+bpD
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
-fyf
-thG
+tKZ
+iuG
+irP
+rpu
+sYX
+pEv
 fyf
 kGc
 unI
 hbW
 erY
-erY
-koD
-dMW
+gmX
+tBB
+wKP
+sUr
+vfu
+wKP
+sYX
+tOf
+tOf
+sYX
+sYX
+sYX
+sYX
+jYo
+sYX
+xJA
+fyf
+ijv
+fyf
+ijv
+fyf
+ijv
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dTv
 uqa
-rpu
-rpu
-rpu
-rpu
-qfV
-rpu
 uqa
-cWG
-cWG
-wDc
+uqa
+sDp
+uqa
+uqa
+uqa
+drN
+uqa
+drN
+uqa
+drN
+uqa
+thR
+dHl
+huA
+sUr
+mkV
+doZ
+fAN
+gmX
+tBB
+vfu
+fIV
+vPU
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-oFP
-oFP
-aAR
-oFP
-oFP
 gcK
-eVb
+gcK
 gcK
 gcK
 gcK
@@ -64330,112 +66687,112 @@ cGu
 azC
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sYX
-xUO
-xUO
-sYX
-sYX
-sYX
-sYX
-sYX
-sYX
-unI
-box
-erY
-gmX
-koD
-dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dTv
-uqa
-itJ
-uqa
-uqa
-bxl
-rpu
-rpu
-itJ
+tBN
 mvv
 mvv
 bpD
 fyf
-uHT
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+nGq
+dCV
+kxq
+uCO
+uCO
+oIQ
+pYN
+rdC
+sDj
+rdC
+sDr
+xwW
+nEi
+dCV
+eyp
+cpK
+xUO
+qKz
+kIM
 oFP
-rTt
+jsw
+tFK
+oIQ
+oIQ
+xem
+uqa
+vhu
+oIQ
+dCV
+gts
+gts
+fyf
+fyf
+fyf
+dPw
+sKH
+eyN
+rpu
+sYX
+fyf
+fyf
+kGc
+unI
+hbW
+erY
+gmX
+tBB
+dNg
+vfu
+akO
+vfu
+sYX
+oIQ
+tIE
+nEa
+gpv
+hUG
+fYv
+oIQ
+sYX
+xJA
+fyf
+fyf
+fyf
+fyf
+fyf
+uqa
+drN
+uqa
+uqa
+uqa
+lRW
+lRW
+lRW
+rpu
+ivi
+oYd
+ivi
+rpu
+hYI
+oYd
+ivi
+uqa
+uqa
+fyf
+huA
+sUr
+nZT
+nZd
+fAN
+gmX
+qoJ
+rcP
+sUr
+fIV
 vPU
-mPk
-oFP
+fyf
+fyf
 gcK
-dfR
+gcK
 gcK
 gcK
 gcK
@@ -64587,111 +66944,111 @@ gjP
 gjP
 fyf
 fyf
+nlO
+mfD
+mfD
+hCg
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-sYX
-sYX
-sYX
-sYX
-fyf
-fyf
-fyf
+nGq
+dCV
+dCV
+lCi
+mvV
+rdC
+qbe
+rHE
+quy
+oIQ
+uMZ
+dCV
+dCV
+dCV
 gmR
-onh
-wRb
-uCO
-csO
-rpu
-rpu
-clL
-kGD
+rRt
+cpK
+dCV
+dCV
+oFP
+wBA
+oIQ
+oIQ
+dpC
+hXu
+uqa
+kTz
+vhu
+dCV
+dCV
+gts
+fyf
+fyf
+fyf
+tKZ
+oeL
+fcw
+iGO
+sYX
+fyf
+fyf
+kGc
 unI
 hbW
 erY
 gmX
-koD
-dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dTv
-uqa
-rpu
-esj
-uqa
-rpu
-rpu
-rpu
-uqa
-xGH
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-oFP
+tBB
 sUr
+sUr
+kyA
+sUr
+lzW
+oIQ
+oIQ
+sDi
+nCp
+oIQ
+gHW
+oIQ
+qbA
+xJA
+fyf
+ijv
+fyf
+fyf
+fyf
 uqa
-lrf
-oFP
-gcK
+hNw
+csO
+eqx
+uqa
+lRW
+lRW
+ptt
+lRW
+ivi
+rpu
+yej
+nSQ
+ivi
+rpu
+ivi
+plt
+uqa
+sZF
+oVa
+sUr
+exn
+nZd
+iIc
+gmX
+pNY
+sUr
+sUr
+sUr
+fIV
+vPU
+fyf
+fyf
 gcK
 gcK
 gcK
@@ -64830,7 +67187,7 @@ bFJ
 gjP
 jTq
 vFz
-lly
+bcx
 uRJ
 cbk
 uRJ
@@ -64848,108 +67205,108 @@ fyf
 fyf
 fyf
 fyf
+wSj
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sYX
-wEO
-oIQ
-sYX
-sYX
-sYX
-sYX
-sYX
-dbh
-dhC
+nGq
+gts
+dCV
 uCO
-bmK
-rpu
-klA
-nlv
+mEn
+oKy
+qcS
+rHT
+qcS
+oIQ
+uOr
+xMP
+uqa
+uqa
+dkg
+cpK
+cpK
+mkV
+tvr
+oFP
+oFP
+oFP
+gts
+bFr
+lPT
+lPT
+lPT
+lPT
+lPT
+dCV
+gts
+fyf
+fyf
+fyf
 sYX
+sYX
+sYX
+sYX
+sYX
+fyf
+fyf
+kGc
 unI
-dXy
-cdc
-snB
-koD
-dMW
+hbW
+erY
+gmX
+tBB
+vfu
+sUr
+akO
+dNg
+sYX
+gHW
+oIQ
+oIQ
+gQA
+voQ
+oIQ
+hoS
+sYX
+xJA
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dTv
-uqa
-bxl
-lzV
-uqa
+sDp
 rpu
-tJe
 rpu
+bHX
+uqa
+dpA
 lRW
-tBN
-mvv
-bpD
+dim
+lRW
+ivi
+rpu
+ivi
+jZk
+ivi
+rpu
+ivi
+rpu
+uqa
+huA
+nlL
+sUr
+daW
+vIN
+mmK
+gmX
+wTf
+sUr
+sUr
+sUr
+ioU
+jIe
 fyf
 fyf
 fyf
-fyf
-fyf
-oFP
-oFP
-oFP
-coZ
-iOd
-fyy
-lrf
-oFP
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -65108,47 +67465,36 @@ fyf
 fyf
 fyf
 fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-sYX
-lmw
-gCU
+gts
+dCV
 uCO
-uFK
-uCO
-ykD
-uCO
-wQZ
-dhC
-uCO
-iLr
-rpu
-rpu
-msy
-gmR
-unI
-dXy
-cdc
-snB
-koD
-dMW
+mGh
+oIQ
+rdC
+oIQ
+rdC
+rdC
+rdC
+hqr
+uqa
+eMW
+dkg
+cpK
+gdY
+mkV
+tvr
+uqa
+hJM
+mvv
+iRN
+mvv
+mzS
+mvv
+aGj
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-fyf
-fyf
+djY
+dCV
+gts
 fyf
 fyf
 fyf
@@ -65159,59 +67505,70 @@ sqA
 fyf
 fyf
 fyf
+kGc
+unI
+hbW
+erY
+gmX
+tBB
+sUr
+sUr
+akO
+wKP
+qbA
+oIQ
+oIQ
+xxV
+vHI
+hZm
+tRa
+gUb
+qbA
+xJA
+fyf
+ijv
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rVr
 uqa
+wfC
+rpu
+uUd
+sDp
 lRW
-uqa
-uqa
-uqa
-uqa
-uqa
-uqa
-tBN
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-oFP
-oFP
+lRW
+rVr
+lRW
+lRW
+lRW
+lRW
+lRW
+lRW
+lRW
+lRW
+rpu
+yjG
+huA
+wKP
+sUr
+xoZ
+sZD
+nBC
+gmX
 tBB
 hnB
-rTu
-lDi
+vfu
+sUr
 vIr
-dZT
-oFP
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gpC
 ktB
 "}
 (112,1,1) = {"
@@ -65351,7 +67708,7 @@ uRJ
 usn
 jnX
 uRJ
-uRJ
+buO
 uRJ
 uRJ
 nbI
@@ -65365,106 +67722,106 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sYX
-jgq
-sYX
+gts
+dCV
 uCO
-uCO
-uCO
-jgq
-uCO
-uCO
-sDp
-uCO
-uCO
-uCO
-sDp
-sYX
-sYX
-unI
-lSD
-cdc
-snB
-koD
-dMW
-fyf
-fyf
-uey
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
+mMN
+oON
+rdC
+rdC
+rdC
+rdC
+rdC
+xPh
+gVV
+dkg
+dkg
+gdY
+jGl
+pBv
+mUy
+lWJ
 mvv
-bpD
+mvv
+mvv
+rjH
+mvv
+mvv
+alN
+fyf
+pvS
+dCV
+gts
 fyf
 fyf
 fyf
 fyf
-oFP
+fyf
+fyf
+fyf
+fyf
+uey
+fyf
+kGc
+unI
+hbW
+erY
+gmX
+tBB
+sYX
+sYX
+sYX
+sYX
+sYX
+jYo
+sYX
+sYX
+sYX
+tKZ
+tKZ
+sYX
+sYX
+xJA
+fyf
+fyf
+fyf
+fyf
+fyf
+uqa
+rbc
+nSQ
+uUd
+uqa
+dpA
+lRW
+dwk
+lRW
+ivi
+rpu
+ivi
+rpu
+yej
+rpu
+ivi
+rpu
+uqa
+huA
+qCu
+sUr
+mkV
+sZD
+fAN
 nBC
-cIA
+tBB
 vfu
-rTt
+vfu
 ioU
 jIe
-cbr
-oFP
-gcK
-gcK
-gcK
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
@@ -65601,7 +67958,7 @@ uaf
 ndV
 uRJ
 mvJ
-uRJ
+buO
 wXv
 dJg
 uRJ
@@ -65622,106 +67979,106 @@ fyf
 fyf
 fyf
 fyf
+gts
+dCV
+dCV
+mPa
+oQv
+qlE
+rdC
+oIQ
+rdC
+uQx
+qlE
+uqa
+cam
+dkg
+cam
+dkg
+ajD
+uze
+rjH
+mvv
+mvv
+rjH
+rjH
+mvv
+mvv
+iec
+fyf
+fyf
+dCV
+gts
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-sYX
-rpu
-hFM
-rpu
-hFM
-hFM
-rpu
-uCO
-tkS
-rpu
-uCO
-tzk
-tzk
-rpu
-tzk
-kGD
+fyf
+fyf
+uey
+uey
+kGc
 unI
 hbW
-apk
-apk
-koD
-dMW
+erY
+gmX
+tBB
+sYX
+afK
+ibg
+fps
+sYX
+voQ
+xxV
+gQA
+lwJ
+oIQ
+oIQ
+oIQ
+sYX
+xJA
+fyf
+ijv
 fyf
 fyf
 fyf
-uey
-uey
+uqa
+nfp
+rpu
+oeL
+iub
+lRW
+lRW
+ptt
+lRW
+ivi
+rpu
+ivi
+rpu
+ivi
+rpu
+ivi
+fsO
+uqa
+dGR
+sHM
+sHM
+mkV
+doZ
+erY
+gmX
+tBB
+vfu
+ioU
+jIe
 fyf
 fyf
 fyf
+sqA
 fyf
 fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-oFP
-wER
-kDm
-nlU
-cZE
-bGO
-slT
-okz
-oFP
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -65778,7 +68135,7 @@ pMI
 fyf
 fyf
 upX
-fyf
+hAC
 fyf
 fyf
 fyf
@@ -65879,107 +68236,107 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sYX
-rpu
+gts
+gts
+dCV
+uCO
+oTB
+quy
 rdC
-rkZ
+sDr
+rdC
+quy
 aLg
-rdC
-foz
-sDp
-trr
-rpu
-sDp
-rpu
-trr
-rpu
-tzk
-sYX
+drN
+mbr
+qCu
+jGl
+dkg
+nhv
+smp
+rjH
+mvv
+mvv
+mvv
+mvv
+rjH
+rjH
+lsW
+fyf
+fyf
+dCV
+gts
+fyf
+fyf
+uey
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+uey
+kGc
 unI
 hbW
 erY
-ubg
-koD
-dMW
+gmX
+tBB
+tKZ
+tRa
+puN
+oIQ
+sYX
+sDi
+xVh
+pIK
+gKg
+xVh
+kND
+oIQ
+sYX
+xJA
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+uqa
+uqa
+uqa
+drN
+uqa
+lRW
+lRW
+lRW
+rpu
 ivi
+hOC
+ivi
+rpu
+ivi
+wXR
+ivi
+uqa
+uqa
+fyf
+eqo
+dGR
+jXw
+aJK
+lLP
+erY
+tBB
+ioU
+jIe
 fyf
 fyf
 fyf
 fyf
-tBN
-mvv
-bpD
 fyf
 fyf
 fyf
 fyf
-fyf
-oFP
-oFP
-oFP
-oFP
-nlO
-mfD
-oFP
-oFP
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -66132,94 +68489,102 @@ fyf
 fyf
 fyf
 fyf
-sND
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-sND
-fyf
-sYX
-rpu
-rMz
-rMz
-rpu
-rMz
-rpu
+nGq
+gts
+dCV
 uCO
-rpu
-rpu
-uCO
-wYv
-dss
-rpu
-tzk
-kGD
+oUj
+qwq
+oIQ
+oIQ
+oIQ
+uRN
+qwq
+uqa
+dHO
+cam
+jGl
+dkg
+jIB
+mUw
+rjH
+rjH
+mvv
+mvv
+mvv
+rjH
+rjH
+iTV
+fyf
+fyf
+dCV
+gts
+fyf
+fyf
+fyf
+fyf
+fyf
+pis
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 hbW
-ubg
-snB
-koD
-dMW
+erY
+gmX
+oJS
+tKZ
+nvc
+kvC
+oIQ
+cvI
+gHW
+tqs
+mUP
+tqs
+mUP
+tqs
+ryc
+qbA
+xJA
 fyf
-ivi
+ijv
 fyf
+ijv
 fyf
-dva
-fyf
-fyf
-fyf
-fyf
-qHZ
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+ijv
 fyf
 fyf
 fyf
+uqa
+uqa
+uqa
+sDp
+uqa
+uqa
+uqa
+drN
+uqa
+drN
+uqa
+drN
+uqa
+fyf
+fyf
+eqo
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-bpD
+lwT
+lvy
+pNj
+jIe
 fyf
 fyf
 fyf
@@ -66229,14 +68594,6 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -66391,70 +68748,68 @@ fyf
 fyf
 fyf
 fyf
+upX
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sYX
-sYX
-sYX
-xnh
-xUO
-sYX
-sYX
-sYX
-yjG
-yjG
-sYX
-sYX
-xnh
+nGq
+gts
+dCV
+uCO
+uCO
+qyj
+rJO
+oIQ
+oIQ
+uCO
+uCO
+uqa
+yht
+dkg
+jPG
+cam
+ajD
+lPT
+mzS
 ovN
-sYX
-sYX
+mvv
+mvv
+mvv
+mvv
+rjH
+ciL
+hqC
+hqC
+dCV
+gts
+fyf
+fyf
+dva
+fyf
+fyf
+fyf
+fyf
+doo
+fyf
+fyf
+kGc
 unI
 hbW
-dmL
-uVo
-koD
-dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+erY
+gmX
+tBB
+tKZ
+mXy
+gHW
+daY
+tKZ
+bpo
+gQA
+oIQ
+oIQ
+ioV
+oIQ
 dWt
-fyf
-sND
-fyf
-fyf
+qbA
+xJA
 fyf
 fyf
 fyf
@@ -66464,23 +68819,23 @@ fyf
 fyf
 fyf
 fyf
+uqa
+sUT
+kPI
+rpu
+noD
+uqa
+brr
+cpK
+cpK
+wKP
+wKP
+sUr
+rvP
+vPU
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dWt
-fyf
-nlO
-mfD
-hCg
-fyf
-fyf
-fyf
-fyf
+eqo
 fyf
 fyf
 fyf
@@ -66491,9 +68846,11 @@ fyf
 fyf
 fyf
 fyf
-gcK
-gcK
-gcK
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
@@ -66643,117 +69000,117 @@ gjP
 gjP
 fyf
 fyf
+fyf
+fyf
 gSt
 igz
 igz
 igz
 igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-hgX
+nGq
+gts
+gts
+dCV
+dCV
+qAc
+qAc
+sNM
+sNM
+dCV
+dCV
+pMI
+sQo
+cpK
+cpK
+sKG
+ajD
+dEY
+nxL
+lKw
+wEJ
+wEJ
+wEJ
+lKw
+nxL
+lWJ
+nxL
+flI
+dCV
+gts
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 hbW
-apk
-snB
-koD
-jkJ
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-bEw
+erY
+gmX
+tBB
+tKZ
+ohc
+tIE
+xxV
+tKZ
+oIQ
+tIE
+hzX
+myF
+tIE
+vcb
+rxo
+sYX
+xJA
+fyf
+ijv
+fyf
+ijv
+fyf
+ijv
+fyf
+rMd
+fyf
+uqa
+fQv
+uqa
+rpu
+gvW
+uqa
+cpK
+cpK
+wKP
+wKP
+sUr
+sUr
+ioU
+jIe
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 gcK
 gcK
-gcK
-gcK
-gcK
-gpC
 ktB
 "}
 (118,1,1) = {"
@@ -66900,117 +69257,117 @@ sJw
 xgV
 fyf
 fyf
+fyf
+fyf
 wIK
 hkW
 sTa
-sTa
-sJw
+ybI
+hxQ
+gts
+gts
+dCV
+dCV
+dCV
+qDM
+rLi
+sOD
+ucw
+uSz
+xSa
+rRR
+lXd
 ybI
 ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
+llP
 onk
+ybI
+ybI
+eTL
+lhp
+lhp
+lhp
+eTL
+ybI
+ybI
+jRv
+pMI
+dCV
+gts
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
+unI
 hbW
 erY
-apk
-fLc
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-nkp
-dMW
+gmX
+tBB
+sYX
+hRF
+dWz
+xxV
+sYX
+oON
+tIE
+hEe
+cuf
+tIE
+xVh
+wIG
+sYX
+xJA
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+uqa
+wGY
+kPI
+nSQ
+gvW
+uqa
+cpK
+wKP
+wKP
+sUr
+sUr
+ioU
+jIe
+fyf
+fyf
+fyf
+fyf
+fyf
+eqo
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+sqA
+fyf
+qOV
+cWG
+wDc
 fyf
 gcK
 gcK
-gcK
-gcK
-gcK
-gpC
 ktB
 "}
 (119,1,1) = {"
@@ -67066,7 +69423,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+hAC
 fyf
 fyf
 kdJ
@@ -67157,115 +69514,115 @@ aJb
 fJv
 fyf
 sZA
+fyf
+fyf
 hCs
 rnx
 aJb
 aJb
 aJb
-tUb
-idu
-idu
 aJb
 aJb
-aJb
-aJb
-tUb
-idu
+lCo
 hBN
 aJb
-aJb
-aJb
-aJb
-tUb
-idu
-hBN
-aJb
-aJb
-aJb
-aJb
-aJb
-tUb
-idu
-hBN
-ehN
-ehN
-ehN
-hBN
-aJb
-idu
-idu
-hBN
-aJb
-agr
-idu
-idu
-idu
-hBN
-aJb
-cdc
-idu
-idu
-idu
-hBN
-aJb
-tUb
-idu
-idu
-hBN
-aJb
-agr
-idu
-idu
-idu
-hBN
-aJb
-cdc
-idu
-idu
-idu
-hBN
-aJb
-tUb
-idu
-dbY
-idu
-idu
-idu
-idu
-hBN
 aJb
 tUb
 idu
 idu
 idu
-hBN
-aJb
-agr
+idu
+idu
+idu
+idu
+idu
+jMO
 idu
 idu
 idu
 hBN
 aJb
-cdc
-idu
-idu
-idu
-hBN
+rnx
 aJb
 tUb
 idu
-dbY
-idu
-idu
-nFL
-koD
-dMW
+jMO
+xtl
+pMI
+dCV
+gts
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+hgX
+unI
+hbW
+erY
+gmX
+tBB
+sYX
+sYX
+sYX
+tKZ
+tKZ
+tKZ
+sYX
+tOf
+sYX
+sYX
+tOf
+sYX
+sYX
+eCJ
+cgi
+cgi
+cgi
+cgi
+cgi
+cgi
+cgi
+ykw
+uxC
+uqa
+uqa
+uqa
+uqa
+uqa
+uqa
+wKP
+wKP
+wKP
+sUr
+ioU
+jIe
 fyf
 fyf
-gcK
-gcK
-gcK
-gcK
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+vCY
+vIe
+vIe
+iGk
+pAd
+bpD
+fyf
 gcK
 gcK
 ktB
@@ -67320,7 +69677,7 @@ gcK
 gcK
 gcK
 gcK
-fyf
+hAC
 fyf
 fyf
 fyf
@@ -67414,115 +69771,115 @@ kjQ
 pWN
 uPP
 fyf
+fyf
+fyf
 mEL
 wKo
 dmL
-sgz
-kjQ
-cdc
 ehN
 hOl
-cdc
-cdc
-cdc
-cdc
-cdc
-ehN
-jni
 hOl
-dmL
-dmL
-sgz
-cdc
-ehN
-jni
 hOl
-dmL
-dmL
-sgz
-kjQ
-ehN
-ehN
-sgz
-ehN
-gwn
-ehN
-jni
+lEG
 hOl
-ehN
 hOl
-sgz
-dmL
-sgz
-kjQ
-ehN
-ehN
-ehN
 hOl
-cdc
-ehN
-ehN
-hOl
-sgz
-dmL
-sgz
-ehN
-hOl
-sgz
-dmL
-sgz
-kjQ
-ehN
-ehN
-ehN
-hOl
-cdc
-ehN
-ehN
-hOl
-sgz
-dmL
-sgz
-kjQ
-dmL
-rbi
-ehN
-ehN
-hOl
-sgz
-dmL
-sgz
-kjQ
-ehN
-hOl
-sgz
-dmL
-sgz
-kjQ
-ehN
-ehN
-ehN
-hOl
-cdc
-ehN
-ehN
-hOl
-sgz
-dmL
-sgz
-kjQ
-dmL
-ehN
-ehN
-ehN
-koD
-dMW
+erY
+erY
+erY
+erY
+erY
+erY
+erY
+wGJ
+erY
+erY
+wGJ
+wtJ
+erY
+erY
+wGJ
+wGJ
+wGJ
+erY
+erY
+erY
+aRG
+dCV
+dCV
+nGq
+hxQ
+ybI
+dpc
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+onk
+hbW
+erY
+gmX
+kFW
+fQc
+fQc
+fQc
+fQc
+gWm
+pWw
+fQc
+vNW
+vNW
+vVK
+sTm
+pFZ
+trJ
+fQc
+qjZ
+fQc
+pWw
+pWw
+wvH
+cSF
+cSF
+cwS
 fyf
 fyf
-gcK
-gcK
-gcK
-gcK
+xGz
+epy
+pWw
+pWw
+cSF
+fQc
+fQc
+gDJ
+cSF
+cwS
+fyf
+fyf
+eqo
+fyf
+sqA
+eqo
+fyf
+fyf
+fyf
+pis
+fyf
+eqo
+fyf
+fyf
+qOV
+fAB
+uls
+frO
+cbr
+shu
+hCg
+fyf
 gcK
 gcK
 ktB
@@ -67578,7 +69935,7 @@ gcK
 gcK
 gcK
 fyf
-fyf
+hAC
 fyf
 sND
 fyf
@@ -67672,114 +70029,114 @@ gWo
 uit
 fyf
 fyf
+fyf
+fyf
 rlN
 btW
+kaM
 btW
-fvz
+hOl
+hOl
+lEG
+hOl
+oUy
+oUy
+oUy
+sPJ
 kaM
 kaM
 kaM
-btW
-btW
-btW
-btW
 kaM
-qoS
-btW
-btW
-btW
-btW
-btW
-kaM
-qoS
-btW
-btW
-btW
-oGB
-btW
-sBQ
-kaM
-kaM
-qoS
-ehN
-ehN
-ehN
-btW
-btW
-kaM
-kaM
-qoS
-btW
-fvz
-ehN
-ehN
-ehN
-ehN
-ehN
-ehN
-ehN
-ehN
-ehN
-qoS
-btW
-fvz
-kaM
-kaM
-qoS
-btW
-fvz
-kaM
-kaM
-qoS
-btW
-btW
+erY
+erY
+wGJ
+wGJ
+wGJ
+erY
+erY
+ubg
+erY
 cdc
-kaM
-kaM
-kaM
-qoS
-btW
-fvz
-kaM
-btW
-kaM
-kaM
-kaM
-kaM
-qoS
-btW
-fvz
-kaM
-kaM
-kaM
-qoS
-btW
-fvz
-kaM
-kaM
-qoS
-btW
-btW
-cdc
-kaM
-kaM
-kaM
-qoS
-btW
-fvz
-kaM
-btW
-kaM
+wGJ
+erY
+erY
+kjQ
+kjQ
+ijs
+hBN
+uWb
+pIN
+pIN
+pIN
+pIN
+pIN
+pIN
+pIN
+pIN
+pIN
+pIN
+pIN
+idu
+ehN
+ehN
+ehN
+wzg
+pIN
+pIN
+pIN
+pIN
+wzg
+wzg
+pIN
+pIN
+pIN
+uVn
+wzg
+wzg
+uWb
+pIN
+pIN
+pIN
+wzg
+uWb
+oCb
+dSx
+wzg
+lHZ
+fyf
+fyf
+wld
+ygP
+wzg
+wzg
+wzg
+uWb
+pIN
+uVn
+wzg
+lHZ
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 eqo
-huu
-koD
-dMW
+nZr
+qOV
+daU
+kvr
+cbr
+lJf
+cPV
+qcT
 fyf
 fyf
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 ktB
@@ -67929,114 +70286,114 @@ qjm
 fyf
 fyf
 fyf
+fyf
+fyf
 ars
-fsm
-gQv
-fsm
-krJ
+gmZ
 ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-lCo
-ees
-ees
-ees
+hEa
+gts
+gts
+sYX
+sYX
+sYX
+sYX
+sYX
+sQC
+uet
+uUZ
+xTF
 muk
+hbW
+erY
+fPl
+wGJ
+erY
+pyM
+jZg
+wGJ
+erY
+apk
+wGJ
+erY
+erY
+erY
+vFh
+krR
+hOl
+hOl
+hOl
+hOl
+hOl
+erY
 ehN
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-erY
-geM
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-sVF
-dMW
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+hOl
+sgz
+dmL
+sgz
+fSD
+vat
+djH
+djH
+sPJ
+hiX
+fSD
+vat
+iIc
+sPJ
+fSD
+hiX
+hiX
+djH
+djH
+djH
+djH
+hiX
+hiX
+vat
+djH
+sPJ
+rvP
+eSC
+fyf
+lwT
+lLP
+fSD
+hiX
+vat
+djH
+iIc
+sPJ
+vat
+rvP
+eSC
 fyf
 fyf
-gcK
-gcK
-gcK
-gcK
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+qOV
+dwS
+mvv
+iDJ
+iJG
+cbr
+frO
+qcT
+fyf
+fyf
 gcK
 gcK
 ktB
@@ -68186,45 +70543,45 @@ gjP
 fyf
 fyf
 fyf
+fyf
+fyf
 nJW
 ptf
 ptf
 ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
+gts
+dCV
+sYX
+mPk
+rpu
+qEj
+sYX
+sYX
+sYX
+sYX
+cpK
+ajD
+hbW
+hOl
+wGJ
+rrA
 qac
-ptf
-ptf
 qac
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-gNA
-unI
+dpZ
+wGJ
+erY
+kjF
+apk
+kwy
+qBf
+voE
+xzU
+lEG
+qoS
+qoS
+qoS
+btW
+fvz
 erY
 erY
 erY
@@ -68232,68 +70589,68 @@ erY
 erY
 erY
 erY
-erY
-erY
-koD
-sUX
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-owG
+ehN
+ehN
+qoS
+btW
+fvz
+kaj
 oBQ
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-edA
+oBQ
+oBQ
+oBQ
+hRA
+kaj
+oBQ
+oBQ
+oBQ
+hRA
+kaj
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+fSD
+gkv
+mZk
+oBQ
+hRA
+dNt
+wnU
 fyf
 fyf
-gcK
-gcK
-gcK
-gcK
+wZn
+kaj
+kaj
+gkv
+vpJ
+oBQ
+oBQ
+gkv
+dNt
+wnU
+fyf
+fyf
+eqo
+fyf
+fyf
+pJR
+cWG
+cWG
+wDc
+fyf
+qOV
+nGJ
+wEJ
+mvv
+eMZ
+gZx
+gZx
+gZx
+vtD
+fyf
+fyf
 gcK
 gcK
 ktB
@@ -68449,108 +70806,108 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-qOV
-cWG
-wDc
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-kGc
-unI
+gts
+dCV
+sYX
+sYX
+aug
+rpu
+sYX
+sUd
+ueL
+sYX
+cpK
+uaJ
+ogB
+hOl
+wGJ
+erY
+hOl
+bAX
+cdc
+wGJ
+ubg
+wGJ
+wVk
+aHN
+dCV
+kDd
+kDd
+nmU
+lMB
+gts
+hEa
+ees
+muk
+hbW
 erY
 erY
 erY
 erY
-fAt
 erY
 erY
 erY
-erY
-koD
-dMW
+gmX
+geM
+ees
+ees
+dqk
+gqj
+dqk
+dqk
+dqk
+dqk
+dqk
+dqk
+dqk
+dqk
+dqk
+dqk
+dqk
+dqk
+dqk
+gqj
+dqk
+dqk
+dqk
+bWt
+dqk
+dqk
+kiB
+fyf
+fyf
+fyf
+xdL
+dqk
+dqk
+dqk
+dqk
+gqj
+dqk
+dqk
+kiB
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
+ocU
+mvv
+mvv
+bpD
+fyf
+tBN
+mvv
+wEJ
+wZG
+mvv
+mvv
+mvv
+aBH
+hCg
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 ktB
@@ -68706,40 +71063,40 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-kGc
-unI
+gts
+dCV
+sYX
+mPw
+oUR
+rpu
+rPM
+rpu
+vXh
+uVF
+gdY
+ajD
+hbW
 erY
+hOl
+wGJ
+cdc
+hOl
+dpZ
+wGJ
+wGJ
+nTc
+rrA
+aHN
+dCV
+uXd
+rgI
+rgI
+xdD
+gts
+cpK
+cpK
+unI
+hbW
 erY
 erY
 erY
@@ -68747,7 +71104,7 @@ bEZ
 erY
 cdc
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -68792,22 +71149,22 @@ uxC
 uxC
 uxC
 uxC
-uxC
-uxC
-wEo
+kne
+pXo
+adn
+bpD
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
+tBN
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+bpD
+qOV
+cWG
+wDc
 gcK
 gcK
 ktB
@@ -68950,7 +71307,7 @@ gjP
 hAC
 fyf
 ijg
-uRJ
+aWF
 gjP
 uRJ
 gjP
@@ -68960,43 +71317,43 @@ fyf
 fyf
 fyf
 fyf
-qOV
-cWG
-wDc
 fyf
 fyf
 fyf
-fyf
-tBN
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+dCV
+sYX
+mUU
+rpu
+rpu
+sYX
+bxl
+rpu
+sYX
+dkg
+ajD
+hbW
+erY
+hOl
+lZP
+hnx
+cdc
+wGJ
+wGJ
+dpZ
+wGJ
+wGJ
+gmX
+dCV
+iOv
+xdD
+xdD
+xdD
+gts
 fyf
 kGc
 unI
-liv
+ucz
 erY
 erY
 erY
@@ -69004,7 +71361,7 @@ bkJ
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -69049,22 +71406,22 @@ fyf
 fyf
 fyf
 fyf
+thR
+mfD
+tSF
+bpD
 fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
+tBN
+czR
+ljA
+mvv
+mvv
+mvv
+bGM
+bpD
+tBN
+mvv
+bpD
 gcK
 gcK
 ktB
@@ -69217,43 +71574,43 @@ fyf
 fyf
 fyf
 fyf
-nlO
-xGH
-bpD
+upX
 fyf
 fyf
-fyf
-fyf
-tBN
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+dCV
+uTq
+mXF
+rpu
+rpu
+rTY
+rpu
+iyu
+jAf
+dkg
+ajD
+mLa
+wGJ
+cdc
+wGJ
+ixC
+tDb
+wVk
+mGA
+roh
+cdc
+ubg
+gmX
+dCV
+uZR
+oum
+xdD
+rgI
+gts
 fyf
 kGc
 unI
-erY
+hbW
 erY
 erY
 cdc
@@ -69261,7 +71618,7 @@ fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -69308,20 +71665,20 @@ gts
 gts
 fyf
 fyf
-thG
+ddf
+hCg
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
+tBN
+bGM
+mvv
+mvv
+wsC
+mvv
+aBH
+hCg
+nlO
+mfD
+hCg
 gcK
 gcK
 ktB
@@ -69459,7 +71816,7 @@ uRJ
 uRJ
 uRJ
 hOJ
-uRJ
+aWF
 gjP
 yeJ
 lae
@@ -69470,55 +71827,55 @@ gjP
 gjP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-nlO
-hCg
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-bpD
+sND
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+dCV
+uTq
+neN
+rpu
+qHx
+rTY
+rpu
+iyu
+uXa
+dkg
+ajD
+iPN
+wGJ
+dmL
+okJ
+mYF
+okJ
+uVo
+mGA
+iJw
+wGJ
+wGJ
+gmX
+dCV
+lEC
+vXM
+aET
+fmO
+gts
 fyf
 kGc
 unI
-erY
+hbW
 cdc
 erY
-erY
+oua
 fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -69568,17 +71925,17 @@ fyf
 thG
 fyf
 fyf
+tBN
+mvv
+mvv
+mvv
+mvv
+aBH
+hCg
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 ktB
@@ -69712,7 +72069,7 @@ koD
 bFJ
 xql
 ako
-uRJ
+aWF
 cpH
 xMe
 uRJ
@@ -69734,40 +72091,40 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+dCV
+uTq
+ngg
+rpu
+rpu
+sYX
+rpu
+iyu
+sYX
+cam
+ajD
+hbW
+jmm
+dCJ
+gAv
+giH
+okJ
+cdc
+mGA
+iJw
+wGJ
+wGJ
+ubg
+dCV
+iBv
+dCV
+dCV
+xdD
+gts
 fyf
 kGc
 unI
-erY
+hbW
 cdc
 erY
 erY
@@ -69775,7 +72132,7 @@ bkJ
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -69825,19 +72182,19 @@ fyf
 thG
 fyf
 fyf
-fyf
-fyf
+nlO
+xGH
+rEg
+mvv
+aBH
+hCg
 fyf
 fyf
 fyf
 fyf
 fyf
 gcK
-hBr
-hUV
-oXd
-oUR
-hBr
+gcK
 ktB
 "}
 (130,1,1) = {"
@@ -69987,44 +72344,44 @@ fyf
 fyf
 fyf
 fyf
+wSj
 fyf
 fyf
 fyf
-qOV
-wDc
-fyf
-fyf
-fyf
-tBN
-mvv
-bpD
-dDC
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
+gts
+dCV
+uTq
+nlv
+rpu
+rpu
+rPM
+aug
+iyu
+sYX
+xUW
+ajD
+xhJ
+kaM
+kaM
+kaM
+qoS
+qoS
+qoS
+bUR
+mgP
+qoS
+qoS
+qoS
+sYX
+pxs
+pxs
+uqa
+uqa
+gts
 fyf
 kGc
 unI
-erY
+hbW
 cdc
 erY
 erY
@@ -70032,7 +72389,7 @@ fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -70083,16 +72440,16 @@ thG
 fyf
 fyf
 fyf
+tBN
+mvv
+aBH
+hCg
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-gcK
-gcK
-gcK
 gcK
 gcK
 ktB
@@ -70247,49 +72604,49 @@ fyf
 fyf
 fyf
 fyf
-nlO
-hCg
 fyf
-fyf
-ulH
-tBN
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-qOV
-cWG
-hpm
-cWG
-wDc
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+dCV
+uTq
+nqU
+rpu
+rpu
+sYX
+tdv
+vcM
+uTq
+cpK
+dJs
+ees
+dNT
+gQv
+gQv
+gQv
+ees
+ees
+ees
+gQv
+jZE
+qJl
+ees
+yiM
+rgI
+rgI
+plH
+uUK
+gts
 fyf
 kGc
 unI
-erY
-erY
+hbW
+oua
 erY
 erY
 fAt
 erY
 erY
 sCK
-erY
+gmX
 koD
 dMW
 fyf
@@ -70302,7 +72659,7 @@ hmy
 sYX
 iAz
 rpu
-rpu
+sKH
 rpu
 sYX
 sYX
@@ -70340,6 +72697,9 @@ thG
 fyf
 fyf
 fyf
+tBN
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -70347,9 +72707,6 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-gcK
 gcK
 gcK
 ktB
@@ -70501,44 +72858,44 @@ fyf
 fyf
 fyf
 fyf
-tlD
-uxC
-uxC
-uxC
-uxC
-sUv
 fyf
 fyf
-tBN
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-qOV
-daU
-mvv
-haP
-wUv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+gts
+gts
+dCV
+uTq
+sYX
+sYX
+uTq
+uTq
+bWF
+ufP
+sYX
+yaw
+cpK
+cpK
+dkg
+dkg
+dkg
+dkg
+cpK
+xtm
+dkg
+dkg
+dkg
+cpK
+iIG
+uqa
+uqa
+uqa
+gxv
+uqa
+gts
 fyf
 kGc
 unI
-erY
+hbW
 erY
 erY
 fmW
@@ -70546,7 +72903,7 @@ fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -70596,17 +72953,17 @@ fyf
 thG
 fyf
 fyf
+qOV
+sOS
+mvv
+bpD
 fyf
 fyf
 fyf
 fyf
+sqA
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-gcK
 gcK
 gcK
 ktB
@@ -70758,44 +73115,44 @@ fyf
 fyf
 fyf
 fyf
-thG
-aDX
-cWG
-cWG
-cWG
-bPj
-cWG
-cWG
-daU
-mvv
-bpD
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-aBH
-mfD
-hCg
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+iBv
+sYX
+kKZ
+cpK
+jPG
+jGl
+jGl
+jGl
+jPG
+dkg
+dxG
+dkg
+dkg
+dkg
+cpK
+vmg
+uqa
+kGP
+uqa
+vcM
+bto
+gts
 fyf
 kGc
 unI
-erY
+hbW
 erY
 erY
 erY
@@ -70803,7 +73160,7 @@ txr
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -70812,7 +73169,7 @@ fyf
 cuv
 eOZ
 fqg
-klA
+irf
 sYX
 iAz
 rpu
@@ -70853,6 +73210,10 @@ fyf
 thG
 fyf
 fyf
+tBN
+mvv
+aBH
+hCg
 fyf
 fyf
 fyf
@@ -70860,10 +73221,6 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-gcK
 gcK
 gcK
 ktB
@@ -71015,44 +73372,44 @@ fyf
 fyf
 fyf
 fyf
-thG
-tBN
-mvv
-mvv
-mvv
-iWi
-mvv
-mvv
-mvv
-mvv
-bpD
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+dCV
+giZ
+giZ
+bet
+giZ
+giZ
+giZ
+giZ
+dCV
+ulU
+dkg
+cpK
+cpK
+wHo
+kBa
+eRU
+odk
+odk
+uND
+kBa
+oGL
+ykD
+sbk
+uCW
+cFx
+uqa
+ruN
+xjA
+vlz
+buC
+pNN
 fyf
 kGc
 unI
-erY
+hbW
 erY
 erY
 erY
@@ -71060,7 +73417,7 @@ bbU
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -71110,6 +73467,9 @@ fyf
 thG
 fyf
 fyf
+tBN
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -71117,10 +73477,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-gcK
+wjt
 gcK
 gcK
 ktB
@@ -71269,43 +73626,43 @@ uRJ
 ijg
 fyf
 fyf
-fyf
-fyf
-fyf
-thG
-ury
-qPQ
-aBH
-mfD
-kXv
-mfD
-mfD
-xGH
-mvv
-bpD
+pis
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-nlO
-mfD
-mfD
-hCg
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+dCV
+giZ
+vlg
+vlg
+vlg
+oWU
+qHZ
+giZ
+giZ
+iBT
+dkg
+gdY
+cpK
+dit
+dit
+aFD
+uCS
+uCS
+fkW
+dit
+fcr
+fYZ
+yel
+uCW
+aOg
+mST
+wXK
+gqo
+rpu
+rpu
+vdB
 fyf
 kGc
 unI
@@ -71317,7 +73674,7 @@ fAt
 erY
 cdc
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -71367,6 +73724,9 @@ fyf
 thG
 fyf
 fyf
+tBN
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -71375,9 +73735,6 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-gcK
 gcK
 gcK
 ktB
@@ -71529,44 +73886,44 @@ fyf
 fyf
 fyf
 fyf
-thG
-tBN
-qPQ
-kQC
-gjP
-gjP
-ras
-gjP
-gjP
-ntl
-gjP
-gjP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-qOV
-cWG
-cWG
-cWG
-wDc
-fyf
-fyf
+gts
+dCV
+giZ
+kIZ
+vlg
+vlg
+vlg
+oWU
+saf
+bet
+iFr
+dkg
+dkg
+cpK
+dit
+jvN
+ucN
+qkB
+qkB
+tqi
+dit
+dit
+kBa
+dit
+uCW
+uCW
+uqa
+mLC
+bQy
+vcM
+bVp
+gts
 fyf
 kGc
 unI
-erY
+hbW
 erY
 hsy
 hsy
@@ -71574,7 +73931,7 @@ woX
 hsy
 hsy
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -71622,19 +73979,19 @@ gts
 fyf
 fyf
 thG
+eqo
+fyf
+nlO
+mfD
+hCg
 fyf
 fyf
 fyf
 fyf
 fyf
+sqA
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
 gcK
 gcK
 ktB
@@ -71786,44 +74143,44 @@ fyf
 fyf
 fyf
 fyf
-thG
-nlO
-mfD
-hCg
-gjP
-tWd
-lly
-lok
-cbk
-uRJ
-uRJ
-gjP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-bpD
-fyf
-fyf
+gts
+dCV
+giZ
+kPZ
+lKK
+dWR
+oXd
+eTZ
+sap
+twP
+dkg
+cah
+dkg
+cpK
+dit
+uCS
+ucN
+ucN
+ucN
+rOF
+dit
+qoj
+rbF
+dit
+uCW
+nNm
+uqa
+uqa
+uqa
+uqa
+dCV
+gts
 fyf
 kGc
 unI
-erY
+hbW
 erY
 erY
 erY
@@ -71831,7 +74188,7 @@ fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -71877,7 +74234,7 @@ rpu
 rpu
 gts
 fyf
-fyf
+eqo
 thG
 fyf
 fyf
@@ -71890,8 +74247,8 @@ fyf
 fyf
 fyf
 fyf
-gcK
-gcK
+fyf
+eqo
 gcK
 gcK
 ktB
@@ -72043,44 +74400,44 @@ fyf
 fyf
 fyf
 fyf
-gjP
-ntl
-gjP
-gjP
-gjP
-mvJ
-uRJ
-uRJ
-cbk
-uRJ
-jxq
-gjP
-gjP
-gjP
-gjP
-gjP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-kzR
-bpD
-fyf
-fyf
+gts
+dCV
+giZ
+kXv
+lRT
+nwp
+dWR
+dWR
+sgr
+twP
+jPG
+jGl
+dkg
+cpK
+dit
+rpD
+ucN
+qkB
+qkB
+ucN
+pSk
+qot
+rgI
+dit
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+gts
 fyf
 kGc
 unI
-fmW
+sif
 mmK
 erY
 erY
@@ -72088,7 +74445,7 @@ fAt
 erY
 erY
 erY
-cdc
+gmX
 koD
 dMW
 fyf
@@ -72134,7 +74491,7 @@ ohk
 rpu
 gts
 fyf
-fyf
+eqo
 thG
 fyf
 fyf
@@ -72142,13 +74499,13 @@ fyf
 fyf
 fyf
 fyf
+eqo
 fyf
 fyf
 fyf
 fyf
-fyf
-gcK
-gcK
+eqo
+eqo
 gcK
 gcK
 ktB
@@ -72288,7 +74645,7 @@ uRJ
 uRJ
 mvJ
 gjP
-uRJ
+aWF
 uRJ
 xql
 uRJ
@@ -72300,44 +74657,44 @@ fyf
 fyf
 fyf
 fyf
-gjP
-uRJ
-uRJ
-xGJ
-cbk
-hsP
-uRJ
-rHE
-cbk
-cPX
-uRJ
-cbk
-vAy
-uRJ
-vAy
-gjP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-nlO
-xGH
-mvv
-mvv
-bpD
-fyf
-fyf
+gts
+dCV
+giZ
+giZ
+giZ
+giZ
+vlg
+vlg
+sgr
+twP
+jPG
+jPG
+yel
+vpH
+dit
+pnB
+uCS
+uCS
+uCS
+xwZ
+dit
+rWL
+rgI
+dit
+dCV
+gts
+gts
+gts
+gts
+gts
+gts
+gts
 fyf
 kGc
 unI
-erY
+hbW
 erY
 xuL
 erY
@@ -72345,7 +74702,7 @@ mmK
 erY
 erY
 erY
-erY
+gmX
 koD
 cOk
 dDC
@@ -72359,7 +74716,7 @@ dhC
 jbw
 rpu
 rpu
-rpu
+vXh
 rpu
 rpu
 rpu
@@ -72386,14 +74743,15 @@ fyf
 acn
 rpu
 rpu
-bqB
+ofd
 uzJ
 rpu
 gts
 fyf
-fyf
+eqo
 thG
 fyf
+eqo
 fyf
 fyf
 fyf
@@ -72402,10 +74760,9 @@ fyf
 fyf
 fyf
 fyf
-fyf
-gcK
-gcK
-gcK
+wjt
+eqo
+eqo
 gcK
 gcK
 ktB
@@ -72549,52 +74906,52 @@ uRJ
 iFb
 jnX
 uRJ
-uRJ
+aWF
 uRJ
 gjP
 fyf
 fyf
+sND
 fyf
 fyf
 fyf
-gjP
-gva
-qMi
-yaw
-cbk
-ems
-uRJ
-jnr
-cbk
-uRJ
-jMN
-cbk
-uRJ
+fyf
+gts
+dCV
+giZ
+giZ
+giZ
+giZ
 xdD
-jMN
-gjP
+xdD
+giZ
+giZ
+cpK
+jPG
+ykD
+cpK
+dit
+dit
+dit
+fhs
+fhs
+dit
+dit
+xdD
+rgI
+dit
+dCV
+gts
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-pSk
-fyf
-fyf
-fyf
-fyf
-nlO
-mfD
-mfD
-hCg
 fyf
 fyf
 fyf
 kGc
 unI
-erY
+hbW
 erY
 erY
 erY
@@ -72602,7 +74959,7 @@ fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -72652,11 +75009,11 @@ fyf
 thG
 fyf
 fyf
+eqo
 fyf
 fyf
 fyf
-fyf
-fyf
+eqo
 wjt
 fyf
 fyf
@@ -72796,7 +75153,7 @@ koD
 cam
 gjP
 iKm
-uRJ
+aWF
 pPe
 ijO
 uRJ
@@ -72814,34 +75171,34 @@ fyf
 fyf
 fyf
 fyf
-ras
-uRJ
-uRJ
-wXq
-cbk
-cbk
-jnX
-cbk
-cbk
-jnX
-cbk
-cbk
-vAy
-jxq
-vAy
-gjP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+dCV
+giZ
+noH
+rgI
+nwu
+xdD
+xdD
+sln
+giZ
+cpK
+uCW
+ykD
+mrQ
+wFz
+dit
+tWt
+uCS
+uCS
+mJW
+fRM
+xdD
+rgI
+dit
+dCV
+gts
 fyf
 fyf
 fyf
@@ -72851,7 +75208,7 @@ fyf
 fyf
 kGc
 unI
-erY
+hbW
 erY
 erY
 erY
@@ -72859,7 +75216,7 @@ bkJ
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -72876,7 +75233,7 @@ rkZ
 rkZ
 rkZ
 rpu
-rpu
+aug
 cuv
 fyf
 fyf
@@ -72909,11 +75266,11 @@ fyf
 thG
 fyf
 fyf
-fyf
+eqo
 fyf
 fyf
 wjt
-fyf
+eqo
 fyf
 fyf
 fyf
@@ -72983,7 +75340,7 @@ gts
 fyf
 fyf
 fyf
-fyf
+hAC
 fyf
 fyf
 fyf
@@ -73055,7 +75412,7 @@ gjP
 udt
 uRJ
 pPe
-uRJ
+aWF
 wyI
 uRJ
 jnX
@@ -73071,44 +75428,44 @@ fyf
 fyf
 fyf
 fyf
-gjP
-nPJ
-uRJ
+fyf
+fyf
+gts
+dCV
+giZ
 noH
-cbk
-uRJ
-uRJ
-uRJ
-uRJ
-uRJ
-uRJ
-jnX
-uRJ
-jMN
+rgI
 xdD
-gjP
+xdD
+eVh
+slT
+giZ
+cpK
+uZj
+ueN
+cpK
+kzW
+dit
+dit
+whh
+lCs
+flj
+dit
+xdD
+rgI
+dit
+dCV
+gts
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qTY
 fyf
 fyf
 fyf
 fyf
 kGc
 unI
-erY
+hbW
 erY
 rQR
 erY
@@ -73116,7 +75473,7 @@ fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -73170,7 +75527,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+eqo
 fyf
 fyf
 fyf
@@ -73240,7 +75597,7 @@ gcK
 fyf
 fyf
 fyf
-fyf
+hAC
 fyf
 fyf
 fyf
@@ -73328,44 +75685,44 @@ fyf
 fyf
 fyf
 fyf
-gjP
-aPr
-jxq
-uRJ
-jnX
-hDQ
-jMN
-bMg
-kdu
-lly
-uRJ
-cbk
-bzf
-uRJ
-uRJ
-gjP
 fyf
 fyf
+gts
+dCV
+giZ
+aDX
+xdD
+alM
+xdD
+qIE
+qIE
+giZ
+jPG
+cam
+gdY
+dkg
+rHA
+dit
+ggk
+dit
+xdJ
+dit
+dit
+bnf
+rgI
+dit
+dCV
+gts
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+upX
 fyf
 fyf
 fyf
 fyf
 kGc
 unI
-erY
+hbW
 erY
 hsy
 hsy
@@ -73373,14 +75730,14 @@ woX
 hsy
 hsy
 erY
-erY
+gmX
 koD
 dMW
 fyf
 thG
 fyf
 fyf
-fyf
+upX
 fyf
 fyf
 fyf
@@ -73404,7 +75761,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+eqo
 fyf
 fyf
 fyf
@@ -73423,11 +75780,11 @@ fyf
 thG
 fyf
 fyf
+sqA
 fyf
 fyf
 fyf
-fyf
-fyf
+eqo
 wjt
 fyf
 fyf
@@ -73497,7 +75854,7 @@ gcK
 fyf
 fyf
 fyf
-fyf
+hAC
 gts
 gts
 gts
@@ -73585,44 +75942,44 @@ fyf
 fyf
 fyf
 fyf
-gjP
-kmQ
-uRJ
-nQY
-cbk
-gbR
-jTq
-eLJ
-bMg
-jMN
-wXv
-cbk
-vAy
-uRJ
-vAy
-gjP
+fyf
+fyf
+gts
+dCV
+giZ
+xdD
+xdD
+oYI
+oXV
+sVs
+eDz
+lTx
+jPG
+jPG
+dkg
+dkg
+kzW
+dit
+rgI
+fAG
+xdD
+xdD
+psR
+rgI
+iRz
+dit
+dCV
+gts
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sND
 fyf
 kGc
 unI
-erY
+hbW
 erY
 erY
 erY
@@ -73630,7 +75987,7 @@ fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -73684,7 +76041,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+eqo
 fyf
 fyf
 fyf
@@ -73754,7 +76111,7 @@ gcK
 gcK
 fyf
 fyf
-fyf
+hAC
 gts
 qPp
 qIv
@@ -73842,34 +76199,34 @@ fyf
 fyf
 fyf
 fyf
-gjP
-cbk
-cbk
-cbk
-cbk
-uRJ
-jTq
-bMg
-bMg
-lly
-uRJ
-cbk
-cbk
-cbk
-cbk
-gjP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+dCV
+giZ
+giZ
+giZ
+giZ
+giZ
+qIE
+snA
+lTx
+cpK
+vpa
+kQC
+cpK
+lKV
+dit
+frv
+dit
+dit
+xdD
+xdD
+rgI
+uwZ
+dit
+dCV
+gts
 fyf
 fyf
 fyf
@@ -73879,7 +76236,7 @@ fyf
 fyf
 kGc
 unI
-erY
+hbW
 erY
 erY
 erY
@@ -73887,7 +76244,7 @@ khX
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -74099,34 +76456,34 @@ cPn
 gjP
 gjP
 fyf
-gjP
-ipn
-uRJ
-uRJ
-jnX
-uRJ
-uRJ
-uRJ
-uRJ
-uRJ
-vzb
-cbk
-lMp
-uRJ
-wXR
-gjP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+gts
+gts
+gts
+gts
+dCV
+giZ
+giZ
+uMU
+ids
+ids
+vuH
+rRt
+cpK
+oXA
+dit
+rgI
+gFA
+ccG
+rgI
+xdD
+xdD
+xdD
+dit
+dCV
+gts
 fyf
 fyf
 fyf
@@ -74136,15 +76493,15 @@ fyf
 fyf
 kGc
 unI
+hbW
 erY
 erY
 erY
-erY
-fAt
-erY
-erY
+srt
+wGJ
 erY
 erY
+gmX
 koD
 dMW
 fyf
@@ -74181,7 +76538,7 @@ fyf
 gts
 tUf
 rpu
-rpu
+aug
 nUT
 gts
 pTE
@@ -74356,34 +76713,34 @@ uRJ
 uRJ
 srw
 fyf
-gjP
-tFM
-jxq
-qQe
-cbk
-cbk
-cbk
-cbk
-cbk
-jnX
-cbk
-cbk
-aBx
-jxq
-vfs
-gjP
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
+gts
+dCV
+dCV
+dCV
+dCV
+dCV
+sYX
+jPN
+cpK
+cpK
+ecx
+dit
+aPF
+alk
+slU
+feM
+hsc
+omV
+uhp
+dit
+dCV
+gts
 fyf
 fyf
 fyf
@@ -74393,15 +76750,15 @@ fyf
 fyf
 kGc
 unI
+hbW
+wGJ
 erY
 erY
+srt
+wGJ
 erY
 erY
-fAt
-cdc
-erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -74431,7 +76788,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+eqo
 fyf
 fyf
 fyf
@@ -74613,34 +76970,34 @@ cRX
 uRJ
 srw
 fyf
-gjP
-smw
-uRJ
-wSj
-cbk
-uRJ
-jTq
-gmZ
-lly
-uRJ
-wXv
-cbk
-odc
-uRJ
-uCT
-gjP
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+gts
+gts
+gts
+gts
+gts
+dCV
+dCV
+ids
+ids
+lTx
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dCV
+gts
 fyf
 fyf
 fyf
@@ -74650,15 +77007,15 @@ fyf
 fyf
 kGc
 unI
-erY
+hbW
 cdc
+wGJ
+erY
+srt
+wGJ
 erY
 erY
-fAt
-erY
-erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -74688,7 +77045,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+eqo
 fyf
 fyf
 fyf
@@ -74700,7 +77057,7 @@ gts
 gts
 aYG
 rpu
-ioh
+jUw
 hKY
 gts
 fyf
@@ -74870,22 +77227,9 @@ nSK
 uRJ
 gjP
 fyf
-gjP
-uRJ
-uRJ
-mvJ
-cbk
-uRJ
-uRJ
-uRJ
-jMN
-uRJ
-uRJ
-jnX
-uRJ
-uRJ
-lMp
-gjP
+fyf
+fyf
+wSj
 fyf
 fyf
 fyf
@@ -74894,28 +77238,41 @@ fyf
 fyf
 fyf
 fyf
+gts
+gts
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+gts
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+lWZ
 fyf
 kGc
 unI
-erY
-erY
-erY
+hbW
+wGJ
+wGJ
 erY
 khX
+wGJ
 erY
 erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -74927,7 +77284,7 @@ ccF
 rpu
 rpu
 jbx
-rpu
+aug
 rpu
 sYX
 fyf
@@ -74941,11 +77298,11 @@ fyf
 fyf
 fyf
 fyf
+eqo
 fyf
 fyf
 fyf
-fyf
-fyf
+eqo
 fyf
 fyf
 fyf
@@ -74964,11 +77321,11 @@ fyf
 fyf
 thG
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+xKa
+vgc
+vgc
+vgc
+aTh
 fyf
 fyf
 fyf
@@ -75123,26 +77480,10 @@ uRJ
 uRJ
 ijg
 uRJ
-uRJ
+buO
 uRJ
 srw
 fyf
-gjP
-eNC
-uRJ
-jMN
-cbk
-hJd
-uRJ
-qMi
-jxq
-uRJ
-kFi
-cbk
-kPZ
-uRJ
-lMp
-gjP
 fyf
 fyf
 fyf
@@ -75155,6 +77496,22 @@ fyf
 fyf
 fyf
 fyf
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
 fyf
 fyf
 fyf
@@ -75164,15 +77521,15 @@ fyf
 fyf
 kGc
 unI
+hbW
 erY
+wGJ
+wGJ
+srt
+wGJ
 erY
-erY
-erY
-fAt
-erY
-erY
-erY
-erY
+wGJ
+gmX
 koD
 dMW
 fyf
@@ -75184,7 +77541,7 @@ uCO
 uCO
 uCO
 uCO
-rpu
+uRw
 rpu
 cuv
 fyf
@@ -75198,11 +77555,11 @@ fyf
 fyf
 fyf
 fyf
+eqo
 fyf
 fyf
 fyf
-fyf
-fyf
+eqo
 fyf
 fyf
 fyf
@@ -75213,7 +77570,7 @@ dpO
 rpu
 gts
 rpu
-rpu
+kyu
 ioh
 rkZ
 gts
@@ -75221,14 +77578,14 @@ fyf
 fyf
 thG
 fyf
+uCt
+jEP
+khJ
+vHg
+jvt
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+eqo
 fyf
 fyf
 gcK
@@ -75367,7 +77724,7 @@ yeJ
 srw
 nSK
 oDC
-cnX
+bwo
 hpc
 gjP
 gjP
@@ -75380,26 +77737,26 @@ uRJ
 jZb
 ijg
 wSw
-cnX
+xVI
 wSw
 srw
 fyf
-gjP
-jml
-uRJ
-jMz
-cbk
-mPw
-uRJ
-uRJ
-hDQ
-uRJ
-aUb
-cbk
-vfs
-uRJ
-vfs
-gjP
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+trW
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -75421,15 +77778,15 @@ fyf
 fyf
 kGc
 unI
+hbW
 erY
-erY
-erY
-erY
+wGJ
+wGJ
 fAt
-cdc
-erY
-cdc
-erY
+wGJ
+wGJ
+wGJ
+gmX
 koD
 dMW
 fyf
@@ -75438,7 +77795,7 @@ fyf
 fyf
 cuv
 ccF
-rpu
+aug
 rpu
 jbx
 rpu
@@ -75459,12 +77816,12 @@ fyf
 fyf
 fyf
 fyf
-fyf
+eqo
 fyf
 fyf
 fyf
 gts
-rpu
+hiB
 wcA
 dGK
 rpu
@@ -75478,17 +77835,17 @@ fyf
 fyf
 thG
 fyf
+uCt
+jkh
+cbr
+jdv
+jvt
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
+fDp
 gcK
 gcK
 gcK
@@ -75624,7 +77981,7 @@ bFJ
 gjP
 gva
 uRJ
-iFb
+bzq
 uRJ
 jnX
 uRJ
@@ -75641,22 +77998,16 @@ iFb
 lNh
 gjP
 fyf
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-uWs
-uWs
-gjP
-ntl
-gjP
-gjP
-gjP
-uWs
-gjP
-gjP
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+qOV
+wDc
 fyf
 fyf
 fyf
@@ -75671,22 +78022,28 @@ fyf
 fyf
 fyf
 fyf
+uey
+qOV
+cWG
+hpm
+wDc
 fyf
 fyf
 fyf
+sND
 fyf
 fyf
 kGc
 unI
+hbW
 erY
-erY
-liv
-erY
-fAt
-erY
-erY
+aXC
+wGJ
+srt
+wGJ
+wGJ
 cdc
-erY
+gmX
 koD
 dMW
 fyf
@@ -75708,7 +78065,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+eqo
 fyf
 fyf
 fyf
@@ -75735,14 +78092,14 @@ fyf
 fyf
 thG
 fyf
+uCt
+foX
+mqn
+jdv
+jvt
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+oiP
 fyf
 fyf
 fyf
@@ -75886,7 +78243,7 @@ egK
 gjP
 ijg
 uRJ
-uRJ
+buO
 bAS
 ijg
 jZb
@@ -75898,21 +78255,16 @@ uRJ
 wSw
 srw
 fyf
-xLY
-rym
-sCF
-cGb
-cGb
-cGb
-cGb
-cGb
-cGb
-cGb
-cGb
-cGb
-cGb
-dgG
-xLY
+fyf
+fyf
+fyf
+fyf
+hAC
+fyf
+qOV
+cWG
+daU
+bpD
 fyf
 fyf
 fyf
@@ -75927,23 +78279,28 @@ fyf
 fyf
 fyf
 fyf
-sqA
+qOV
+daU
+mvv
+haP
+bpD
+fyf
 fyf
 fyf
 fyf
 fyf
 fyf
 kGc
-pBv
-erY
-erY
-erY
-erY
-fAt
-erY
-erY
-erY
-erY
+unI
+hbW
+wGJ
+wGJ
+wGJ
+srt
+wGJ
+wGJ
+wGJ
+gmX
 koD
 dMW
 fyf
@@ -75992,13 +78349,13 @@ fyf
 fyf
 thG
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+ccf
+cDk
+hKQ
+gks
+tYW
+cWG
+wDc
 fyf
 fyf
 fyf
@@ -76074,8 +78431,8 @@ gcK
 gcK
 gcK
 fyf
-fyf
-fyf
+hAC
+hAC
 fyf
 kGc
 ajD
@@ -76155,21 +78512,16 @@ uRJ
 nHE
 srw
 fyf
-xLY
-jsP
-fbq
-fbq
-fbq
-fbq
-lRX
-fbq
-lRX
-fbq
-lRX
-fbq
-lRX
-qcS
-xLY
+fyf
+fyf
+fyf
+fyf
+fyf
+qOV
+daU
+adn
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -76183,24 +78535,29 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
+rtR
+tBN
+mvv
+mvv
+aBH
+hCg
+wSj
 fyf
 fyf
 fyf
 fyf
 fyf
 kGc
-jIB
-erY
+unI
+hbW
 cdc
-erY
-erY
+wGJ
+wGJ
 ltl
 erY
-sCK
-erY
-erY
+wVk
+wGJ
+gmX
 koD
 dMW
 fyf
@@ -76212,7 +78569,7 @@ fQY
 rpu
 rpu
 jbx
-jhp
+rpu
 rpu
 sYX
 mGZ
@@ -76221,14 +78578,14 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+bIh
+dtK
+pud
+bIh
+pSt
+dtK
+bIh
+bIh
 fyf
 fyf
 fyf
@@ -76249,14 +78606,14 @@ fyf
 fyf
 thG
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+uCt
+nJG
+jyF
+cbr
+qhE
+mvv
+bpD
+eqo
 fyf
 fyf
 fyf
@@ -76332,7 +78689,7 @@ gcK
 gcK
 gcK
 fyf
-fyf
+hAC
 fyf
 kGc
 jIB
@@ -76412,21 +78769,16 @@ jnX
 gjP
 gjP
 fyf
-xLY
-cmj
-kvT
-kvT
-kvT
-hNY
-lRX
-fbq
-lRX
-fbq
-lRX
-fbq
-lRX
-qcS
-xLY
+fyf
+fyf
+fyf
+fyf
+mtL
+tBN
+mvv
+ucA
+mvv
+xxf
 fyf
 fyf
 fyf
@@ -76435,11 +78787,16 @@ fyf
 fyf
 fyf
 fyf
+sND
 fyf
 fyf
 fyf
 fyf
 fyf
+tBN
+mvv
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -76448,29 +78805,29 @@ fyf
 fyf
 fyf
 kGc
-ajD
-erY
-erY
-erY
-erY
-fAt
+unI
+hbW
+wGJ
+wGJ
+wGJ
+srt
 erY
 sCK
-erY
-erY
+wGJ
+gmX
 koD
 dMW
 fyf
 thG
 fyf
 fyf
-cuv
-ccF
-rpu
-rkZ
-uCO
+sYX
 bxl
 rpu
+iuS
+uCO
+wPl
+jhp
 sYX
 fyf
 fyf
@@ -76478,14 +78835,14 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-mGZ
-fyf
+bIh
+kRf
+jXm
+sYw
+qij
+qij
+ioY
+bIh
 fyf
 fyf
 fyf
@@ -76506,18 +78863,18 @@ fyf
 fyf
 thG
 fyf
+jMy
+qwn
+szQ
+jUv
+hop
+mfD
+hCg
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hwC
 gcK
 gcK
 ktB
@@ -76589,7 +78946,7 @@ gcK
 gcK
 gcK
 fyf
-fyf
+hAC
 fyf
 kGc
 ofX
@@ -76669,21 +79026,16 @@ uRJ
 dyt
 srw
 fyf
-xLY
 fyf
-gjP
-gjP
-gjP
-jsP
-fbq
-fbq
-fbq
-fbq
-fbq
-fbq
-fbq
-qcS
-xLY
+fyf
+fyf
+fyf
+qOV
+vGg
+mvv
+ucA
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -76697,6 +79049,11 @@ fyf
 fyf
 fyf
 fyf
+fyf
+nlO
+mfD
+mfD
+hCg
 fyf
 fyf
 fyf
@@ -76706,15 +79063,15 @@ fyf
 fyf
 kGc
 unI
-erY
+hbW
 erY
 erY
 erY
 fAt
 erY
+wGJ
 erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -76722,31 +79079,31 @@ thG
 fyf
 fyf
 sYX
+ccF
+ioh
+rkZ
 uCO
-uCO
-uCO
-uCO
+kYz
 rpu
-rpu
-wpx
-fyf
-fyf
-fyf
+sYX
 fyf
 fyf
 fyf
 bIh
+bIh
+bIh
+bIh
 tpA
+qij
+qij
+qij
+qij
+mwg
+bIh
+dtK
+bIh
+dtK
 pud
-bIh
-wSJ
-tpA
-bIh
-bIh
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 tlD
@@ -76763,18 +79120,18 @@ sYX
 sYX
 sYX
 fyf
+rxW
+uwy
+xHC
+fKW
+lSB
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hwC
 gcK
 gcK
 ktB
@@ -76926,22 +79283,20 @@ uRJ
 kfo
 srw
 fyf
-xLY
 fyf
-gjP
-mVc
-ntl
-jsP
-lRX
-fbq
-lRX
-fbq
-pbr
-fbq
-adn
-qcS
-xLY
 fyf
+fyf
+fyf
+tBN
+mvv
+mvv
+ucA
+mvv
+bpD
+fyf
+fyf
+fyf
+qTY
 fyf
 fyf
 fyf
@@ -76951,6 +79306,8 @@ fyf
 fyf
 fyf
 fyf
+fyf
+sND
 fyf
 fyf
 fyf
@@ -76963,47 +79320,47 @@ fyf
 fyf
 kGc
 unI
+hbW
 erY
 erY
 erY
-erY
-fAt
+srt
 erY
 cdc
 erY
-erY
+gmX
 koD
 dMW
 fyf
 thG
 fyf
 fyf
-sYX
-gvN
+tKZ
+uCO
+uCO
+uCO
+uCO
+ipm
 rpu
-rpu
-jbx
-rpu
-rpu
-sYX
-fyf
-fyf
-fyf
+cuv
 fyf
 fyf
 fyf
 bIh
+pDH
+qKL
+pud
 tsB
-uFp
-uZg
 qij
+qij
+fgn
 qij
 bix
 bIh
-fyf
-fyf
-fyf
-fyf
+hMM
+cdL
+hMM
+pud
 fyf
 fyf
 thG
@@ -77031,7 +79388,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+hwC
 gcK
 gcK
 ktB
@@ -77172,32 +79529,27 @@ gjP
 gjP
 gva
 egK
-uRJ
+aWF
 hDQ
 uRJ
 uRJ
 uRJ
 uRJ
 uRJ
-uRJ
+buO
 gjP
 gjP
 fyf
-xLY
 fyf
-gjP
-gjP
-gjP
-jsP
-lRX
-fbq
-lRX
-fbq
-lRX
-fbq
-lRX
-qcS
-xLY
+fyf
+fyf
+rtR
+tBN
+mvv
+mvv
+wsJ
+aBH
+hCg
 fyf
 fyf
 fyf
@@ -77215,51 +79567,56 @@ fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
+sND
+rtR
 fyf
 fyf
 fyf
 kGc
 unI
-erY
+hbW
 erY
 erY
 erY
 khX
 erY
+wGJ
 erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
 thG
 fyf
-fyf
-cuv
-ccF
-rpu
+gcK
+gcK
+oKq
+ioh
 rkZ
 uCO
-xQu
+lRZ
 rpu
-cuv
+sYX
 fyf
 fyf
 fyf
 bIh
-bIh
-bIh
-bIh
-fJj
+fmV
+qKL
+fBT
+qij
+uar
 qij
 qij
+cQM
 qij
+bIh
+voY
 qij
-cjG
-bIh
-tpA
-bIh
-tpA
+rrk
 pud
 fyf
 fyf
@@ -77278,17 +79635,17 @@ swx
 sYX
 fyf
 fyf
+xKa
+vgc
+vgc
+vgc
+aTh
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hwC
 gcK
 gcK
 ktB
@@ -77440,27 +79797,27 @@ uRJ
 tJz
 srw
 fyf
-xLY
+fyf
+fyf
+fyf
+qOV
+daU
+mvv
+aBH
+mfD
+hCg
 fyf
 fyf
 fyf
 fyf
-cmj
-kvT
-kvT
-kvT
-kvT
-kvT
-kvT
-kvT
-lwd
-xLY
 fyf
 fyf
 fyf
-pSk
 fyf
 fyf
+fyf
+fyf
+wSj
 fyf
 fyf
 fyf
@@ -77477,44 +79834,44 @@ fyf
 fyf
 kGc
 unI
+hbW
 erY
 erY
+wGJ
+srt
 erY
+wGJ
 erY
-fAt
-erY
-erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
 gcK
-fyf
-fyf
-sYX
-uCO
-uCO
-uCO
+gcK
+gcK
+gcK
+gcK
+qxe
+xVZ
 uCO
 rpu
 rpu
-sYX
+kGD
 fyf
 fyf
 fyf
 bIh
-oOZ
-pOw
 pud
-tJx
-qij
-qij
+pud
+bIh
+bIh
+bIh
+bSk
 tkm
-qij
+hOD
 nRc
 bIh
-fpF
+qij
 nCS
 fpF
 pud
@@ -77535,17 +79892,17 @@ cbr
 sYX
 fyf
 fyf
+uCt
+jEP
+ctT
+tlg
+fMy
+cWG
+wDc
+oiP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hwC
 gcK
 gcK
 ktB
@@ -77697,64 +80054,64 @@ uRJ
 tJz
 srw
 fyf
-dje
-uxC
-uxC
-uxC
-uxC
-uxC
-uxC
-uxC
-aUl
-uxC
-uxC
-uxC
-uxC
-uxC
-fDm
+fyf
+fyf
+fyf
+nlO
+mfD
+mfD
+hCg
+fyf
+fyf
+yaz
+fyf
+fyf
+sND
+fyf
+vJr
+mDf
+mDf
+mDf
+mDf
+nnh
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-wEo
-qUC
-qUC
-qUC
-qUC
-qUC
-qUC
-qUC
-ejD
-fyf
-fyf
-fyf
+sYX
+sYX
+sYX
+sYX
+sYX
+kom
+maS
+sYX
+sYX
 kGc
 unI
+hbW
+wGJ
 erY
+wGJ
+srt
 erY
+wGJ
 erY
-erY
-fAt
-erY
-erY
-erY
-erY
+gmX
 koD
 dMW
 gcK
 gcK
 gcK
-fyf
-sYX
-gzQ
-rpu
+gcK
+gcK
+gcK
+gcK
 rpu
 jbx
-rpu
+sKH
 rpu
 sYX
 fyf
@@ -77764,18 +80121,18 @@ bIh
 oqm
 pOw
 rja
-qij
-qij
-qij
-qij
-ffy
+gck
+bIh
+ixu
+xUL
+vno
 qij
 bIh
 yhv
-qij
-rzV
 pud
-fyf
+pud
+pud
+pud
 fyf
 fyf
 tBN
@@ -77792,17 +80149,17 @@ cbr
 sYX
 fyf
 fyf
+uCt
+qwn
+cbr
+cbr
+shu
+mfD
+hCg
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hwC
 gcK
 gcK
 ktB
@@ -77968,71 +80325,71 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-xLY
+mFi
 qyR
 qyR
 qyR
 qyR
-qyR
-qyR
-qyR
-hpj
+xNE
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
+sYX
+okz
+aEX
+sDp
+rpu
+wfC
+dqo
+nPP
+kGD
 kGc
 unI
-erY
+hbW
 cdc
-erY
+wGJ
 cdc
-txr
+neX
 erY
+wGJ
 erY
-erY
-erY
+gmX
 koD
 dMW
 gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+tKZ
 sYX
-bxl
-rpu
-iuS
-uCO
-wPl
-jhp
+sYX
+sYX
 sYX
 fyf
 fyf
-fyf
+qOV
 bIh
+gpz
+qij
+rrk
+qij
+tmm
+qij
+qij
+qij
+qij
 pud
-pud
-bIh
-bIh
-bIh
-viv
-xdG
-xUc
 qij
 bIh
-qij
-qhs
 cph
-pud
-fyf
+xTM
+bIh
 fyf
 thG
 tBN
@@ -78049,11 +80406,11 @@ cbr
 sYX
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+uCt
+foX
+ucj
+cbr
+qcT
 fyf
 fyf
 fyf
@@ -78225,71 +80582,71 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-xLY
-pcP
-hgJ
-hgJ
-hgJ
-hgJ
-xuM
+mFi
+dxS
+rQG
+mqy
 qyR
-hpj
+xNE
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
+sYX
+hRZ
+usW
+uCO
+gSp
+rpu
+rpu
+jcu
+vtj
 kGc
 unI
-erY
-erY
-erY
-erY
+hbW
+wGJ
+wGJ
+wGJ
 bbU
 erY
 cdc
-erY
-erY
+wGJ
+gmX
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
-sYX
-ccF
-ioh
-rkZ
-uCO
-kYz
-rpu
-sYX
+xQu
+xQu
+xQu
+qUK
+abi
+xQu
+xQu
+xQu
+xLz
+hCg
+gJW
+tFR
+qvN
 fyf
-fyf
-fyf
+upG
 bIh
 pxf
 pYa
-wFp
+qij
 tSQ
-bIh
+pud
 vno
-xeG
-vwn
+qij
+qij
+qij
+yhv
+qij
+yhv
+qij
 qij
 bIh
-tPt
-pud
-pud
-pud
-pud
 fyf
 thG
 tBN
@@ -78306,11 +80663,11 @@ cbr
 sYX
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+uCt
+kPF
+hHs
+cbr
+qcT
 fyf
 fyf
 fyf
@@ -78469,78 +80826,78 @@ llj
 srw
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-kdi
-hgJ
-bwG
-hgJ
-bwG
-xuM
+tyL
+tyL
+tyL
+tyL
+tyL
+tyL
+tyL
+tyL
+tyL
+tyL
+tyL
+tyL
+tyL
+tyL
+lGG
+rQG
+mqy
 qyR
-hpj
+xNE
 fyf
 fyf
 fyf
+fyf
+sVO
+uxC
+sYX
+tKZ
+tKZ
+sYX
+bdg
+rpu
+rpu
+rpu
+kGD
 kGc
 unI
-erY
-erY
+hbW
+wGJ
 erY
 erY
 fAt
 erY
-erY
-erY
-erY
+wGJ
+wGJ
+gmX
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
-tKZ
-uCO
-uCO
-uCO
-uCO
-vtv
+evP
+frO
+cbr
+hKQ
+cbr
 rpu
-cuv
+qCT
+xQu
+xUc
 fyf
 fyf
 fyf
+qOV
+wDc
+upG
 bIh
-pHi
-qij
+bIh
+bIh
 rzV
-qij
-uTA
-qij
-qij
-qij
-qij
+bIh
+bIh
+dRN
+tqG
+sjy
+gbl
 pud
 qij
 bIh
@@ -78563,11 +80920,11 @@ uNQ
 sYX
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+uCt
+shT
+gWF
+pIB
+sxy
 fyf
 fyf
 fyf
@@ -78726,83 +81083,83 @@ gjP
 gjP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-bQV
-lav
-cXh
-dxm
-bQV
-pAA
-uBE
-pAA
-bQV
-xNE
-eJu
-rQG
-ktX
-bQV
-kdi
-grC
-cxy
-isL
-cxy
-xuM
+tyL
+goK
+hFY
+iRE
+tyL
+igy
+nxj
+igy
+tyL
+spi
+tAS
+umi
+vAy
+tyL
+lGG
+kOi
+mqy
 qyR
-hpj
+xNE
 fyf
 fyf
 fyf
+fyf
+thG
+fyf
+fyf
+fyf
+fyf
+sYX
+rkZ
+jlB
+rpu
+rpu
+sYX
 kGc
 unI
-erY
-erY
+hbW
+wGJ
 erY
 erY
 fAt
 erY
-xuL
-erY
-erY
+cGO
+wGJ
+gmX
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
+evP
+cbr
+gQO
+jyF
 eXw
-ccF
-ioh
-rkZ
-uCO
-lRZ
-rpu
-sYX
+cbr
+iBO
+xQu
+doX
+wDc
+qLa
 fyf
-fyf
-fyf
+nlO
+xBX
+upG
+wsN
 bIh
-pKP
 qlv
 qij
 uar
-pud
-vwn
-qij
-qij
-qij
-tPt
-qij
-tPt
-qij
-qij
+bIh
+bIh
+bIh
+bIh
+bIh
+bIh
+bIh
+bIh
+bIh
+bIh
 bIh
 fyf
 mmj
@@ -78820,11 +81177,11 @@ sYX
 sYX
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+rxW
+foB
+foB
+foB
+lSB
 fyf
 fyf
 mwp
@@ -78983,84 +81340,84 @@ llj
 srw
 fyf
 fyf
-fyf
-hAC
-fyf
-uey
-fyf
-uey
-fyf
-fyf
-fyf
-bQV
+tyL
+grC
+hJd
+iSE
+kZh
+igy
+igy
+igy
+qJR
 ulE
+tCc
 nUS
-shd
-ubv
-pAA
-pAA
-pAA
-uzn
-bzG
-lIX
-bzq
+wER
+fIa
+lwG
+rQG
 cVw
-cBb
-luD
-hgJ
-bwG
-hgJ
-bwG
-vtj
 qyR
-hpj
+xNE
 fyf
 fyf
 fyf
+fyf
+thG
+fyf
+fyf
+fyf
+fyf
+vtj
+rMz
+vXh
+rpu
+rpu
+yjG
 kGc
 unI
-erY
-erY
-sCK
+hbW
+wGJ
+wVk
 erY
 fAt
 erY
 erY
-erY
-erY
+wGJ
+gmX
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
-eXw
-eXw
 xQu
-xVZ
-uCO
-rpu
-rpu
-kGD
+fJj
+cbr
+ipG
+cbr
+cbr
+xQu
+xQu
+bGM
+bpD
+qOV
+cWG
+hhQ
 fyf
-fyf
-fyf
+aRT
+ajj
 bIh
-bIh
-bIh
+xjS
 rEB
+aXR
 bIh
-bIh
-wpo
-cIm
-xWu
-aYY
-pud
-qij
-bIh
-hiG
-fpF
-bIh
+fDp
+gcK
+gcK
+gcK
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -79231,7 +81588,7 @@ uRJ
 uRJ
 uRJ
 gjP
-uRJ
+buO
 uRJ
 uRJ
 gjP
@@ -79239,86 +81596,86 @@ uRJ
 llj
 nMl
 fyf
-hAC
 fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-uey
-fyf
-bQV
-tma
-nYI
-shd
-bQV
-mHY
-pAA
-pAA
-bQV
-pbj
-aFu
-qAc
-pNk
-bQV
-eEK
-hgJ
-hgJ
-lzW
-lzW
+tyL
+gwn
+hNY
+iSE
+tyL
 xuM
+igy
+igy
+tyL
+gsV
+tIO
+ury
+wLB
+tyL
+eSF
+rSf
+mqy
 qyR
-hpj
+xNE
 fyf
 fyf
 fyf
+fyf
+thG
+fyf
+fyf
+fyf
+fyf
+sYX
+uCO
+uCO
+sDp
+sYX
+sYX
 kGc
 unI
-erY
-erY
-erY
+hbW
+wGJ
+wGJ
 erY
 fAt
 erY
-erY
+wGJ
 cdc
-erY
+gmX
 koD
 dMW
+xQu
+fWi
+gSq
+xQu
+cbr
+cbr
+qPk
+mvv
+mvv
+bpD
+fOQ
+mvv
+doX
+wDc
+aRT
+hwC
+urt
+urt
+urt
+urt
+urt
 gcK
 gcK
 gcK
 gcK
-eXw
-eXw
-eXw
-rpu
-jbx
-rpu
-rpu
-sYX
-fyf
-fyf
-fyf
-fyf
-bIh
-qrw
-qij
-qij
-bIh
-bIh
-bIh
-bIh
-bIh
-bIh
-bIh
-bIh
-bIh
-bIh
-bIh
-fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 fyf
 fyf
 fyf
@@ -79483,7 +81840,7 @@ sBk
 oLL
 gjP
 gjP
-uRJ
+qMi
 uRJ
 cpH
 gjP
@@ -79495,87 +81852,87 @@ gjP
 jnX
 cPn
 gjP
-daM
-daM
-jGl
-uxC
-uxC
-daM
-uxC
 wEo
 fyf
-fyf
-fyf
-bQV
-iPW
-cfK
-pcY
-bQV
-gfc
-pAA
-oQv
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
+tyL
+gQW
+hOs
+iWi
+tyL
+bzf
+igy
+pbr
+tyL
+tyL
+tyL
+tyL
+tyL
+tyL
+bFJ
 qyR
 qyR
-qyR
-qyR
-qyR
-qyR
-mvV
-hpj
+kdS
+xNE
 fyf
 fyf
 fyf
+fyf
+thG
+fyf
+fyf
+fyf
+fyf
+ubS
+csO
+wQY
+rpu
+sYX
+slt
 kGc
 unI
-erY
-erY
+hbW
+cdc
 cdc
 erY
 fAt
 erY
 cdc
-erY
-erY
+wGJ
+gmX
 koD
 dMW
-fyf
-gcK
-gcK
-gcK
+xQu
+xQu
+xQu
+xQu
 eZg
-eXw
-eXw
-tKZ
-sYX
-sYX
-sYX
-sYX
-fyf
-fyf
-fyf
-fyf
-bIh
-qzr
-pEs
+cbr
+cbr
+mvv
+mvv
+bpD
+tBN
+mvv
+mvv
+doX
+ayf
+hwC
 urt
-bIh
-fyf
+urt
+urt
+urt
+urt
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -79749,62 +82106,77 @@ eHj
 gjP
 uey
 fyf
+uey
+uey
 fyf
-gSt
-igz
-igz
-igz
-igz
-igz
-bEw
+thG
+fyf
+tyL
+gVd
+hVd
+ilh
+tyL
+xuM
+igy
+igy
+igy
+igy
+wCA
+wCA
+kcY
+lhN
+inj
+bWx
+pbj
+pbj
+tRx
+fyf
+fyf
 fyf
 fyf
 thG
-uey
 fyf
 fyf
-bQV
-ePT
-rvr
-exL
-bQV
-mHY
-pAA
-pAA
-pAA
-pAA
-pAA
-pAA
-swU
-bQV
-dzf
-cht
-bGu
-bGu
-bGu
-bGu
-bGu
-ePQ
 fyf
 fyf
+vug
+rpu
+rpu
+rpu
+kGD
 fyf
 kGc
 unI
-erY
-erY
-erY
+hbW
+cdc
+wGJ
 erY
 bkJ
 erY
-erY
-erY
-erY
+wGJ
+wGJ
+gmX
 koD
 dMW
-fyf
-fyf
-fyf
-fyf
+xQu
+gan
+rpu
+iqF
+cbr
+oLV
+iqF
+mvv
+mvv
+bpD
+tBN
+mvv
+mvv
+aBH
+lSz
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -79821,10 +82193,6 @@ gcK
 gbL
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
@@ -79833,21 +82201,10 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-fyf
 gcK
 gcK
 gcK
@@ -80005,36 +82362,27 @@ uRJ
 xYN
 srw
 fyf
-uey
-hAC
-kGc
-dkg
-xKx
-hFY
-xKx
-xKx
-dMW
-hAC
+gSt
+igz
+igz
+bEw
+thG
 fyf
+tyL
+hgJ
+ilh
+iXz
+tyL
 igy
-fyf
-fyf
-fyf
-bQV
-eRO
-exL
-fCA
-bQV
-pAA
-pAA
-pAA
-pAA
-rVB
-blp
-kdS
-fFh
-eyI
-bFJ
+igy
+igy
+igy
+hXv
+qPQ
+uzn
+uXU
+liO
+iHr
 dMW
 fyf
 fyf
@@ -80043,29 +82391,68 @@ fyf
 fyf
 fyf
 fyf
-atL
+thG
+fyf
+fyf
+fyf
+fyf
+sYX
+vXh
+rpu
+taN
+vtj
 fyf
 kGc
 unI
-erY
-erY
-erY
+hbW
+cdc
+wGJ
 erY
 fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
-fyf
-fyf
+fqa
+xpj
+rpu
+rpu
+cbr
+xQu
+uqa
+uqa
+mvv
+bpD
+kMs
+mvv
+mvv
+bpD
+soE
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gbL
 gbL
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
@@ -80074,36 +82461,6 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
 gcK
 gcK
 gcK
@@ -80262,36 +82619,27 @@ uRJ
 tdU
 srw
 uey
-fyf
-fyf
 kGc
-xKx
-uaf
-uaf
-xKx
+eVb
 xKx
 dMW
-fyf
-hAC
 thG
 fyf
-uey
-fyf
-bQV
-eRO
-exL
-gkZ
-bQV
-mMI
-bQV
-bQV
-pAA
-wCA
-bnm
-qZI
-ebc
-eyI
-bFJ
+tyL
+hgJ
+ilh
+jiP
+tyL
+lUg
+tyL
+tyL
+igy
+gGt
+tJk
+puX
+kdi
+liO
+iHr
 dMW
 fyf
 fyf
@@ -80300,53 +82648,62 @@ fyf
 fyf
 fyf
 fyf
+thG
 fyf
+fyf
+fyf
+fyf
+fQV
+odo
+jiX
+dpO
+sYX
 fyf
 kGc
 unI
-erY
-cdc
+hbW
+apk
 erY
 erY
 fAt
 erY
+wGJ
 erY
-erY
-erY
+gmX
 koD
 dMW
-fyf
-fyf
-fyf
-fyf
+fqa
+gsy
+rpu
+rpu
+rpu
+rpu
+qQN
+uqa
+aBH
+hCg
+tBN
+mvv
+mvv
+bpD
+tBN
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
 gbL
 gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
 gbL
 gbL
 gcK
@@ -80357,10 +82714,10 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -80511,7 +82868,7 @@ sVF
 bFJ
 srw
 rjW
-uRJ
+buO
 iFb
 cpH
 gjP
@@ -80519,84 +82876,74 @@ uRJ
 uRJ
 srw
 fyf
-hAC
-fyf
 kGc
 uaf
-oYI
-eTZ
-dkg
-uaf
+xKx
 dMW
-hAC
-fyf
 thG
 fyf
-fyf
-fyf
-bQV
-mgV
-nPO
-gkZ
-bQV
-ipS
-hMs
-bQV
-pAA
-dJY
-iNN
-pAA
-swU
-bQV
-uUL
+tyL
+hmc
+ilM
+jiP
+tyL
+bIV
+nyZ
+tyL
+igy
+gCN
+nRu
+wCA
+kcY
+lhN
+miL
 dMW
 fyf
 fyf
 fyf
+pis
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
+vxC
+uxC
+uxC
+uxC
+uxC
+sYX
+sYX
+sYX
+sYX
+sYX
+cLD
 kGc
 unI
-erY
+hbW
 erY
 erY
 erY
 fAt
-erY
-erY
-erY
-erY
+wGJ
+wGJ
+wGJ
+gmX
 koD
 dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gcK
-gcK
+xQu
+gsP
+rpu
+iBO
+xQu
+uqa
+uqa
+xny
+xWu
+cWG
+daU
+bGM
+mvv
+bpD
+tBN
 gcK
 gcK
 gbL
@@ -80608,15 +82955,25 @@ gbL
 gcK
 gcK
 gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -80776,71 +83133,81 @@ qkf
 mNS
 gjP
 fyf
-uey
-uey
 kGc
-uCW
-qIE
-lae
-xKx
-xKx
+fbH
+trd
 dMW
+thG
+fyf
+tyL
+hnq
+isL
+jzN
+tyL
+bPj
+nCx
+tyL
+igy
+hXv
+tNI
+uzn
+uXU
+liO
+iHr
+dMW
+fyf
 hAC
+hAC
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 thG
 fyf
 fyf
-fyf
-bQV
-pDX
-ook
-qwp
-bQV
-uRU
-pCf
-bQV
-pAA
-rVB
-nkq
-kdS
-fFh
-eyI
-bFJ
-dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+thG
 fyf
 fyf
 kGc
 unI
-erY
+hbW
 erY
 erY
 erY
 fAt
 cdc
-erY
+wGJ
 cdc
-erY
+gmX
 koD
 dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+xQu
+xQu
+xQu
+xQu
+xQu
+iBO
+mvv
+vFD
+mfD
+mfD
+xGH
+mvv
+mvv
+bpD
+ksp
 gcK
 gcK
+gcK
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -80851,16 +83218,6 @@ gbL
 gbL
 gbL
 gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
 gbL
 gcK
 gcK
@@ -80871,9 +83228,9 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
 gcK
 gcK
 wjU
@@ -80941,7 +83298,7 @@ cTp
 fyf
 fyf
 fyf
-fyf
+hAC
 fyf
 fyf
 fyf
@@ -81033,36 +83390,27 @@ ijg
 ijg
 gjP
 gjP
-fyf
-fyf
 kGc
-esP
-cam
-xKx
-xKx
-xKx
+eme
+lae
 dMW
-fyf
-hAC
 thG
 fyf
-uey
-fyf
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-pAA
-wCA
-peG
-qZI
-ebc
-eyI
-bFJ
+tyL
+tyL
+tyL
+tyL
+tyL
+tyL
+tyL
+tyL
+igy
+gGt
+qTa
+puX
+kdi
+liO
+iHr
 dMW
 fyf
 fyf
@@ -81073,34 +83421,43 @@ fyf
 fyf
 fyf
 fyf
+sYX
+maS
+maS
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
 kGc
 unI
-erY
+hbW
 erY
 erY
 erY
 fAt
 cdc
-erY
+wGJ
 cdc
-erY
+gmX
 koD
 dMW
+xQu
+gvN
+rpu
+rpu
+lvc
+oMR
+mvv
+bpD
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
+sWy
+tBN
+ulY
+aBH
+hCg
+lYx
 gcK
 gcK
 gcK
@@ -81128,10 +83485,10 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
+gcK
 gcK
 fTT
 mwp
@@ -81198,7 +83555,7 @@ vQS
 fyf
 fyf
 fyf
-fyf
+hAC
 fyf
 fyf
 fyf
@@ -81290,74 +83647,74 @@ uRJ
 uRJ
 uRJ
 gjP
-uey
-uey
 kGc
-esP
 xKx
-xKx
-uaf
 xKx
 dMW
-tOH
+thG
 fyf
+tyL
 igy
-fyf
-fyf
-fyf
-bQV
-pAA
-pAA
-pAA
-pAA
-uBE
-pAA
-pAA
-pAA
-pAA
-pAA
-pAA
-rSf
-bQV
-bFJ
+igy
+igy
+igy
+bPk
+wCA
+wCA
+wCA
+wCA
+wCA
+wCA
+kfx
+lhN
+iHr
 dMW
 fyf
+hAC
+sYX
+sYX
+sYX
+sYX
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+vtj
+uKT
+vPh
+uCO
+csO
+rpu
+rpu
+lxk
+kGD
 kGc
 unI
-cdc
+hbW
 erY
 mmK
 erY
 fAt
-erY
-erY
+wGJ
+wGJ
 cdc
-erY
+gmX
 koD
 dMW
+xQu
+bHo
+cbr
+mvv
+lDd
+mvv
+mvv
+doX
+wDc
 fyf
+nlO
+mfD
+hCg
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
+aRT
 gcK
 gcK
 gcK
@@ -81385,10 +83742,10 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-wjt
-fyf
+gcK
+gcK
+gcK
+gcK
 gcK
 tOV
 fTT
@@ -81453,7 +83810,7 @@ mNU
 mNU
 fyf
 fyf
-fyf
+hAC
 fyf
 fyf
 fyf
@@ -81547,76 +83904,76 @@ uRJ
 wRG
 xYN
 srw
-fyf
-fyf
 kGc
-esP
-uaf
-wmJ
-dkg
 xKx
+uaf
 dMW
-hAC
-uey
 thG
-uey
 fyf
-fyf
-bQV
-pAA
-rVB
-blp
-eAl
-smh
-sQC
-rVB
-blp
-pAA
-bQV
-bQV
-bQV
-bQV
-ptf
+tyL
+igy
+hXv
+jEd
+aYp
+bRF
+dza
+pcP
+qPQ
+wCA
+lhN
+lhN
+lhN
+lhN
+bCm
 edA
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+wEO
+sft
+sYX
+sYX
+sYX
+sYX
+sYX
+jEl
+dhC
+uCO
+kzl
+rpu
+caq
+sph
+sYX
 kGc
 unI
-erY
+hbW
 erY
 erY
 erY
 fAt
+wGJ
 erY
-erY
-cdc
-erY
+wGJ
+gmX
 koD
 dMW
+ewa
+gzQ
+hiG
+mvv
+mvv
+mvv
+mvv
+xQu
+ymd
+cWG
+cWG
+cWG
+wDc
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+tBN
+haP
+bpD
 fyf
 gcK
 gcK
@@ -81642,11 +83999,11 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -81714,7 +84071,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+hAC
 fyf
 tBN
 mvv
@@ -81730,7 +84087,7 @@ sYX
 sYX
 sYX
 fyf
-fyf
+qTY
 kGc
 ofX
 hbW
@@ -81792,7 +84149,7 @@ cpK
 gjP
 gva
 uRJ
-uRJ
+buO
 uRJ
 jnX
 iFb
@@ -81804,76 +84161,76 @@ uRJ
 gwW
 jZb
 srw
-hAC
-hAC
 kGc
-uaf
-xKx
-uaf
-xKx
-xKx
+foN
+dkg
 dMW
-uey
+thG
 fyf
-igy
-fyf
-fyf
-uey
-bQV
-pAA
-wCA
-peG
-pAA
-pAA
-bts
-amy
-peG
-pAA
-bQV
-sQs
 tyL
-bQV
-yeJ
+igy
+gGt
+jEX
+igy
+wCA
+nHi
+pjQ
+qTa
+wCA
+lhN
+uCn
+peG
+lhN
+aaS
 ssm
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+aYU
+hRZ
+uCO
+iNO
+uCO
+vFc
+uCO
+vei
+dhC
+uCO
+jKx
+rpu
+rpu
+msy
+vtj
 kGc
 unI
+hbW
 erY
-erY
-erY
+wGJ
 erY
 khX
 sCK
 erY
-erY
-erY
+wGJ
+gmX
 koD
 dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+fbM
+gCc
+hlh
+mfD
+xGH
+xQu
+xQu
+vKd
+bHt
+mvv
+bHt
+nXd
+fej
+fiB
+daU
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -81899,11 +84256,11 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-wjt
-fyf
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -82058,79 +84415,79 @@ iFb
 cpH
 gjP
 uRJ
-iFb
+bzq
 wXv
 gjP
-fyf
-fyf
 kGc
-uaf
-dkg
 uCW
 xKx
-xKx
 dMW
-hAC
-hAC
 thG
-uey
 fyf
-fyf
-bQV
+tyL
+hpj
+igy
+igy
+igy
+lYu
+nJM
+wCA
+wCA
+wCA
 iwm
-pAA
-pAA
-pAA
-urL
-gfc
-pAA
-pAA
-pAA
-uZj
-hXv
-jXV
-bQV
-uUS
+uCS
+kfJ
+lhN
+xCX
 nPX
 uey
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+jgq
+sYX
+uCO
+uCO
+uCO
+jgq
+uCO
+uCO
+sDp
+uCO
+uCO
+uCO
+sDp
+sYX
+sYX
 kGc
 unI
-erY
-erY
-erY
+hbW
+wGJ
+wGJ
 erY
 fAt
 erY
 erY
-erY
-erY
+apk
+gmX
 koD
 dMW
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+nlO
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+hCg
 fyf
 fyf
 fyf
@@ -82158,10 +84515,10 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 sYX
@@ -82318,57 +84675,57 @@ jZb
 uRJ
 jZb
 gjP
-hAC
-uey
 kGc
-xKx
-uCW
-xKx
-xKx
+fqS
 xKx
 dMW
-uey
-fyf
 thG
 fyf
-fyf
-fyf
-bQV
-pAA
-kdS
-fFh
-aXk
-pAA
+tyL
+igy
+iGP
+jFb
+loo
+wCA
+nNZ
+pnw
 uXU
-kQE
-fFh
-pAA
-bQV
-bQV
-bQV
-bQV
-nHi
+wCA
+lhN
+lhN
+lhN
+lhN
+rFD
 nPX
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+rpu
+hFM
+rpu
+hFM
+hFM
+rpu
+uCO
+tkS
+rpu
+uCO
+tzk
+tzk
+rpu
+tzk
+kGD
 kGc
 unI
-erY
+hbW
 cdc
-erY
+wGJ
 erY
 fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -82388,7 +84745,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+jxH
 fyf
 fyf
 fyf
@@ -82411,15 +84768,15 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 sYX
 tKZ
@@ -82575,77 +84932,77 @@ qkf
 cnX
 nHE
 srw
-fyf
-fyf
-kGc
-xKx
-uaf
-uCW
-xKx
-xKx
-dMW
-fyf
-uey
+nJW
+ptf
+ptf
+edA
 thG
 fyf
-hAC
-fyf
-bQV
-pAA
-qZI
-ebc
-swU
-dsi
-iNN
-qZI
-ebc
-pAA
-uZj
-hXv
-rNv
-bQV
-uUS
+tyL
+igy
+iIS
+jKV
+lpd
+lZY
+nRu
+puX
+kdi
+wCA
+iwm
+uCS
+wQZ
+lhN
+xCX
 nPX
 hAC
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+rpu
+jVg
+rkZ
+pFS
+jVg
+foz
+sDp
+trr
+aug
+sDp
+rpu
+trr
+sKH
+tzk
+sYX
 kGc
 unI
+hbW
+wGJ
+wGJ
+erY
+srt
+wGJ
 erY
 erY
-erY
-erY
-fAt
-cdc
-erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
 fyf
+jxH
+jxH
+jxH
+fyf
+fyf
+fyf
+jxH
+jxH
+jxH
+jxH
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+jxH
+igU
 fyf
 fyf
 fyf
@@ -82667,17 +85024,17 @@ fyf
 fyf
 upX
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 fyf
 fyf
 fyf
@@ -82833,56 +85190,56 @@ iFb
 jZb
 srw
 fyf
-hAC
-kGc
-dkg
-cpK
-nWl
-xKx
-xKx
-dMW
-hAC
-hAC
+fyf
+fyf
+fyf
 thG
 fyf
-fyf
-fyf
-bQV
-pAA
-pAA
-pAA
-pAA
-sXy
-pAA
-pAA
-pAA
-pAA
-bQV
-hXv
-vlg
-bQV
-hzb
+tyL
+igy
+igy
+igy
+igy
+mar
+wCA
+wCA
+wCA
+wCA
+lhN
+uCS
+wRb
+lhN
+uPD
 jMC
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+rpu
+rMz
+rMz
+rpu
+rMz
+aug
+uCO
+rpu
+rpu
+uCO
+wYv
+dss
+rpu
+tzk
+kGD
 kGc
 unI
+hbW
+erY
+wGJ
+wGJ
+srt
+wGJ
 erY
 erY
-erY
-erY
-fAt
-erY
-erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -83005,7 +85362,7 @@ gcK
 gcK
 gcK
 fyf
-fyf
+hAC
 sqA
 tBN
 mvv
@@ -83090,56 +85447,56 @@ uRJ
 qkf
 gjP
 uey
-uey
-nJW
-ptf
-ptf
-ptf
-ptf
-ptf
-edA
-uey
+fyf
+fyf
 fyf
 thG
 fyf
-fyf
-fyf
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-oCi
+tyL
+tyL
+tyL
+tyL
+tyL
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+gbS
 ssm
 hAC
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+sYX
+sYX
+kom
+maS
+sYX
+sYX
+sYX
+yjG
+yjG
+sYX
+sYX
+kom
+qUK
+sYX
+sYX
 kGc
 unI
-erY
+hbW
 erY
 cdc
+wGJ
+srt
+wGJ
 erY
-fAt
 erY
-erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -83262,7 +85619,7 @@ gcK
 gcK
 gcK
 fyf
-fyf
+hAC
 fyf
 tBN
 mvv
@@ -83350,14 +85707,7 @@ feL
 feL
 feL
 feL
-feL
-feL
-feL
-feL
-feL
-feL
-feL
-iys
+fTW
 igz
 igz
 igz
@@ -83368,6 +85718,13 @@ igz
 igz
 igz
 igz
+igz
+igz
+igz
+hgX
+cpK
+cpK
+jkJ
 igz
 igz
 igz
@@ -83388,15 +85745,15 @@ igz
 igz
 hgX
 unI
+hbW
 erY
-erY
-erY
-erY
+wGJ
+wGJ
 bkJ
 erY
 erY
 erY
-erY
+gmX
 koD
 jkJ
 igz
@@ -83604,10 +85961,10 @@ ybI
 ybI
 ybI
 dkP
-sTa
-sTa
-hkW
-sTa
+ybI
+ybI
+ybI
+ybI
 ybI
 ybI
 ybI
@@ -83645,15 +86002,15 @@ ybI
 ybI
 ybI
 onk
+hbW
 erY
 erY
-erY
-erY
-khX
+wGJ
+srt
 erY
 erY
 cdc
-erY
+gmX
 fLc
 ybI
 ybI
@@ -83905,7 +86262,7 @@ idu
 erY
 erY
 erY
-erY
+wGJ
 fAt
 erY
 erY
@@ -84161,8 +86518,8 @@ ehN
 ehN
 erY
 erY
-erY
-erY
+wGJ
+wGJ
 fAt
 erY
 liv
@@ -84419,9 +86776,9 @@ kaM
 erY
 erY
 cdc
-erY
+wGJ
 fAt
-erY
+wGJ
 erY
 erY
 erY
@@ -84673,15 +87030,15 @@ ees
 ees
 ees
 muk
+hbW
 erY
 erY
-erY
-erY
+wGJ
 bbU
+wGJ
 erY
 erY
-erY
-erY
+gmX
 geM
 ees
 ees
@@ -84930,14 +87287,14 @@ iHQ
 gts
 uCW
 unI
-erY
+hbW
 sCK
 erY
-erY
+wGJ
 txr
-cdc
+wGJ
 erY
-erY
+wGJ
 bWB
 koD
 sUX
@@ -85187,15 +87544,15 @@ uKY
 eDg
 uCW
 unI
+hbW
 erY
 erY
-erY
-erY
+wGJ
 fAt
-erY
-erY
+wGJ
+wGJ
 cdc
-erY
+gmX
 eQb
 dMW
 jxH
@@ -85403,10 +87760,10 @@ fyf
 jMj
 wdJ
 tsT
-tsT
+fru
 tsT
 niH
-xed
+fVZ
 qwi
 wdJ
 naZ
@@ -85444,15 +87801,15 @@ uKY
 eDg
 uCW
 unI
+hbW
 erY
 erY
-erY
-erY
+wGJ
 fAt
 erY
 erY
-erY
-erY
+wGJ
+gmX
 nNn
 dMW
 nDd
@@ -85663,7 +88020,7 @@ qwi
 twI
 qwi
 qwi
-qwi
+jMj
 qwi
 nPV
 niH
@@ -85701,15 +88058,15 @@ shp
 gts
 cpK
 unI
-erY
+hbW
 erY
 qnz
 erY
 fAt
 erY
 erY
-erY
-erY
+wGJ
+gmX
 koD
 dMW
 jRX
@@ -85918,8 +88275,8 @@ qwi
 hsh
 qwi
 tsT
-tsT
-fmm
+fru
+frx
 wzw
 qwi
 qwi
@@ -85958,7 +88315,7 @@ vYv
 etf
 cpK
 unI
-erY
+hbW
 erY
 cdc
 erY
@@ -85966,7 +88323,7 @@ fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 jRX
@@ -86176,7 +88533,7 @@ qwi
 qwi
 rZf
 niH
-tsT
+frz
 gOf
 qwi
 fyf
@@ -86215,15 +88572,15 @@ vYv
 gts
 cpK
 unI
+hbW
 erY
 erY
 erY
-erY
-fAt
-erY
+srt
 erY
 erY
 erY
+gmX
 koD
 dMW
 kGc
@@ -86433,7 +88790,7 @@ hsh
 qwi
 toF
 tsT
-tsT
+fuN
 irk
 qwi
 fyf
@@ -86472,7 +88829,7 @@ uKY
 nba
 cpK
 unI
-erY
+hbW
 erY
 liv
 erY
@@ -86480,7 +88837,7 @@ khX
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 gts
@@ -86729,15 +89086,15 @@ uKY
 gts
 cpK
 unI
+hbW
 erY
 erY
-erY
-mmK
+ril
 evL
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 gts
@@ -86971,7 +89328,7 @@ unI
 hbW
 erY
 erY
-erY
+viM
 erY
 qnz
 gmX
@@ -86986,15 +89343,15 @@ gts
 gts
 uCW
 unI
+hbW
 erY
 erY
-erY
-erY
+wGJ
 khX
 erY
 erY
 cdc
-erY
+gmX
 koD
 dMW
 gts
@@ -87243,15 +89600,15 @@ uaf
 uaf
 uCW
 unI
-erY
+hbW
 cdc
 erY
-erY
-ltl
-erY
-erY
+wGJ
+kws
 erY
 erY
+erY
+gmX
 koD
 dMW
 gts
@@ -87285,7 +89642,7 @@ gcK
 gcK
 gcK
 gcK
-gbL
+gcK
 gcK
 gcK
 gcK
@@ -87500,15 +89857,15 @@ uaf
 uaf
 uCW
 unI
+hbW
 erY
 erY
-erY
-erY
-fAt
+wGJ
+srt
 erY
 erY
 sCK
-erY
+gmX
 koD
 dMW
 gts
@@ -87541,14 +89898,14 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+hom
+hom
+hom
+hom
+hom
+hom
+hom
+hom
 gcK
 gcK
 gcK
@@ -87757,7 +90114,7 @@ uaf
 uCW
 uCW
 unI
-erY
+hbW
 erY
 erY
 erY
@@ -87765,7 +90122,7 @@ fAt
 erY
 erY
 sCK
-erY
+gmX
 koD
 dMW
 jIV
@@ -87798,23 +90155,23 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 hom
+wZd
+xcg
+tIY
+tFr
+tFr
+rZG
 hom
-hom
-hom
-hom
-hom
+fIk
+uag
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -88014,7 +90371,7 @@ cpK
 ofh
 uCW
 unI
-erY
+hbW
 erY
 erY
 erY
@@ -88022,7 +90379,7 @@ fAt
 erY
 erY
 sCK
-erY
+gmX
 eQb
 dMW
 dDC
@@ -88056,6 +90413,16 @@ gcK
 gcK
 gcK
 hom
+xac
+hjc
+hjc
+hjc
+hjc
+hjc
+hom
+ozI
+pIz
+frY
 hom
 hom
 hom
@@ -88063,20 +90430,10 @@ hom
 hom
 hom
 hom
-gcK
-gcK
-gcK
-hom
-xNm
-xNm
-xNm
-xNm
 hom
 hom
 hom
 hom
-hom
-gcK
 gcK
 gcK
 ktB
@@ -88271,15 +90628,15 @@ uCW
 uCW
 cpK
 unI
-erY
-erY
+hbW
+wGJ
 erY
 erY
 fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -88304,7 +90661,7 @@ hom
 cjV
 hbO
 qSM
-xNm
+tTT
 hom
 gcK
 gcK
@@ -88314,26 +90671,26 @@ gcK
 gcK
 hom
 iNI
-qbe
-uOr
-nrB
-nrB
+hjc
+hjc
+hjc
+hjc
 jhx
 hom
-nfu
-gcK
-gcK
+ozI
+pIz
+frY
 hom
-pck
-pck
-xNm
-xNm
+shW
+tTT
+shW
+gUq
+gUq
 hom
 oHR
 pck
-oWU
+dtI
 hom
-gcK
 gcK
 gcK
 gcK
@@ -88528,15 +90885,15 @@ cpK
 cpK
 cpK
 unI
-erY
-cdc
-erY
+hbW
+wGJ
+wGJ
 erY
 iTB
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 sZt
@@ -88561,7 +90918,7 @@ hom
 cjV
 cjV
 ata
-xNm
+tTT
 hom
 gcK
 gcK
@@ -88574,23 +90931,23 @@ ftz
 hjc
 hjc
 hjc
-hjc
+qob
 hjc
 hom
-quy
-uag
-gcK
+ozI
+pIz
+frY
 hom
 kSt
-pck
-xNm
-cLZ
+tTT
+kSt
+gUq
+tag
 hom
-xNm
-xNm
+tTT
+tTT
 vVR
 hom
-gcK
 gcK
 gcK
 gcK
@@ -88747,9 +91104,9 @@ gcK
 gcK
 gbL
 gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -88785,15 +91142,15 @@ uCW
 cpK
 uCW
 unI
-erY
-erY
-erY
+hbW
+wGJ
+wGJ
 erY
 fAt
 erY
 cdc
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -88824,30 +91181,30 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+sVl
+sVl
 hom
-bRF
-hjc
+hom
 hvk
-hjc
-hjc
-oXV
+hvk
+rfx
+hom
+dvo
 hom
 ozI
 pIz
-frY
-hom
-xNm
-xNm
-xNm
+gue
+vfR
+kSt
+tTT
+kSt
 gUq
+oKf
 hom
 aBk
-xNm
-ebl
+tTT
+pzV
 hom
-gcK
 gcK
 gcK
 gcK
@@ -89028,7 +91385,7 @@ gcK
 gcK
 gcK
 gcK
-gts
+gcK
 ghg
 ghg
 gts
@@ -89042,15 +91399,15 @@ gts
 gts
 cpK
 unI
+hbW
 erY
 erY
-erY
-erY
+wGJ
 fAt
 erY
 erY
-erY
-erY
+wGJ
+gmX
 koD
 dMW
 fyf
@@ -89070,41 +91427,41 @@ gts
 ktB
 hom
 hom
-dvo
+vme
 hom
 hbO
 upj
 ata
-uIV
+rfR
 hom
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+sVl
+sVl
 hom
 nTm
-hjc
-hjc
-hjc
-hOs
-hjc
-hom
-ozI
-pIz
-frY
+tTT
+tTT
+tTT
+xwR
+tTT
 rgS
-pck
-pck
-xNm
-cLZ
+jEp
+pIz
+pIz
+vme
+tTT
+tTT
+tTT
+gUq
+oXp
 hom
 hom
-dvo
+vme
 hom
 hom
-gcK
 gcK
 gcK
 gcK
@@ -89268,6 +91625,10 @@ gcK
 gcK
 gcK
 gcK
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
@@ -89282,10 +91643,6 @@ gcK
 gcK
 gcK
 gcK
-gts
-gts
-gts
-gts
 uCW
 cpK
 cpK
@@ -89299,15 +91656,15 @@ vYv
 asF
 cpK
 unI
+hbW
 erY
 erY
-erY
-erY
+wGJ
 iTB
 erY
 erY
-erY
-erY
+wGJ
+gmX
 koD
 dMW
 fyf
@@ -89332,36 +91689,36 @@ uGF
 cjV
 hbO
 dPe
-xNm
+tTT
 hom
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-hom
+sVl
+sVl
 hom
 jNl
 jNl
-isv
-hom
-dvo
-hom
-ozI
+jNl
+jNl
+tTT
+tTT
+rgS
+jEp
 pIz
-goK
-hom
-pck
-pck
-xNm
-xNm
+cVV
+vfR
+kSt
+tTT
+kSt
+gUq
+oKf
 hom
 kpd
-xNm
-ebl
+tTT
+pzV
 hom
-gcK
 gcK
 gcK
 gcK
@@ -89519,9 +91876,18 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 gcK
-kEh
 gcK
 gcK
 gcK
@@ -89534,15 +91900,6 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-tJk
-xya
-xya
-gts
 uCW
 cah
 uCW
@@ -89556,15 +91913,15 @@ vYv
 asF
 cpK
 unI
+hbW
 erY
-erY
-erY
-erY
+wGJ
+wGJ
 fAt
 erY
-erY
-erY
-erY
+wGJ
+wGJ
+gmX
 eEz
 dMW
 fyf
@@ -89589,36 +91946,36 @@ hom
 hom
 hom
 hom
-dvo
+vme
 hom
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-hom
+sVl
+sVl
+ucJ
 qWU
-xNm
-xNm
-xNm
-xNm
-xNm
+xor
+jCg
+tHw
+tTT
+tTT
 rgS
 jEp
 pIz
-pIz
-bbV
-xNm
-xNm
-xNm
-xNm
-dvo
-xNm
-xNm
+frY
+hom
+kSt
+tTT
+kSt
+gUq
+tag
+hom
+tTT
+rfR
 vHe
 hom
-gcK
 gcK
 gcK
 gcK
@@ -89775,12 +92132,22 @@ gts
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 fyf
 fyf
 fyf
-thG
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+pAm
+fyf
 gcK
 gcK
 gcK
@@ -89790,16 +92157,6 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gts
-xya
-mdM
-iIS
 cpK
 uaf
 uaf
@@ -89813,15 +92170,15 @@ vYv
 lLB
 cpK
 unI
+hbW
 erY
-erY
-erY
-erY
+wGJ
+cdc
 fAt
 erY
-erY
+wGJ
 cdc
-erY
+gmX
 koD
 dMW
 fyf
@@ -89841,41 +92198,41 @@ gcK
 gcK
 hom
 aof
-xNm
-uIV
-dvo
+tTT
+tTT
+vme
 oMY
-fqL
-xNm
+tTT
+tTT
 hom
 gcK
 gcK
 gcK
 gcK
-syr
-gcK
+sVl
+sVl
 hom
+tQV
 bla
+tQV
 bla
-bla
-bla
-bla
-xNm
-rgS
-jEp
+tTT
+tTT
+hom
+fbD
 pIz
-cVV
+frY
 hom
-fqL
-xNm
-xNm
-xNm
+shW
+tTT
+shW
+gUq
+gUq
+iMd
+tTT
+xcL
+xcL
 hom
-oHR
-xNm
-oHR
-hom
-gcK
 gcK
 gcK
 gcK
@@ -90032,31 +92389,31 @@ gts
 gcK
 gcK
 fyf
-fyf
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 gcK
 gcK
 gcK
 gcK
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+dje
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+pAm
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gts
-iOF
-xya
-gts
 cpK
 uaf
 uCW
@@ -90070,15 +92427,15 @@ vYv
 asF
 uCW
 unI
+hbW
 erY
-erY
-cdc
+wGJ
 cdc
 fAt
 erY
-erY
+wGJ
 cdc
-erY
+gmX
 koD
 jkJ
 igz
@@ -90102,24 +92459,24 @@ rgS
 hom
 hom
 pSu
-oMY
-xNm
+fMv
+tTT
 hom
 gcK
 gcK
 gcK
-gcK
-syr
-gcK
+sVl
+sVl
+sVl
 hom
-hHi
-dgS
-gQW
-tHw
-ucJ
-xNm
-rgS
-jEp
+nTm
+tTT
+tTT
+tTT
+tTT
+tTT
+qIc
+pIz
 pIz
 frY
 hom
@@ -90132,7 +92489,7 @@ hom
 hom
 hom
 hom
-gcK
+hom
 gcK
 gcK
 gcK
@@ -90200,7 +92557,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+qTY
 fyf
 dit
 eQx
@@ -90289,31 +92646,31 @@ gts
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gts
-gts
-gts
-gts
+fyf
+fyf
+qOV
+hqC
+hqC
+hqC
+hqC
+ghx
+fyf
+eqo
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+xJA
+fyf
+fyf
+hej
 dkg
 caa
 uaf
@@ -90327,15 +92684,15 @@ gts
 gts
 uCW
 unI
+hbW
 erY
-erY
-erY
-erY
+wGJ
+cdc
 fAt
 erY
 erY
-erY
-erY
+wGJ
+gmX
 dsW
 ybI
 hkW
@@ -90359,24 +92716,24 @@ uag
 brE
 hom
 pSu
-xNm
+tTT
 oMY
 hom
 hom
 hom
 hom
 syr
-syr
-gcK
+sVl
+sVl
 hom
-tQV
+gZJ
 fmn
-tQV
+jNl
 fmn
-tQV
-eLb
+tTT
+tTT
 hom
-fbD
+gaF
 pIz
 frY
 nfu
@@ -90546,31 +92903,31 @@ gts
 fyf
 fyf
 fyf
-fyf
-sqA
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gts
+fyf
+fyf
+tBN
+rjH
+rjH
+rjH
+rjH
+bpD
+fyf
+fyf
+fyf
+fyf
+sYX
+sYX
+sYX
+sYX
+sYX
+fyf
+xJA
+fyf
+fyf
+hej
 rRt
 cpK
 dkg
@@ -90584,10 +92941,10 @@ uCW
 uCW
 cpK
 unI
+hbW
 erY
-erY
-erY
-erY
+wGJ
+wGJ
 bkJ
 erY
 erY
@@ -90614,26 +92971,26 @@ kbS
 pIz
 pIz
 pIz
-dvo
-xNm
-xNm
-tQx
+vme
+tTT
+tTT
+vHe
 hom
 tHw
 rEd
 hom
 syr
 syr
-gcK
-hom
-qWU
-xNm
-xNm
-xNm
-xNm
-xNm
-saf
-pIz
+sVl
+ucJ
+tHw
+xBK
+tfc
+xor
+tTT
+lny
+rgS
+ozI
 pIz
 hgM
 hom
@@ -90803,30 +93160,30 @@ gts
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-kEh
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+fyf
+fyf
+fyf
+tBN
+mvv
+mvv
+mvv
+mvv
+bpD
+fyf
+fyf
+rsE
+sYX
+sYX
+qDS
+nwG
+sUu
+sYX
+sYX
+xJA
+fyf
+fyf
 hej
 cpK
 uCW
@@ -90841,7 +93198,7 @@ cpK
 uCW
 cpK
 unI
-erY
+hbW
 erY
 erY
 erY
@@ -90874,23 +93231,23 @@ cVV
 hom
 pck
 wxR
-xNm
-dvo
-xNm
+tTT
+vme
+tTT
 vHe
 hom
 syr
 syr
-gcK
+syr
 hom
-bla
-hxQ
-bla
-hxQ
-bla
-xNm
-hom
-qEj
+tQV
+tQV
+tQV
+tQV
+tTT
+tTT
+rgS
+ozI
 pIz
 frY
 rgS
@@ -91060,29 +93417,29 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-thG
-fyf
+sYX
 fyf
 fyf
 fyf
 fyf
+tBN
+rjH
+rjH
+rjH
+rjH
+bpD
 fyf
 fyf
 fyf
+srM
+lrB
+jZk
+jZk
+jZk
+cVW
+sYX
+xJA
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
 fyf
 hej
 cpK
@@ -91098,7 +93455,7 @@ gts
 gts
 cpK
 unI
-erY
+hbW
 erY
 erY
 erY
@@ -91134,19 +93491,19 @@ tHw
 nbD
 hom
 pBM
-xNm
+tTT
 hom
 syr
 syr
-gcK
+syr
 hom
-tHw
+hom
 ucJ
-lpk
-dgS
-hHi
-xNm
-rgS
+ucJ
+ucJ
+ucJ
+hom
+hom
 ozI
 pIz
 tjI
@@ -91154,7 +93511,7 @@ hom
 dUv
 vDg
 dUv
-xNm
+tTT
 hom
 hom
 hom
@@ -91317,28 +93674,28 @@ fyf
 fyf
 fyf
 sqA
+xJA
 fyf
 fyf
 fyf
 fyf
+nlO
+mfD
+mfD
+mfD
+mfD
+hCg
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
+pya
+jZk
+jZk
+jZk
+jZk
+jZk
+srM
+xJA
 fyf
 fyf
 hej
@@ -91355,15 +93712,15 @@ vYv
 asF
 cpK
 unI
-erY
+hbW
 erY
 erY
 sCK
 fAt
+wGJ
 erY
-erY
-erY
-erY
+wGJ
+gmX
 xqQ
 ees
 ees
@@ -91376,12 +93733,12 @@ fyf
 fyf
 fyf
 ier
-bPk
-hmc
-kiW
-kiW
-kiW
-qTa
+nfu
+nfu
+nfu
+nfu
+nfu
+nfu
 vPA
 pIz
 frY
@@ -91395,22 +93752,22 @@ oHR
 hom
 syr
 syr
-gcK
-hom
-tQV
-tQV
-tQV
-tQV
-tQV
-xNm
-rgS
-ozI
+nfu
+wSP
+eEt
+xFv
+dWw
+wlX
+wlX
+wlX
+wSS
+tdu
 pIz
 pIz
 vme
-xNm
-xNm
-xNm
+tTT
+tTT
+tTT
 xox
 hom
 aBk
@@ -91574,6 +93931,13 @@ fyf
 fyf
 fyf
 fyf
+xJA
+fyf
+qOV
+hqC
+hqC
+hqC
+ghx
 fyf
 fyf
 fyf
@@ -91581,21 +93945,14 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
+srM
+jZk
+iMJ
+sNE
+mdM
+jZk
+spC
+xJA
 fyf
 fyf
 hej
@@ -91612,15 +93969,15 @@ vYv
 lLB
 cpK
 unI
-erY
+hbW
 erY
 xuL
 erY
 fAt
+wGJ
 erY
 erY
-erY
-erY
+gmX
 koD
 sUX
 ptf
@@ -91633,12 +93990,12 @@ fyf
 fjT
 fyf
 ier
-mCG
-pIz
-pIz
-pIz
-pIz
-sDj
+nfu
+nfu
+nfu
+nfu
+nfu
+nfu
 ozI
 pIz
 frY
@@ -91653,25 +94010,25 @@ hom
 syr
 syr
 nRz
-hom
-hom
-hom
-hom
-hom
-hom
-hom
-hom
-ozI
+jEp
+frY
+yiF
+qAR
+pIz
+pIz
+pIz
+bhr
+tdu
 pIz
 ulc
 hom
 aPB
-xNm
-xNm
-xNm
-dvo
-xNm
-xNm
+tTT
+lny
+tTT
+vme
+lny
+tTT
 tQV
 hom
 gcK
@@ -91831,28 +94188,28 @@ fyf
 fyf
 fyf
 fyf
+xJA
+fyf
+tBN
+mvv
+mvv
+mvv
+bpD
+mcz
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rtR
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
+sYX
+tKZ
+tKZ
+sYX
+uCO
+uCO
+uCO
+jZk
+aQm
+sYX
+xJA
 fyf
 fyf
 hej
@@ -91869,15 +94226,15 @@ vYv
 lLB
 cpK
 unI
+hbW
 erY
 erY
 erY
+kws
+wGJ
 erY
-bkJ
-erY
-erY
-cdc
-erY
+wGJ
+gmX
 koD
 dMW
 jJb
@@ -91890,13 +94247,13 @@ fyf
 fyf
 gxn
 ier
-mCG
-pIz
-aep
-pIz
-pIz
-dTT
-fbD
+nfu
+nfu
+nfu
+nfu
+nfu
+nfu
+ozI
 pIz
 frY
 hom
@@ -91910,15 +94267,15 @@ hom
 syr
 syr
 buG
-xor
-uag
-eEt
-quy
-uag
-uag
-uag
+jEp
+frY
+yiF
+pIz
+pIz
+pIz
+pIz
 kut
-ozI
+kbS
 pIz
 hgM
 hom
@@ -91928,7 +94285,7 @@ dvo
 hom
 hom
 mHy
-xNm
+tTT
 jxO
 hom
 gcK
@@ -92088,28 +94445,28 @@ fyf
 fyf
 fyf
 fyf
+xJA
 fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+tBN
+bGM
+mvv
+mvv
+bpD
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
+sYX
+tOP
+jZk
+wUv
+nLD
+wTE
+uCO
+iHP
+rZx
+sYX
+xJA
 fyf
 fyf
 hej
@@ -92126,15 +94483,15 @@ vYv
 asF
 cpK
 unI
-erY
+hbW
 cdc
 erY
 erY
 khX
-erY
-erY
-erY
-erY
+wGJ
+wGJ
+wGJ
+gmX
 eEz
 dMW
 fyf
@@ -92146,14 +94503,14 @@ fyf
 fyf
 fyf
 fyf
-hwC
+ier
 mCG
-pIz
-pIz
-pIz
-pIz
-obV
-pIz
+nfu
+nfu
+nfu
+nfu
+nfu
+ozI
 pIz
 frY
 hom
@@ -92161,27 +94518,27 @@ fpg
 kKs
 kKs
 jIn
-xNm
+tTT
 vHe
 hom
 syr
 syr
 buG
-jEp
-nZV
-xkl
 ozI
-aFF
-pIz
-sDr
 frY
-ozI
+yiF
+pIz
+pIz
+pIz
+pIz
+uZf
+pIz
 pIz
 frY
 hom
 kpd
-xNm
-xNm
+tTT
+tTT
 vHe
 hom
 hom
@@ -92345,28 +94702,28 @@ fyf
 fyf
 fyf
 fyf
+sYX
+fyf
+nlO
+mfD
+mfD
+mfD
+hCg
 fyf
 fyf
-hAC
+rsE
 fyf
-fyf
-fyf
-fyf
-rtR
-fyf
-fyf
-fyf
-rtR
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-kEh
-fyf
+spC
+jZk
+uCT
+jZk
+jZk
+iJS
+uCO
+jZk
+yiv
+tKZ
+xJA
 fyf
 fyf
 hej
@@ -92383,15 +94740,15 @@ gts
 gts
 cpK
 unI
+hbW
 erY
 erY
-erY
-erY
+wGJ
 fAt
-erY
-erY
+wGJ
+wGJ
 cdc
-erY
+gmX
 koD
 dMW
 fyf
@@ -92402,14 +94759,14 @@ fyf
 fyf
 tTV
 fyf
-gcK
-gcK
+fyf
+ier
 mCG
-pIz
-pIz
-aep
-pIz
-uXa
+nfu
+nfu
+nfu
+nfu
+nfu
 tnu
 pIz
 frY
@@ -92425,23 +94782,23 @@ syr
 syr
 buG
 jEp
-nZV
-xkl
-ozI
-pIz
-pIz
-pIz
 frY
-ozI
+yiF
+pIz
+pIz
+pIz
+pIz
+rqx
+xJY
 pIz
 frY
 hom
 qBu
-xNm
+tTT
 qBu
-xNm
-dvo
-xNm
+tTT
+vme
+tTT
 pck
 tHw
 hom
@@ -92601,6 +94958,9 @@ tKZ
 fyf
 fyf
 fyf
+qOV
+cWG
+ghx
 fyf
 fyf
 fyf
@@ -92610,20 +94970,17 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-trW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
+srM
+tPA
+uFK
+wXq
+jZk
+hfK
+uCO
+sxs
+uCO
+sYX
+xJA
 fyf
 fyf
 hej
@@ -92640,15 +94997,15 @@ cpK
 cpK
 cpK
 unI
+hbW
 erY
 erY
-erY
-erY
+wGJ
 fAt
 erY
-erY
-erY
-erY
+wGJ
+wGJ
+gmX
 koD
 dMW
 fyf
@@ -92659,14 +95016,14 @@ fyf
 fyf
 fyf
 fyf
-gcK
-gcK
+fyf
+ier
 mCG
-pIz
-pIz
-pIz
-pIz
-sDj
+nfu
+nfu
+nfu
+nfu
+nfu
 ozI
 pIz
 frY
@@ -92682,24 +95039,24 @@ syr
 syr
 buG
 jEp
-nZV
-xkl
-ozI
-sDr
-pIz
-aFF
 frY
-ozI
+yiF
+pIz
+pIz
+pIz
+qAR
+bhr
+tdu
 pIz
 frY
 rgS
 nMk
-xNm
+tTT
 pRl
-xNm
+tTT
 hom
-xNm
-xNm
+tTT
+tTT
 vVR
 hom
 gcK
@@ -92858,29 +95215,29 @@ sYX
 fyf
 fyf
 fyf
-trW
+fHx
+mvv
+bpD
 fyf
 fyf
 fyf
 fyf
 fyf
+eqo
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
+sYX
+sYX
+sYX
+tRX
+uFK
+wXq
+mdM
+eAo
+uCO
+jZk
+eAo
+sYX
+xJA
 fyf
 fyf
 hej
@@ -92897,15 +95254,15 @@ cpK
 cpK
 cpK
 unI
+hbW
 erY
-erY
-erY
-erY
+wGJ
+wGJ
 fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -92914,16 +95271,16 @@ fyf
 fyf
 fyf
 fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-uUZ
-puX
-puX
-cKC
+fyf
+fyf
+fyf
+ier
+mCG
+nfu
+nfu
+nfu
+nfu
+nfu
 vPA
 pIz
 frY
@@ -92939,24 +95296,24 @@ syr
 syr
 buG
 hAX
-pIz
 frY
+dwG
 gRf
-xJY
-pIz
-ulc
+gRf
+gRf
+gRf
 qip
-ozI
+tdu
 pIz
 frY
 hom
 qBu
-fqL
+tTT
 qBu
-xNm
+tTT
 hom
 qBu
-xNm
+tTT
 qBu
 hom
 gcK
@@ -93115,32 +95472,32 @@ sYX
 fyf
 fyf
 fyf
+tBN
+mvv
+bpD
 fyf
 fyf
+rsE
+fyf
+qTY
 fyf
 fyf
-fyf
-rtR
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rtR
-fyf
-fyf
-fyf
-fyf
+pya
+jZk
+jZk
+jZk
+uIK
+jZk
+jZk
+jZk
+rGT
+mdM
+iHP
+srM
+xJA
 fyf
 fyf
-thG
-fyf
-fyf
-fyf
-nGq
+gts
 tSd
 pgl
 pgl
@@ -93154,15 +95511,15 @@ ybI
 ybI
 nkp
 unI
-erY
-erY
-erY
+hbW
+wGJ
+wGJ
 cdc
 fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -93170,17 +95527,17 @@ fyf
 gxn
 fyf
 fyf
-gcK
-ktB
-ktB
-gcK
-gbL
-gcK
-gcK
-gcK
-gcK
+fyf
+fyf
+fyf
+fyf
+ier
 nfu
-ebT
+nfu
+nfu
+wsE
+nfu
+nfu
 ozI
 pIz
 tjI
@@ -93196,24 +95553,24 @@ aKv
 sZQ
 jTJ
 kbS
-pIz
 tjI
 uag
-nwp
-pIz
-sap
+uag
+ubt
+uag
+ubt
 uag
 kbS
 pIz
 frY
 hom
 nMk
-xNm
+lny
 pRl
-xNm
+tTT
 hom
 poX
-xNm
+tTT
 pQL
 hom
 gcK
@@ -93372,6 +95729,9 @@ sYX
 fyf
 fyf
 fyf
+nlO
+mfD
+hCg
 fyf
 fyf
 fyf
@@ -93379,22 +95739,19 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
+sYX
+qUC
+jZk
+jZk
+jZk
+wXR
+jZk
+yiU
+uCO
+jZk
+jZk
+sYX
+xJA
 fyf
 fyf
 hej
@@ -93411,33 +95768,33 @@ idu
 idu
 koD
 unI
-erY
+hbW
 cdc
-erY
-erY
+wGJ
+cdc
 fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
 fyf
 fyf
 fyf
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ebT
+wSj
+fyf
+fyf
+fyf
+fyf
+ier
+nfu
+nfu
+nfu
+nfu
+nfu
+nfu
 ozI
 pIz
 pIz
@@ -93465,9 +95822,9 @@ pIz
 frY
 rgS
 qBu
-xNm
+tTT
 qBu
-xNm
+tTT
 hom
 hom
 hom
@@ -93630,28 +95987,28 @@ fyf
 fyf
 fyf
 fyf
-trW
+sYX
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-trW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-upX
-fyf
-fyf
-fyf
-fyf
-kEh
-fyf
+sYX
+sYX
+tKZ
+tKZ
+sYX
+sYX
+uCO
+pya
+uCO
+uCO
+uCO
+uCO
+uCO
+uCO
+vWE
+uCO
+sYX
+xJA
 fyf
 fyf
 hej
@@ -93668,34 +96025,34 @@ hOl
 hOl
 fLc
 onk
-erY
-erY
-erY
-erY
+hbW
+wGJ
+wGJ
+wGJ
 fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
 fyf
 fyf
-gcK
-gcK
-gcK
-ktB
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-dWR
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+ier
+nfu
+nfu
+nfu
+nfu
+nfu
+nfu
+sDc
 xAq
 xAq
 xAq
@@ -93722,7 +96079,7 @@ pIz
 frY
 hom
 nMk
-xNm
+tTT
 pRl
 vHe
 hom
@@ -93887,28 +96244,28 @@ fyf
 fyf
 fyf
 fyf
+xJA
 fyf
 fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+sYX
+jNj
+lrB
+jZk
+jZk
 vWE
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
+lrB
+mdM
+jZk
+vWE
+jZk
+jZk
+lrB
+jZk
+jZk
+iOF
+sYX
+xJA
 fyf
 fyf
 hej
@@ -93928,25 +96285,25 @@ erY
 erY
 erY
 erY
-erY
+wGJ
 khX
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
 osj
 fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
-gcK
-gcK
-gbL
-gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -94144,28 +96501,28 @@ fyf
 fyf
 fyf
 fyf
+xJA
 fyf
 fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rtR
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
+hsP
+iMi
+jRU
+jZk
+mdc
+mdM
+uCO
+uCO
+sxs
+uCO
+uCO
+tOP
+jZk
+mdc
+jZk
+tPA
+uIJ
+srM
+xJA
 fyf
 fyf
 hej
@@ -94185,31 +96542,31 @@ dmL
 erY
 erY
 erY
-erY
+wGJ
 fAt
 liv
 erY
 cdc
-erY
+gmX
 koD
 dMW
 fyf
 fFu
 fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
 ktB
-gcK
-gbL
-gcK
-gcK
 gbL
 gcK
 gcK
 hom
 rEk
-xNm
+tTT
 xYS
 iVE
 uag
@@ -94401,28 +96758,28 @@ fyf
 fyf
 fyf
 fyf
+xJA
 fyf
 fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
+hsP
+iOF
+jZk
+jZk
+jZk
+nYY
+uCO
+qfh
+dhC
+tUC
+uCO
+xgC
+mdM
+jZk
+jZk
+jZk
+jZk
+srM
+xJA
 fyf
 fyf
 hej
@@ -94439,34 +96796,34 @@ hOl
 erY
 geM
 muk
+hbW
 erY
 erY
-erY
-erY
+wGJ
 fAt
 erY
 mmK
 xuL
-erY
+gmX
 koD
 dMW
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
 ktB
-ktB
-gcK
-gcK
 gcK
 gcK
 gcK
 gcK
 hom
 cTN
-xNm
+tTT
 ozI
 qul
 qul
@@ -94655,31 +97012,31 @@ rpu
 oIZ
 sYX
 fyf
-lWZ
 fyf
 fyf
 fyf
-fyf
-fyf
-thG
-fyf
+xJA
 fyf
 fyf
 sYX
 sYX
-sYX
+jZM
+luD
+mdE
+nZV
+uCO
 gEY
+sBQ
+tUH
+uCO
+xll
+mdE
+afR
+mdE
+oml
+mdE
 sYX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
+xJA
 fyf
 fyf
 hej
@@ -94696,15 +97053,15 @@ jni
 erY
 koD
 unI
+hbW
 erY
-erY
-erY
+wGJ
 erY
 bkJ
 cdc
 erY
 erY
-erY
+gmX
 koD
 dMW
 gxn
@@ -94712,9 +97069,9 @@ dhD
 fyf
 gcK
 gcK
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -94723,7 +97080,7 @@ gcK
 gcK
 hom
 sgJ
-xNm
+tTT
 ozI
 qul
 qul
@@ -94745,7 +97102,7 @@ jei
 xys
 hom
 ozI
-qot
+jfx
 frY
 nfu
 nfu
@@ -94915,31 +97272,31 @@ fyf
 fyf
 fyf
 fyf
+xJA
 fyf
 fyf
 fyf
-kEh
-uxC
-uxC
-uxC
 sYX
-nqU
-tRX
-mZD
 sYX
-xMP
-uxC
-uxC
-kEh
-uxC
-uxC
-uxC
-uxC
-kEh
+sYX
+sYX
+sYX
+sYX
+tKZ
+sYX
+sYX
+sYX
+sYX
+hsP
+sYX
+qLT
+sYX
+qLT
+sYX
+xJA
 fyf
 fyf
-fyf
-nGq
+gts
 sIf
 ees
 ees
@@ -94953,15 +97310,15 @@ ees
 ees
 sVF
 unI
+hbW
 erY
-erY
-erY
+wGJ
 erY
 fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -94980,7 +97337,7 @@ gcK
 gcK
 hom
 mVR
-xNm
+tTT
 ozI
 qul
 qul
@@ -95002,7 +97359,7 @@ yir
 qKU
 hom
 ozI
-jfx
+crW
 frY
 nfu
 nfu
@@ -95172,28 +97529,28 @@ igz
 igz
 igz
 igz
-igz
-igz
-igz
-igz
-igz
-bEw
-gSt
 sYX
-jzN
-jzN
-jzN
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
 sYX
-jkJ
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
 bEw
 gSt
 hgX
@@ -95210,15 +97567,15 @@ cpK
 uCW
 cpK
 unI
+hbW
 erY
-erY
-erY
+wGJ
 erY
 fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -95233,8 +97590,8 @@ gcK
 gcK
 gcK
 gcK
-pIz
-pIz
+bcM
+bcM
 hom
 hom
 kGL
@@ -95467,15 +97824,15 @@ ybI
 ybI
 ybI
 onk
-erY
-erY
-erY
-erY
+hbW
+wGJ
+wGJ
+wGJ
 fAt
 erY
 erY
-erY
-erY
+wGJ
+gmX
 koD
 dMW
 fyf
@@ -95489,10 +97846,10 @@ ktB
 gcK
 gcK
 gcK
-pIz
+bcM
 piw
-pIz
-pIz
+bcM
+bcM
 hom
 nfu
 ozI
@@ -95725,14 +98082,14 @@ erY
 erY
 erY
 erY
-erY
-erY
-erY
+wGJ
+wGJ
+wGJ
 fAt
 erY
 erY
-erY
-erY
+cdc
+gmX
 koD
 dMW
 fyf
@@ -95745,11 +98102,11 @@ gbL
 gcK
 gcK
 gcK
-pIz
-pIz
-pIz
-pIz
-pIz
+bcM
+bcM
+bcM
+bcM
+bcM
 okZ
 sJr
 ozI
@@ -95982,14 +98339,14 @@ erY
 erY
 erY
 erY
-erY
-cdc
-erY
+wGJ
+wGJ
+wGJ
 bkJ
 erY
-erY
+wGJ
 cdc
-erY
+gmX
 koD
 dMW
 fyf
@@ -96003,10 +98360,10 @@ ktB
 gcK
 gcK
 gbL
-pIz
-pIz
+bcM
+bcM
 sUl
-pIz
+bcM
 iLQ
 nfu
 ozI
@@ -96240,13 +98597,13 @@ erY
 erY
 erY
 erY
+wGJ
+wGJ
+srt
 erY
-erY
-fAt
-erY
-erY
-erY
-erY
+wGJ
+cdc
+gmX
 koD
 dMW
 fyf
@@ -96260,10 +98617,10 @@ ktB
 gcK
 gcK
 gcK
-pIz
-pIz
+bcM
+bcM
 nTO
-pIz
+bcM
 okZ
 hge
 sDc
@@ -96499,11 +98856,11 @@ erY
 erY
 erY
 erY
-fAt
+srt
 erY
 erY
-erY
-erY
+wGJ
+gmX
 koD
 dMW
 fyf
@@ -96519,7 +98876,7 @@ gcK
 gcK
 gcK
 piw
-pIz
+bcM
 cRh
 hom
 uNK
@@ -96757,10 +99114,10 @@ sCK
 mYz
 uYf
 khX
+wGJ
+wGJ
 erY
-erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -96770,21 +99127,21 @@ gcK
 gcK
 gcK
 ktB
+gcK
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-pIz
+hom
+hom
+hom
+hom
+hom
 ezG
 nCl
 xfy
 ntJ
-xNm
-uIV
-xNm
-dvo
+tTT
+tTT
+tTT
+vme
 pIz
 pIz
 frY
@@ -96796,7 +99153,7 @@ eXO
 pIz
 frY
 hom
-xNm
+tTT
 mTN
 hcr
 hom
@@ -97013,11 +99370,11 @@ erY
 erY
 erY
 erY
-fAt
-erY
+srt
+wGJ
 cdc
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -97028,19 +99385,19 @@ gcK
 gcK
 ktB
 gcK
-gcK
-gcK
 ktB
-gcK
-gcK
-gcK
+hom
+wgf
+tTT
+wPS
+wPS
 hom
 ooz
 cjV
 ntJ
-xNm
+lSf
 oMY
-fNB
+nvL
 hom
 eDx
 pIz
@@ -97053,8 +99410,8 @@ eXO
 pIz
 frY
 hHk
-eQH
 oMY
+peH
 uhW
 hom
 gcK
@@ -97272,9 +99629,9 @@ erY
 erY
 fAt
 erY
+wGJ
 erY
-erY
-erY
+gmX
 koD
 dMW
 trW
@@ -97285,19 +99642,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
 ktB
-gcK
-gcK
-gcK
-gcK
+hom
+wmJ
+oMY
+wPS
+wPS
 hom
 hom
 hom
 pqs
 uFt
 awT
-xNm
+tTT
 rgS
 pIz
 pIz
@@ -97509,7 +99866,7 @@ erY
 erY
 erY
 erY
-erY
+jqM
 erY
 erY
 dFQ
@@ -97531,7 +99888,7 @@ iTB
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -97542,12 +99899,12 @@ gcK
 gcK
 ktB
 gcK
-gcK
-ktB
 hom
 hom
-hom
-gcK
+woy
+tTT
+idC
+wPS
 hom
 oFC
 biv
@@ -97560,7 +99917,7 @@ gcK
 gcK
 pIz
 syr
-syr
+sVl
 syr
 bPH
 eXO
@@ -97785,10 +100142,10 @@ erY
 erY
 erY
 fAt
+nBC
 erY
 erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -97799,25 +100156,25 @@ gcK
 gcK
 ktB
 gcK
-gcK
-ktB
 hom
+vxb
+wqe
 jfu
-xNm
-gcK
+wPS
+wPS
 hom
 nCl
 hbO
 ntJ
-eQH
-xNm
+oMY
+tTT
 lAD
 hom
 gcK
 gcK
-pIz
-syr
-syr
+bcM
+sVl
+sVl
 hom
 hom
 hom
@@ -98037,15 +100394,15 @@ ees
 ees
 ees
 muk
-erY
+hbW
 erY
 fmW
 erY
 fAt
+wGJ
 erY
 erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -98056,25 +100413,25 @@ gcK
 gcK
 gcK
 ktB
-gcK
-ktB
 hom
-kxq
-oMY
+ime
+tTT
+wPS
+wPS
 wPS
 cRh
 hom
 hom
 hom
 vKl
-oMY
+hPL
 ooh
 kRD
 gcK
-wPS
-wPS
-syr
-syr
+ggK
+ggK
+sVl
+sVl
 hom
 kQJ
 oMY
@@ -98294,15 +100651,15 @@ ptf
 ptf
 gNA
 unI
-erY
+hbW
 erY
 erY
 erY
 iTB
+wGJ
+wGJ
 erY
-erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -98312,26 +100669,26 @@ gcK
 gcK
 gcK
 ktB
-ktB
 gcK
 hom
-hom
+vJq
+ime
 mes
-xNm
 idC
+wPS
 hom
 hbO
 xfy
 hbO
-uIV
+rfR
 oMY
 abC
 hom
 gcK
-wPS
-syr
-syr
-wPS
+ggK
+sVl
+sVl
+ggK
 hom
 wFo
 bwM
@@ -98551,29 +100908,29 @@ fyf
 fyf
 kGc
 unI
+hbW
 erY
-erY
-erY
-erY
-fAt
+wGJ
+wGJ
+srt
 cdc
+wGJ
 erY
-erY
-erY
+gmX
 koD
 dMW
+qTY
 fyf
-fyf
 gcK
 gcK
 gcK
 gcK
 gcK
-ktB
 gcK
 hom
+vQU
 hJf
-wzm
+wPS
 fKN
 wPS
 hom
@@ -98581,14 +100938,14 @@ tZW
 tZW
 lez
 vHR
-xNm
+tTT
 udT
 fBx
-wPS
-wPS
-syr
-syr
-wPS
+ggK
+ggK
+sVl
+sVl
+ggK
 hom
 kIs
 oMY
@@ -98808,15 +101165,15 @@ fyf
 fyf
 kGc
 unI
+hbW
+wGJ
+wGJ
+cdc
+srt
+wGJ
+wGJ
 erY
-erY
-erY
-erY
-fAt
-erY
-erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -98826,14 +101183,14 @@ gbL
 gcK
 ktB
 gcK
-ktB
-ktB
 hom
-ime
-xNm
-wPS
-wPS
-gsV
+hom
+hom
+hom
+hom
+wzm
+hom
+hom
 cRh
 cRh
 hom
@@ -98841,11 +101198,11 @@ hom
 hom
 hom
 mCf
-wPS
-syr
-syr
-syr
-wPS
+ggK
+sVl
+sVl
+sVl
+ggK
 hom
 mgg
 oMY
@@ -98855,7 +101212,7 @@ uNK
 dpK
 seY
 qCX
-bMP
+qCX
 leX
 hom
 wPS
@@ -99065,15 +101422,15 @@ fyf
 uey
 kGc
 unI
-erY
-erY
-erY
-erY
+hbW
+wGJ
+wGJ
+cdc
 fAt
+wGJ
+apk
 erY
-erY
-erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -99081,27 +101438,27 @@ fyf
 gcK
 gcK
 gcK
-gcK
 ktB
-gcK
-gcK
+ktB
 hom
-aGX
+aBk
+oMY
+dvo
 ime
-fLB
-idC
-fuN
-wPS
-wPS
+qpx
+hom
+ggK
+ggK
+ggK
 gcK
 gcK
 gcK
 gcK
 gcK
-wPS
-syr
-syr
-wPS
+ggK
+sVl
+sVl
+ggK
 gcK
 hom
 hom
@@ -99111,7 +101468,7 @@ oMY
 cfp
 oMY
 oMY
-oMY
+qpx
 oMY
 kTP
 mCf
@@ -99322,15 +101679,15 @@ fyf
 fyf
 kGc
 unI
-erY
+hbW
 cdc
-erY
-erY
+wGJ
+wGJ
 iTB
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -99338,27 +101695,27 @@ fyf
 gcK
 gcK
 gcK
-gcK
-gcK
 ktB
 gcK
 hom
-qyj
-spC
-wPS
-ulU
-frz
-wPS
-wPS
-wPS
+qCv
+nvL
+hom
+pck
+tTT
+vme
+ggK
+ggK
+ggK
+ggK
 gcK
 gcK
 gcK
-iyu
-wPS
-syr
-syr
-wPS
+rwv
+ggK
+sVl
+sVl
+ggK
 gcK
 gcK
 pdn
@@ -99579,15 +101936,15 @@ fyf
 fyf
 kGc
 unI
-erY
-erY
-erY
-erY
+hbW
+wGJ
+wGJ
+apk
 fAt
 erY
 erY
 erY
-cdc
+gmX
 koD
 dMW
 fyf
@@ -99595,36 +101952,36 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
 ktB
+gcK
 hom
 hom
 hom
 hom
-hom
-hom
-hom
-wPS
-wPS
-wPS
-wPS
-wPS
-wPS
-wPS
-wPS
-syr
-syr
-wPS
+wrG
+wzn
+rgS
+ggK
+ggK
+ggK
+ggK
+ggK
+ggK
+ggK
+ggK
+ggK
+sVl
+sVl
+ggK
 gcK
 gcK
 pdn
 oMY
 ime
-bMP
+qCX
 kAJ
 ezv
-iDX
+seY
 seY
 vfn
 iDk
@@ -99836,15 +102193,15 @@ fyf
 fyf
 kGc
 unI
-erY
-erY
+hbW
+wGJ
 erY
 erY
 fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 fyf
@@ -99855,30 +102212,30 @@ gcK
 gcK
 gcK
 gcK
+ktB
+gcK
 hom
-aBk
-oMY
-dvo
-ime
-oMY
-dvo
-wPS
-wPS
-iyu
-wPS
-wPS
-wPS
-wPS
-wPS
-syr
-syr
-wPS
+hom
+uGF
+hom
+ggK
+ggK
+ggK
+rwv
+ggK
+ggK
+ggK
+ggK
+ggK
+sVl
+sVl
+ggK
 gcK
 gcK
 gcK
 yaI
 oMY
-bMP
+qCX
 cRh
 hom
 mCf
@@ -100093,15 +102450,15 @@ fyf
 fyf
 kGc
 unI
-erY
-erY
+hbW
+wGJ
 mmK
 erY
 fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 gcK
@@ -100112,24 +102469,24 @@ ktB
 gcK
 gcK
 ktB
-hom
-qCv
-nvL
-hom
-pck
-xNm
-rgS
-wPS
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-wPS
-syr
-syr
-wPS
+gcK
+ggK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ggK
+sVl
+sVl
+ggK
 gcK
 gcK
 gcK
@@ -100350,15 +102707,15 @@ fyf
 fyf
 kGc
 unI
-erY
-erY
+hbW
+wGJ
 erY
 erY
 fAt
 erY
 erY
 erY
-erY
+gmX
 koD
 dMW
 gcK
@@ -100369,25 +102726,25 @@ ktB
 ktB
 gcK
 ktB
-hom
-hom
-hom
-hom
-aQa
-oEF
-hom
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-wPS
-wPS
-syr
-syr
-wPS
-iyu
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ggK
+ggK
+sVl
+sVl
+ggK
+rwv
 gcK
 gcK
 gcK
@@ -100607,15 +102964,15 @@ gcK
 fyf
 kGc
 unI
-erY
+hbW
 cdc
-erY
+wGJ
 erY
 fAt
 sCK
 erY
 erY
-erY
+gmX
 koD
 dMW
 gcK
@@ -100627,24 +102984,24 @@ gcK
 gcK
 ktB
 gcK
-ktB
-gcK
-hom
-hom
-uGF
-hom
 gcK
 gcK
 gcK
 gcK
 gcK
-wPS
-wPS
-wPS
-syr
-syr
-syr
-wPS
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ggK
+ggK
+ggK
+sVl
+sVl
+sVl
+ggK
 gcK
 gcK
 gcK
@@ -100864,15 +103221,15 @@ gcK
 mGC
 mGC
 oZc
-vDP
-vDP
+rEi
+bQB
 vDP
 vDP
 mKe
 vDP
 vDP
 vDP
-vDP
+sTw
 hoo
 mGC
 mGC
@@ -100883,10 +103240,6 @@ gcK
 gcK
 gcK
 gcK
-ktB
-gcK
-gcK
-ktB
 gcK
 gcK
 gcK
@@ -100894,14 +103247,18 @@ gcK
 gcK
 gcK
 gcK
-wPS
-wPS
-wPS
-wPS
-wPS
-syr
-syr
-wPS
+gcK
+gcK
+gcK
+gcK
+ggK
+ggK
+ggK
+ggK
+ggK
+sVl
+sVl
+ggK
 gcK
 gcK
 gcK
@@ -101121,15 +103478,15 @@ gcK
 gcK
 mGC
 oZc
+rEi
 vDP
 vDP
-vDP
-vDP
+bQB
 mKe
 vDP
 vDP
 vDP
-vDP
+sTw
 hoo
 mGC
 gcK
@@ -101150,10 +103507,10 @@ gcK
 gcK
 gbL
 gcK
-wPS
-wPS
-wPS
-ktB
+ggK
+ggK
+ggK
+ggK
 ggK
 ggK
 sVl
@@ -101378,15 +103735,15 @@ gcK
 gcK
 mGC
 oZc
+rEi
 vDP
-vDP
-vDP
-vDP
+bQB
+bQB
 mKe
 vDP
 vDP
 vDP
-vDP
+sTw
 hoo
 mGC
 gcK
@@ -101410,7 +103767,7 @@ hom
 hom
 bbV
 hom
-ktB
+wPS
 ggK
 sVl
 sVl
@@ -101635,15 +103992,15 @@ gcK
 gcK
 mGC
 tvl
+rEi
 vDP
-vDP
-vDP
+bQB
 nAz
-mKe
+uld
 vDP
 vDP
 vDP
-vDP
+sTw
 gjC
 mGC
 gcK
@@ -101667,7 +104024,7 @@ kRD
 ydY
 fqL
 mCf
-ktB
+wPS
 ggK
 sVl
 sVl
@@ -101892,7 +104249,7 @@ gcK
 gcK
 mGC
 dxx
-gqz
+ecM
 gqz
 gqz
 gqz
@@ -101900,7 +104257,7 @@ bXM
 gqz
 gqz
 gqz
-gqz
+nfv
 wuR
 mGC
 gcK
@@ -101924,11 +104281,11 @@ hom
 hom
 hom
 hom
-ktB
+wOj
 oYb
 sVl
 sVl
-ggK
+oYb
 oYb
 ktB
 gcK

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -584,15 +584,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"arG" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3"
-	},
-/area/f13/wasteland)
 "arT" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/f13{
@@ -2322,12 +2313,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"bxk" = (
-/obj/effect/decal/riverbankcorner{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
 "bxl" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3030,6 +3015,15 @@
 /obj/machinery/mineral/wasteland_vendor/medical,
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
+"bUF" = (
+/obj/structure/closet/crate/trashcart{
+	name = "corpse cart"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "bUR" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
@@ -3270,6 +3264,10 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/water,
 /area/f13/caves)
+"cfS" = (
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "cgi" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4859,20 +4857,6 @@
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dpQ" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Bar";
-	req_one_access_txt = "28"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "barshutters"
-	},
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_y = 32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "dpZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -5093,6 +5077,11 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"dvL" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "dvQ" = (
 /obj/structure/barricade/bars,
 /obj/structure/window/fulltile/house,
@@ -6308,6 +6297,14 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "bar"
+	},
+/area/f13/building)
+"eqL" = (
+/obj/structure/simple_door/house{
+	icon_state = "room"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
 "eqN" = (
@@ -7761,6 +7758,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"fjN" = (
+/obj/machinery/light/sign,
+/obj/structure/barricade/wooden,
+/obj/effect/decal/fakelattice,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop3"
+	},
+/area/f13/wasteland)
 "fjR" = (
 /obj/item/kitchen/knife/butcher,
 /turf/open/floor/f13/wood,
@@ -8185,12 +8190,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"fxc" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermaintop"
-	},
-/area/f13/building)
 "fxx" = (
 /obj/item/picket_sign,
 /turf/open/indestructible/ground/outside/road{
@@ -9278,10 +9277,6 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"gie" = (
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "gin" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
@@ -10165,10 +10160,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"gHZ" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "gIE" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/police,
@@ -10176,6 +10167,10 @@
 /obj/item/clothing/shoes/combat,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"gJI" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
 "gJP" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -10948,14 +10943,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
-"hii" = (
-/obj/machinery/light/sign,
-/obj/structure/barricade/wooden,
-/obj/effect/decal/fakelattice,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3"
-	},
-/area/f13/wasteland)
 "hio" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/balaclava,
@@ -11043,6 +11030,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"hkG" = (
+/obj/effect/decal/riverbank{
+	dir = 5
+	},
+/turf/open/water,
+/area/f13/wasteland)
 "hkL" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -11215,6 +11208,15 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"hpJ" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop3"
+	},
+/area/f13/wasteland)
 "hqr" = (
 /obj/machinery/vending/games,
 /turf/open/floor/f13/wood,
@@ -11670,12 +11672,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"hCU" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outermaincornerinner";
-	tag = "icon-outermaincornerinner"
-	},
-/area/f13/building)
 "hDe" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11961,15 +11957,6 @@
 /obj/item/folder/yellow,
 /obj/item/reagent_containers/pill/patch/jet,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"hLj" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
 /area/f13/building)
 "hLm" = (
 /obj/structure/barricade/wooden/strong,
@@ -14349,6 +14336,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"jde" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "jdg" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/ruins{
@@ -15210,12 +15205,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"jEC" = (
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
 "jEP" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -15560,6 +15549,12 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"jRC" = (
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "jRQ" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
@@ -15739,6 +15734,11 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/brotherhood)
+"jVZ" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2right"
+	},
+/area/f13/building)
 "jWa" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -15767,6 +15767,25 @@
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
+"jWk" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "jWx" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -16032,17 +16051,6 @@
 "kdi" = (
 /turf/open/floor/plasteel/chapel,
 /area/f13/building)
-"kdt" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/building)
 "kdJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermaintop"
@@ -16264,14 +16272,6 @@
 	},
 /turf/open/floor/plating,
 /area/f13/caves)
-"kjY" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
 "kkD" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
@@ -18790,11 +18790,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"lMI" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermaintop"
-	},
-/area/f13/building)
 "lNa" = (
 /obj/structure/closet/fridge/standard,
 /turf/open/floor/f13/wood,
@@ -19255,6 +19250,16 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"mbq" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outermaincornerouter"
+	},
+/area/f13/wasteland)
 "mbr" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/fakelattice{
@@ -19409,6 +19414,17 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"mge" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "mgg" = (
 /obj/machinery/autolathe,
 /turf/open/floor/wood/f13/oak,
@@ -19647,12 +19663,6 @@
 	},
 /turf/open/water,
 /area/f13/caves)
-"mpD" = (
-/obj/effect/decal/riverbank{
-	dir = 5
-	},
-/turf/open/water,
-/area/f13/wasteland)
 "mpE" = (
 /obj/machinery/door/airlock/freezer,
 /turf/open/floor/plasteel/bar,
@@ -19665,6 +19675,17 @@
 	},
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"mpN" = (
+/obj/machinery/vending/boozeomat{
+	density = 0;
+	pixel_x = -32
+	},
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "mpQ" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -21261,11 +21282,6 @@
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"ntq" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
-	},
-/area/f13/building)
 "ntt" = (
 /obj/structure/table/wood,
 /obj/item/pickaxe,
@@ -21431,10 +21447,6 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/building)
-"nzz" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken4,
 /area/f13/building)
 "nzJ" = (
 /obj/item/seeds/poppy/broc,
@@ -21719,33 +21731,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/f13/building)
-"nJS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
 "nJW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
-"nKl" = (
-/obj/structure/wreck/trash/five_tires,
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outermaincornerinner";
-	tag = "icon-outermaincornerinner"
-	},
-/area/f13/building)
 "nKq" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/bandana/gold,
@@ -22888,14 +22879,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"ovV" = (
-/obj/structure/simple_door/house{
-	icon_state = "room"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
 "owh" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass{
@@ -23071,16 +23054,6 @@
 	},
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"oFh" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outermaincornerouter"
-	},
 /area/f13/building)
 "oFp" = (
 /obj/structure/decoration/vent/rusty,
@@ -23326,6 +23299,12 @@
 /area/f13/caves)
 "oKy" = (
 /obj/machinery/microwave/stove,
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters button";
+	pixel_y = 32;
+	req_one_access_txt = "28"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "oKA" = (
@@ -23831,6 +23810,12 @@
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
+"paY" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermaintop"
 	},
 /area/f13/wasteland)
 "pbg" = (
@@ -25036,10 +25021,6 @@
 "pMI" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland)
-"pMR" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
 "pNj" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26093,7 +26074,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "qwW" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/ground/outside/dirt,
@@ -26131,6 +26112,13 @@
 	req_one_access_txt = "62"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"qyz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "qyH" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -26297,7 +26285,7 @@
 "qDM" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/r_wall/rust,
-/area/f13/wasteland)
+/area/f13/building)
 "qDS" = (
 /obj/structure/table/wood/settler,
 /obj/item/seeds/poppy/broc,
@@ -26390,6 +26378,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"qHg" = (
+/obj/effect/decal/riverbankcorner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "qHu" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -27569,6 +27563,10 @@
 /obj/item/trash/chips,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ruj" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "ruD" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/turbo,
@@ -27872,19 +27870,10 @@
 	},
 /area/f13/building)
 "rHE" = (
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_x = -32
+/obj/structure/chair/booth{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
-	anchored = 1;
-	pixel_x = -28
-	},
-/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
-	anchored = 1;
-	pixel_x = -36
-	},
-/turf/closed/wall/f13/wood/interior,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rHO" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -27896,9 +27885,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "rHT" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rIA" = (
@@ -27919,7 +27908,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "rJT" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -27949,9 +27938,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "rLi" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/settler,
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
+	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rLn" = (
@@ -28442,6 +28431,16 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"sbj" = (
+/obj/structure/wreck/trash/five_tires,
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner"
+	},
+/area/f13/wasteland)
 "sbk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -28831,6 +28830,17 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"slq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "slr" = (
 /obj/structure/chair/wood/modern,
@@ -29407,17 +29417,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"sCm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
 "sCu" = (
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
@@ -29428,9 +29427,8 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "sCF" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_south"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "sCK" = (
@@ -29714,10 +29712,11 @@
 	},
 /area/f13/building)
 "sNM" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermainbottom"
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "interiorgate2"
 	},
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland)
 "sNT" = (
 /obj/structure/chair{
 	dir = 4
@@ -29731,7 +29730,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleftbottom"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "sOS" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt{
@@ -29788,10 +29787,12 @@
 /turf/open/floor/plating,
 /area/f13/radiation)
 "sQo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland)
 "sQv" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -30385,6 +30386,26 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"thc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "barwindowshutters";
+	name = "bar window shutters button";
+	pixel_x = 6;
+	pixel_y = -32;
+	req_one_access_txt = "28"
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters button";
+	pixel_x = -6;
+	pixel_y = -32;
+	req_one_access_txt = "28"
+	},
+/obj/machinery/light/small,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "thG" = (
 /obj/structure/fence{
 	dir = 4
@@ -31180,26 +31201,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
-"tFx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "barwindowshutters";
-	name = "bar window shutters button";
-	pixel_x = 6;
-	pixel_y = -32;
-	req_one_access_txt = "28"
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters button";
-	pixel_x = -6;
-	pixel_y = -32;
-	req_one_access_txt = "28"
-	},
-/obj/machinery/light/small,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
 "tFK" = (
 /obj/effect/landmark/start/f13/farmer,
 /turf/open/floor/wood/f13/oak,
@@ -31401,11 +31402,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"tLN" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
 "tLW" = (
 /obj/structure/destructible/tribal_torch,
 /obj{
@@ -31781,11 +31777,11 @@
 	},
 /area/f13/wasteland)
 "tWd" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "interiorgate2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife/cosmicdirty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "tWt" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -31846,12 +31842,10 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "tYd" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "tYe" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -32435,8 +32429,15 @@
 	},
 /area/f13/wasteland)
 "urt" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/clinic)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
+	dir = 8;
+	light_color = "#008000";
+	name = "light tube"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uru" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt{
@@ -33012,11 +33013,14 @@
 	},
 /area/f13/building)
 "uJP" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife/cosmicdirty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "uKq" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/f13/deathskull,
@@ -33044,9 +33048,28 @@
 	},
 /area/f13/building)
 "uKG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "uKJ" = (
 /obj/structure/table/wood/fancy/black,
@@ -33178,13 +33201,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uOr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	desc = "A lighting fixture.";
-	dir = 8;
-	light_color = "#008000";
-	name = "light tube"
+/obj/structure/chair/booth{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "uOu" = (
@@ -33295,7 +33315,7 @@
 	icon_state = "outermaincornerinner";
 	tag = "icon-outermaincornerinner (EAST)"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "uSj" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal,
@@ -33316,8 +33336,8 @@
 	},
 /area/f13/village)
 "uSz" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken4,
 /area/f13/building)
 "uSC" = (
 /obj/structure/table/wood,
@@ -34336,13 +34356,6 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"vtQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_east_north"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "vug" = (
 /obj/structure/simple_door/room,
 /turf/open/indestructible/ground/outside/desert,
@@ -34423,13 +34436,6 @@
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"vxI" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "vye" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/desert,
@@ -34971,10 +34977,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"vPG" = (
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "vPU" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -35378,15 +35380,6 @@
 /obj/item/reagent_containers/syringe/medx,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wgE" = (
-/obj/structure/closet/crate/trashcart{
-	name = "corpse cart"
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "whh" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -35437,16 +35430,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
-"whX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters button";
-	pixel_y = 32;
-	req_one_access_txt = "28"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "wim" = (
 /obj/structure/table/booth,
 /turf/open/floor/wood/wood_tiled,
@@ -35492,6 +35475,20 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"wjF" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Bar";
+	req_one_access_txt = "28"
+	},
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_y = 32
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "barshutters"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wjI" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /turf/open/floor/plating/dirt/dark,
@@ -35822,6 +35819,15 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"wwE" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "wwF" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -37034,25 +37040,6 @@
 	tag = "icon-verticalrightborderrighttop"
 	},
 /area/f13/wasteland)
-"xdU" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/condiment/yeast,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
 "xed" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -38255,7 +38242,18 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "xMP" = (
-/obj/effect/decal/cleanable/generic,
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_x = -32
+	},
+/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
+	anchored = 1;
+	pixel_x = -28
+	},
+/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
+	anchored = 1;
+	pixel_x = -36
+	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "xNm" = (
@@ -38328,13 +38326,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/legion)
-"xPL" = (
-/obj/machinery/vending/boozeomat{
-	density = 0;
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
 "xPO" = (
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt,
@@ -38386,22 +38377,9 @@
 	},
 /area/f13/building)
 "xSa" = (
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"xSl" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "xSC" = (
 /obj/structure/closet/cardboard,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -38934,29 +38912,16 @@
 	},
 /area/f13/wasteland)
 "yht" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/fence{
+	dir = 4
 	},
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "yhv" = (
 /obj/structure/simple_door/brokenglass,
 /turf/open/floor/f13/wood,
@@ -61933,7 +61898,7 @@ sYX
 fyf
 fyf
 tBN
-xSl
+jde
 mvv
 bpD
 fyf
@@ -62694,7 +62659,7 @@ fyf
 fyf
 tBN
 mvv
-xSl
+jde
 mvv
 mvv
 oHO
@@ -63194,14 +63159,14 @@ fyf
 fyf
 fyf
 fyf
-nGq
-nGq
-nGq
-nGq
-nGq
-nGq
-nGq
-nGq
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
 gts
 gts
 gts
@@ -63451,14 +63416,14 @@ fyf
 fyf
 fyf
 fyf
-nGq
-pMI
-pMI
-pMI
-pMI
-pMI
-pMI
-pMI
+gts
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
 dCV
 dCV
 dCV
@@ -63970,10 +63935,10 @@ dCV
 uCO
 oKy
 rpa
-uJP
-yht
-xPL
-sCm
+tWd
+uKG
+mpN
+slq
 dCV
 yla
 aRz
@@ -64231,7 +64196,7 @@ pOo
 pOo
 pOo
 pOo
-ovV
+eqL
 vta
 vta
 vta
@@ -64487,9 +64452,9 @@ pOo
 qZO
 onz
 tUS
-tLN
+dvL
 dCV
-nJS
+mge
 vta
 aRz
 eGt
@@ -64744,10 +64709,10 @@ onz
 onz
 onz
 onz
-tFx
+thc
 uCO
-xdU
-hLj
+jWk
+wwE
 aRz
 aRz
 dCV
@@ -65000,7 +64965,7 @@ onz
 tUS
 onz
 onz
-kjY
+onz
 onz
 dCV
 dCV
@@ -65248,8 +65213,8 @@ fyf
 fyf
 fyf
 fyf
-nGq
-nGq
+gts
+gts
 gts
 dCV
 uCO
@@ -65258,7 +65223,7 @@ oTB
 oTB
 oTB
 uCO
-dpQ
+wjF
 dCV
 iWW
 rvx
@@ -65275,7 +65240,7 @@ tvr
 tvr
 tvr
 pUi
-xSl
+jde
 mvv
 vGl
 wDc
@@ -65505,8 +65470,8 @@ fyf
 fyf
 fyf
 fyf
-nGq
-pMI
+gts
+dCV
 dCV
 dCV
 moO
@@ -65515,7 +65480,7 @@ pSo
 pSC
 pSC
 uCO
-whX
+rdC
 dCV
 fBs
 kdJ
@@ -65762,8 +65727,8 @@ fyf
 fyf
 fyf
 fyf
-nGq
-pMI
+gts
+dCV
 kwe
 uCO
 mPa
@@ -66019,7 +65984,7 @@ cWG
 hpm
 wDc
 fyf
-nGq
+gts
 dCV
 kxq
 lzW
@@ -66276,17 +66241,17 @@ mvv
 mvv
 bpD
 fyf
-nGq
+gts
 dCV
 ktX
 uCO
 uCO
 oIQ
-rHT
+rHE
 rdC
-vxI
+uOr
 rdC
-nzz
+uSz
 xya
 xya
 hsk
@@ -66533,21 +66498,21 @@ mvv
 gfR
 hCg
 fyf
-nGq
+gts
 dCV
 dCV
 lzV
 oEF
 rdC
-rLi
-uKG
-sQo
+rHT
+tYd
+sCF
 oIQ
 rdC
 xya
 xya
 hsk
-wgE
+bUF
 cam
 dkg
 dCV
@@ -66790,14 +66755,14 @@ mvv
 bpD
 fyf
 fyf
-nGq
+gts
 gts
 dCV
 uCO
 oJm
 qbe
 sDj
-uOr
+urt
 sDj
 oIQ
 oIQ
@@ -67054,9 +67019,9 @@ uCO
 mvV
 oIQ
 rdC
-rHE
+oIQ
 rdC
-rdC
+uSz
 uMZ
 dCV
 uqa
@@ -67316,7 +67281,7 @@ rdC
 rdC
 oIQ
 xMP
-gHZ
+ruj
 kzW
 dkg
 cpK
@@ -67567,19 +67532,19 @@ dCV
 dCV
 mGh
 qcS
-sCF
+rLi
 rdC
 oIQ
 oIQ
-vtQ
-sCF
+qyz
+rLi
 uqa
-ntq
+jVZ
 dkg
 cpK
 gdY
 mkV
-mpD
+hkG
 uqa
 hJM
 mvv
@@ -67824,14 +67789,14 @@ gts
 dCV
 uCO
 qAc
-sQo
+sCF
 rdC
-nzz
+uSz
 oIQ
-sQo
+sCF
 xPh
 drN
-arG
+hpJ
 dkg
 gdY
 jGl
@@ -68083,12 +68048,12 @@ uCO
 oQv
 qlE
 oIQ
-vPG
-vPG
+xSa
+xSa
 uQx
 qlE
 uqa
-hii
+fjN
 dkg
 cam
 cah
@@ -68339,7 +68304,7 @@ dCV
 dCV
 dCV
 dCV
-uSz
+qDM
 sDr
 sDr
 sDr
@@ -68590,18 +68555,18 @@ fyf
 fyf
 fyf
 fyf
-nGq
+gts
 dCV
 lCi
 lCi
 oUj
 dCV
-xSa
-kdt
-nKl
+uJP
+yht
+sbj
 uRN
 qwq
-jEC
+jRC
 dHO
 cam
 jGl
@@ -68847,18 +68812,18 @@ fyf
 fyf
 upX
 fyf
-nGq
+gts
 dCV
 rWL
 xdD
 xdD
 qyj
 rJO
-hCU
-oFh
-lMI
-kzW
-ids
+ioU
+mbq
+kdJ
+dkg
+cpK
 cpK
 dkg
 jPG
@@ -69104,17 +69069,17 @@ igz
 igz
 igz
 igz
-nGq
+gts
 dCV
 lCo
 xdD
 xdD
 dCV
-kzW
-sNM
-dbO
-fxc
-kzW
+dkg
+nPX
+fyf
+paY
+dkg
 cpK
 cpK
 cpK
@@ -69623,7 +69588,7 @@ lEG
 aJb
 hBN
 aJb
-tWd
+sNM
 tUb
 pWN
 plq
@@ -70137,7 +70102,7 @@ lEG
 moo
 oUy
 oUy
-tYd
+sQo
 oUy
 sPJ
 ier
@@ -70656,7 +70621,7 @@ sYX
 sYX
 sYX
 sYX
-gie
+cfS
 ajD
 hbW
 hOl
@@ -77081,7 +77046,7 @@ gts
 gts
 dCV
 dCV
-pMR
+gJI
 ids
 lTx
 dit
@@ -81505,7 +81470,7 @@ xjS
 rEB
 aXR
 bIh
-fDp
+gcK
 gcK
 gcK
 gcK
@@ -81756,12 +81721,12 @@ mvv
 doX
 wDc
 aRT
-hwC
-urt
-urt
-urt
-urt
-urt
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -82013,12 +81978,12 @@ mvv
 mvv
 doX
 ayf
-hwC
-urt
-urt
-urt
-urt
-urt
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -99758,7 +99723,7 @@ mvv
 doX
 wDc
 syr
-bxk
+qHg
 uXj
 eXO
 mvv

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -1,10 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aac" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1";
-	tag = "icon-horizontalinnermain1"
-	},
-/area/f13/wasteland)
 "aav" = (
 /obj/item/clothing/head/cone,
 /turf/open/floor/plating/dirt/dark,
@@ -13,17 +7,6 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
 /area/f13/caves)
-"aaS" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/white/box,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/item/stack/crafting/armor_plate/ten,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
 "abd" = (
 /obj/structure/decoration/hatch{
 	dir = 4
@@ -33,12 +16,11 @@
 	},
 /area/f13/wasteland)
 "abi" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbrokenvertical"
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/tunnel)
 "abC" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -64,11 +46,13 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"acI" = (
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+"acK" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTHWEST)"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "acW" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/f13{
@@ -76,11 +60,11 @@
 	},
 /area/f13/building)
 "adn" = (
-/obj/structure/fence/corner{
-	dir = 1
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/tunnel)
 "adq" = (
 /turf/open/indestructible/ground/outside/water{
 	density = 1;
@@ -88,10 +72,15 @@
 	name = "lake water"
 	},
 /area/f13/caves)
+"adu" = (
+/obj/machinery/vending/nukacolavend,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "adD" = (
-/obj/structure/fermenting_barrel,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/settler,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
 "adN" = (
@@ -106,6 +95,14 @@
 /obj/item/stack/f13Cash/random/aureus/low,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
+"adS" = (
+/obj/structure/toilet{
+	pixel_y = 13
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "aeb" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt{
@@ -117,11 +114,11 @@
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
 "aep" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/tunnel)
 "aeJ" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -141,17 +138,19 @@
 /obj/item/pda,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"afp" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plating,
-/area/f13/radiation)
-"afK" = (
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+"afo" = (
+/obj/structure/table,
+/obj/item/kitchen/knife,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/legion)
+"afG" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright2";
+	tag = "icon-verticalrightborderright2"
+	},
+/area/f13/wasteland)
 "afL" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -164,18 +163,13 @@
 	icon_state = "horizontalbottombordertop2"
 	},
 /area/f13/wasteland)
-"afR" = (
-/obj/structure/table/wood/settler,
-/obj/item/storage/backpack/satchel/leather/withwallet,
-/obj/machinery/light/small{
-	dir = 4
+"agk" = (
+/obj/machinery/light/lampost,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2left";
+	tag = "icon-horizontaltopbordertop2left"
 	},
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "agr" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -198,11 +192,20 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"agI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken2,
+/area/f13/legion)
 "agO" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"agP" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
+	},
+/area/f13/tunnel)
 "agU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/machinepile,
@@ -211,11 +214,10 @@
 	},
 /area/f13/caves)
 "agX" = (
-/obj/machinery/light/small/broken{
-	dir = 1
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/tunnel)
 "aha" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -248,16 +250,20 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"ahC" = (
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
+"ahK" = (
+/turf/open/floor/plating/f13/outside/road{
+	dir = 4;
+	icon_state = "crossborder"
+	},
+/area/f13/wasteland)
 "aik" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/suit/f13/sexymaid,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"aim" = (
-/obj/structure/rack,
-/obj/item/seeds/cannabis,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "aip" = (
 /obj/structure/rack,
 /obj/item/storage/backpack/spearquiver,
@@ -276,10 +282,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"ajj" = (
-/obj/structure/wreck/trash/two_tire,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/clinic)
 "ajp" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "shadowright"
@@ -328,6 +330,19 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"ajX" = (
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "cross1"
+	},
+/area/f13/wasteland)
+"aka" = (
+/obj/structure/disposalpipe/broken{
+	dir = 4
+	},
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plating,
+/area/f13/wasteland)
 "akm" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt,
@@ -361,32 +376,20 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"akJ" = (
-/obj/structure/reagent_dispensers/barrel/old,
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"akO" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2";
-	tag = "icon-horizontaloutermain2"
-	},
-/area/f13/wasteland)
 "akU" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland)
-"alk" = (
-/obj/machinery/computer/operating{
-	dir = 8
+"akY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating,
+/area/f13/wasteland)
 "all" = (
 /obj/structure/closet/crate/wicker,
 /turf/open/indestructible/ground/outside/dirt{
@@ -402,17 +405,8 @@
 	},
 /area/f13/wasteland)
 "alM" = (
-/obj/effect/landmark/start/f13/prospector,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"alN" = (
-/obj/structure/simple_door/metal/fence{
-	door_type = "fence_wood";
-	icon_state = "fence_wood"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "cross2"
 	},
 /area/f13/wasteland)
 "alV" = (
@@ -431,6 +425,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"amy" = (
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "cross3"
+	},
+/area/f13/wasteland)
 "ana" = (
 /obj/structure/sign/poster/prewar/poster67{
 	pixel_y = 32
@@ -444,13 +443,6 @@
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"anc" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "anl" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_l,
@@ -459,13 +451,6 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
-	},
-/area/f13/wasteland)
-"anu" = (
-/obj/structure/easel,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "anA" = (
@@ -478,14 +463,6 @@
 	icon_state = "verticaloutermainbottom"
 	},
 /area/f13/wasteland)
-"anK" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "anP" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -540,6 +517,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"apM" = (
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "aqD" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 5;
@@ -567,14 +552,26 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "arb" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
+/turf/open/floor/plating/f13/outside/road{
+	dir = 8;
+	icon_state = "crossborder"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
+"arr" = (
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "ars" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderrighttop"
+	},
+/area/f13/wasteland)
+"arx" = (
+/obj/structure/fermenting_barrel,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "arC" = (
@@ -603,6 +600,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
+"asw" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/legion)
 "asF" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -629,14 +635,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "atX" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "aug" = (
@@ -645,20 +646,17 @@
 	},
 /area/f13/building)
 "aun" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plating,
+/area/f13/wasteland)
+"aup" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plating,
+/area/f13/caves)
 "aut" = (
 /obj/item/lighter,
 /obj/item/clothing/mask/cigarette/cigar,
@@ -692,6 +690,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"avg" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/f13/radiation)
 "avh" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -713,18 +717,21 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"avO" = (
-/obj/structure/closet/cabinet,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/masks,
-/obj/item/lighter,
-/obj/item/clothing/suit/toggle/labcoat/f13/followers,
-/obj/item/storage/box/pillbottles,
-/obj/item/reagent_containers/syringe/medx,
+"avx" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"avO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating,
 /area/f13/building)
 "awj" = (
 /obj/structure/table/wood/settler,
@@ -782,16 +789,6 @@
 /obj/item/clothing/gloves/boxing,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"ayf" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "ayE" = (
 /obj/item/storage/money_stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -804,12 +801,25 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"azj" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "azk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
 /obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/condiment/yeast,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "azz" = (
@@ -828,11 +838,20 @@
 	},
 /area/f13/farm)
 "aAk" = (
-/obj/structure/chair/wood/fancy{
-	dir = 4
-	},
+/obj/structure/closet/fridge,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"aAn" = (
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2top";
+	tag = "icon-verticalleftborderleft2top"
+	},
+/area/f13/wasteland)
 "aAr" = (
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/f13/wood{
@@ -862,7 +881,34 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
-"aAO" = (
+"aAP" = (
+/obj/effect/decal/remains/human,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"aAR" = (
+/obj/structure/chair/wood/fancy{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"aBd" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
+"aBk" = (
+/obj/structure/dresser,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
+"aBx" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/structure/table/wood/fancy,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -877,30 +923,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"aAP" = (
-/obj/effect/decal/remains/human,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
-"aAR" = (
-/obj/structure/chair/wood/fancy{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"aBk" = (
-/obj/structure/dresser,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "aBH" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"aCn" = (
+/obj/structure/chair/wood/fancy{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aCP" = (
 /obj/item/lighter,
 /obj/item/clothing/mask/cigarette/cigar,
@@ -915,61 +949,7 @@
 	name = "lake water"
 	},
 /area/f13/caves)
-"aDq" = (
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowbroken"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/village)
-"aDw" = (
-/obj/structure/chair/left{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 8;
-	pixel_x = -6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/f13/brotherhood)
-"aDX" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/storage/toolbox/drone,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"aET" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/obj/item/taperecorder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"aEX" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
-"aFw" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/item/reagent_containers/blood/AMinus,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"aFD" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
-"aFF" = (
+"aDk" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_middle,
 /obj/item/clothing/shoes/singery,
@@ -985,6 +965,65 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"aDl" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheethos"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"aDq" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbroken"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"aDs" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
+	},
+/area/f13/village)
+"aDw" = (
+/obj/structure/chair/left{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8;
+	pixel_x = -6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/f13/brotherhood)
+"aDX" = (
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"aFu" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"aFv" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottomright";
+	tag = "icon-horizontaltopborderbottomright"
+	},
+/area/f13/wasteland)
+"aFx" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left";
+	tag = "icon-horizontaloutermain2left"
+	},
+/area/f13/wasteland)
+"aFF" = (
+/obj/item/claymore/machete/training,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "aFM" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -996,52 +1035,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"aGh" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt";
-	tag = "icon-dirt (NORTH)"
-	},
-/area/f13/wasteland)
-"aGj" = (
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+"aGv" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/knife/cosmicdirty,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aGw" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"aGO" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop3";
-	tag = "icon-horizontalbottombordertop3"
-	},
-/area/f13/wasteland)
-"aHE" = (
-/obj/item/trash/can,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
+"aGX" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"aHz" = (
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "aHH" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"aHN" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
-	},
 /area/f13/wasteland)
 "aHS" = (
 /obj/structure/chair{
@@ -1050,10 +1065,25 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"aHZ" = (
+/obj/machinery/light/small,
+/obj/structure/table/wood/settler,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aIb" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"aIJ" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "aIS" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1076,12 +1106,12 @@
 	icon_state = "verticalleftborderright2"
 	},
 /area/f13/wasteland)
-"aJK" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottomright";
-	tag = "icon-horizontaltopborderbottomright"
-	},
-/area/f13/wasteland)
+"aJZ" = (
+/obj/structure/table/wood/fancy,
+/obj/item/restraints/handcuffs,
+/obj/item/melee/chainofcommand/tailwhip/kitty,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aKs" = (
 /obj/item/clothing/shoes/sneakers/black,
 /turf/open/floor/f13/wood,
@@ -1114,14 +1144,12 @@
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "aLg" = (
-/turf/open/floor/plating/f13/outside/road{
-	icon_state = "innercornerpieceright"
+/obj/structure/fence{
+	dir = 8
 	},
-/area/f13/wasteland)
-"aLo" = (
-/turf/open/floor/plating/f13/outside/road{
+/turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
-	icon_state = "crossborder"
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "aLq" = (
@@ -1148,12 +1176,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"aLF" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile,
-/obj/structure/curtain,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "aLW" = (
 /obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/dirt,
@@ -1206,27 +1228,10 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"aNZ" = (
-/obj/structure/chair/bench{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "aOc" = (
 /obj/structure/simple_door/dirtyglass,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"aOg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/wreck/car/bike{
-	pixel_x = -12;
-	pixel_y = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "aOE" = (
 /obj/structure/displaycase,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -1241,14 +1246,19 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"aPg" = (
+/obj/structure/simple_door/metal/fence,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "aPr" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/fence{
+	dir = 8
 	},
-/area/f13/city)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "aPw" = (
 /obj/structure/rack,
 /obj/item/weldingtool,
@@ -1267,11 +1277,6 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"aPF" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "aPN" = (
 /obj/structure/fireplace{
 	dir = 8
@@ -1284,6 +1289,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"aQa" = (
+/obj/structure/table/wood/settler,
+/obj/item/lighter,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aQe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -1294,20 +1307,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"aQm" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/f13/leatherarmor,
-/obj/item/clothing/gloves/botanic_leather,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/item/storage/bag/plants,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
 "aQw" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -1316,42 +1315,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"aQN" = (
-/obj/item/retractor,
-/obj/item/hemostat,
-/obj/item/surgicaldrill,
-/obj/item/storage/belt/medical,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"aRc" = (
-/obj/structure/chair/office/light,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/wasteland)
-"aRz" = (
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
 "aRF" = (
 /obj/item/crafting/large_gear,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/village)
-"aRG" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
-"aRT" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "aRW" = (
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/road{
@@ -1359,6 +1328,13 @@
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland)
+"aRZ" = (
+/obj/structure/window/fulltile/wood,
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "aSc" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -1376,18 +1352,19 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
+"aSA" = (
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/under/f13/legslave,
+/obj/item/clothing/shoes/f13/rag,
+/obj/effect/landmark/start/f13/slave,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "aSL" = (
 /obj/structure/displaycase,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/building)
-"aTh" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "aTv" = (
 /obj/structure/wreck/trash/machinepile,
@@ -1396,12 +1373,45 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"aUb" = (
+"aTE" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"aTI" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
-	icon_state = "sheethos"
+	icon_state = "sheetblue"
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"aUb" = (
+/obj/structure/decoration/clock/old{
+	pixel_y = 32
+	},
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"aUc" = (
+/obj/structure/rack,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/tomato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/sugarcane,
+/obj/item/seeds/sugarcane,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aUl" = (
@@ -1446,6 +1456,22 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"aVq" = (
+/obj/structure/rack,
+/obj/item/shovel/spade,
+/obj/item/shovel,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/cultivator,
+/obj/item/storage/bag/plants,
+/obj/item/scythe,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"aVC" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aVF" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/ruins{
@@ -1469,6 +1495,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/brotherhood)
+"aWs" = (
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "aWz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt{
@@ -1477,11 +1507,12 @@
 	},
 /area/f13/legion)
 "aWF" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
-	tag = "icon-housewood3-broken"
+/obj/structure/window/fulltile/house{
+	dir = 2
 	},
-/area/f13/village)
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aXi" = (
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
@@ -1500,12 +1531,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"aXy" = (
-/obj/item/ammo_casing/caseless,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
-/area/f13/building)
 "aXC" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -1534,11 +1559,6 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"aXR" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/syringe/medx,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "aYk" = (
 /obj/structure/sink{
 	pixel_y = 15
@@ -1552,18 +1572,10 @@
 	},
 /area/f13/village)
 "aYp" = (
-/obj/item/twohanded/required/kirbyplants/dead,
-/obj/item/reagent_containers/pill/fixer,
-/obj/item/reagent_containers/pill/insulin,
-/turf/open/floor/wood,
-/area/f13/building)
-"aYu" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/obj/item/clothing/under/f13/classdress,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "aYG" = (
 /obj/structure/decoration/clock{
@@ -1580,12 +1592,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"aYU" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "aYV" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1595,11 +1601,16 @@
 	},
 /area/f13/brotherhood)
 "aYY" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/kitchen/fork,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"aZn" = (
+/obj/structure/table/wood/settler,
+/obj/item/toy/cards/deck,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aZz" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -1617,12 +1628,34 @@
 "aZJ" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"bar" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
 "bav" = (
 /obj/structure/spacevine{
 	name = "vines"
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/brotherhood)
+"baS" = (
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
+"baY" = (
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bbf" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
@@ -1633,6 +1666,13 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"bbK" = (
+/obj/structure/table/wood,
+/obj/item/paper,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/building)
 "bbN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/dead,
@@ -1640,12 +1680,6 @@
 /obj/item/kirbyplants,
 /turf/open/water,
 /area/f13/brotherhood)
-"bbR" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2"
-	},
-/area/f13/wasteland)
 "bbS" = (
 /turf/closed/wall/f13/wood,
 /area/f13/brotherhood)
@@ -1664,26 +1698,21 @@
 	},
 /area/f13/legion)
 "bcx" = (
-/obj/structure/chair/wood{
+/obj/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
-	tag = "icon-housewood3-broken"
+	icon_state = "housewood3-broken"
 	},
-/area/f13/village)
+/area/f13/building)
+"bcF" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bcM" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"bdg" = (
-/obj/structure/chair/wood/worn{
-	dir = 4
-	},
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "bdG" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -1715,8 +1744,8 @@
 	},
 /area/f13/tunnel)
 "bet" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/ruins,
+/obj/machinery/seed_extractor,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "bew" = (
 /obj/machinery/light/small{
@@ -1733,13 +1762,24 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"beE" = (
-/mob/living/simple_animal/hostile/wolf,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0";
-	tag = "icon-verticalrightborderleft0"
+"beG" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"bfq" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
-/area/f13/wasteland)
+/area/f13/village)
+"bfr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating,
+/area/f13/building)
 "bfu" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
@@ -1757,22 +1797,49 @@
 /obj/item/kitchen/knife,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"bgY" = (
-/turf/closed/indestructible/riveted,
-/area/f13/tcoms)
-"bhr" = (
-/obj/structure/fence{
-	dir = 8
+"bgz" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"bgL" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"bgY" = (
+/turf/closed/indestructible/riveted,
+/area/f13/tcoms)
+"bhl" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bhC" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
+"bhF" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
+"bhJ" = (
+/mob/living/simple_animal/hostile/cazador/young,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
 "bhL" = (
@@ -1808,11 +1875,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
-"biJ" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "biN" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -1829,9 +1891,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"bjo" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/city)
 "bjs" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -1854,6 +1913,11 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"bjI" = (
+/obj/structure/decoration/rag,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "bkc" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -1862,12 +1926,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"bkj" = (
-/obj/structure/dresser,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
-/area/f13/building)
 "bkr" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plating/dirt/dark,
@@ -1896,32 +1954,30 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/store,
 /area/f13/building)
+"bkV" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "bkY" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"bla" = (
-/obj/structure/chair/wood{
-	dir = 8
+"blj" = (
+/obj/structure/billboard/ritas,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
-/obj/effect/landmark/start/f13/campfollower,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/area/f13/wasteland)
 "blv" = (
 /obj/structure/decoration/shock,
 /turf/closed/wall/rust,
 /area/f13/caves)
-"blH" = (
-/obj/item/scalpel,
-/obj/item/cautery,
-/obj/item/razor,
-/obj/item/surgical_drapes,
-/obj/item/reagent_containers/medspray/sterilizine,
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "blS" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small/broken{
@@ -1929,6 +1985,11 @@
 	},
 /turf/open/water,
 /area/f13/caves)
+"blX" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "blZ" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1936,6 +1997,35 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"bmg" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"bmj" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
+"bmr" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"bmu" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "bmx" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -1943,18 +2033,21 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"bmG" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plating,
+/area/f13/radiation)
 "bmW" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"bnf" = (
-/obj/structure/sink{
-	pixel_y = 28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"bnm" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "bnn" = (
 /obj/effect/decal/remains{
@@ -1978,6 +2071,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"bnG" = (
+/obj/structure/flora/grass/wasteland{
+	layer = 4.2;
+	pixel_x = -3
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
+	},
+/area/f13/caves)
 "bnJ" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "khanrage";
@@ -2000,6 +2103,13 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"boj" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "bol" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -2058,28 +2168,12 @@
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"bpo" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "bpA" = (
 /obj/structure/table/wood/settler,
 /obj/item/clothing/head/helmet/f13/raidercombathelmet,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"bpB" = (
-/obj/structure/rack,
-/obj/item/shovel,
-/obj/item/radio/off,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "bpD" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -2103,6 +2197,11 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"bpX" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/tunnel)
 "bqs" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -2116,21 +2215,36 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"bqw" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bqB" = (
 /obj/structure/table/wood,
 /obj/item/paper,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"bqC" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole";
+	tag = "icon-hole"
+	},
+/area/f13/wasteland)
 "bqH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"brr" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain2bottom";
-	tag = "icon-verticaloutermain2bottom"
+"bqP" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	tag = "icon-wooden_chair_new (NORTH)"
 	},
-/area/f13/wasteland)
+/obj/effect/decal/remains/human,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "brE" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -2156,15 +2270,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
-"bto" = (
-/obj/effect/landmark/start/f13/deputy,
-/obj/structure/chair/bench,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/pinup_ride{
-	pixel_x = -32
+"bts" = (
+/obj/structure/holohoop{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left"
+	},
+/area/f13/wasteland)
 "btN" = (
 /turf/closed/wall/f13/wood,
 /area/f13/ncr)
@@ -2173,21 +2286,6 @@
 	icon_state = "verticalrightborderleft2"
 	},
 /area/f13/wasteland)
-"buo" = (
-/obj/item/reagent_containers/food/snacks/grown/broc,
-/obj/item/reagent_containers/food/snacks/grown/broc,
-/obj/item/reagent_containers/food/snacks/grown/broc,
-/obj/item/reagent_containers/food/snacks/grown/broc,
-/obj/item/reagent_containers/food/snacks/grown/xander,
-/obj/item/reagent_containers/food/snacks/grown/xander,
-/obj/item/reagent_containers/food/snacks/grown/xander,
-/obj/item/reagent_containers/food/snacks/grown/xander,
-/obj/structure/closet/fridge{
-	desc = "An old pre-war fridge. This one is proudly labeled as lead-lined"
-	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "buu" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -2199,12 +2297,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
-"buC" = (
-/obj/effect/landmark/start/f13/deputy,
-/obj/structure/chair/bench,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "buD" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -2213,11 +2305,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "buO" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
-	tag = "icon-housewood2-broken"
+/obj/effect/decal/waste{
+	pixel_x = 18;
+	pixel_y = 12
 	},
-/area/f13/village)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outermaincornerinner"
+	},
+/area/f13/wasteland)
 "buW" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2232,14 +2327,6 @@
 /obj/machinery/recharger,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"bvq" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1";
-	tag = "icon-horizontaloutermain1 (NORTH)"
-	},
-/area/f13/wasteland)
 "bvs" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2259,44 +2346,25 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"bvV" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
-"bwb" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -10;
-	tag = "icon-sink (WEST)"
-	},
-/obj/structure/mirror{
-	pixel_x = -32
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "bwo" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
-	tag = "icon-housewood3-broken"
+/obj/item/toy/beach_ball/holoball,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
-/area/f13/village)
+/area/f13/wasteland)
 "bwE" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
-"bwF" = (
-/obj/structure/bed,
-/obj/item/bedsheet/blue,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+"bwG" = (
+/obj/structure/holohoop{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "bwM" = (
 /obj/effect/landmark/start/f13/auxilia,
 /obj/effect/decal/cleanable/dirt,
@@ -2361,6 +2429,14 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
+"byY" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "bzb" = (
 /obj/structure/chair/stool{
 	icon_state = "bench"
@@ -2369,11 +2445,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"bzf" = (
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/wasteland)
 "bzm" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -2382,12 +2453,16 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "bzq" = (
-/obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
-	tag = "icon-housewood2-broken"
+	icon_state = "housewood4-broken"
 	},
-/area/f13/village)
+/area/f13/radiation)
+"bzr" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13/wood{
+	icon_state = "housebase"
+	},
+/area/f13/radiation)
 "bzB" = (
 /obj/item/ammo_casing/c10mm/ap,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2407,22 +2482,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"bzU" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
+"bzZ" = (
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
-/area/f13/building)
-"bzV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/wasteland)
+/area/f13/radiation)
 "bAe" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -2441,15 +2506,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
-"bAJ" = (
-/obj/structure/simple_door/house{
-	icon_state = "interior";
-	tag = "icon-interior"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "bAS" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -2466,12 +2522,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"bAX" = (
-/obj/machinery/grill,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "bBi" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -2480,13 +2530,6 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
-"bBm" = (
-/obj/structure/flora/grass/wasteland{
-	layer = 4.2;
-	pixel_x = -3
-	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "bBG" = (
 /obj/structure/chair/sofa/corp,
@@ -2510,18 +2553,22 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"bCm" = (
-/obj/effect/landmark/start/f13/ncrlogisticsofficer,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/wasteland)
 "bCG" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
+"bCM" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
+"bDb" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0";
+	tag = "icon-horizontaltopborderbottom0"
+	},
+/area/f13/wasteland)
 "bDr" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/worn,
@@ -2537,6 +2584,12 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"bDu" = (
+/obj/effect/decal/riverbankcorner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "bDO" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
@@ -2545,6 +2598,16 @@
 /obj/item/clothing/under/f13/formal,
 /obj/machinery/light/small/broken{
 	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"bEe" = (
+/obj/structure/table/wood/settler,
+/obj/item/storage/box/matches,
+/obj/item/storage/fancy/candle_box,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -2560,18 +2623,24 @@
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
-"bEy" = (
-/obj/structure/tires/five,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0";
-	tag = "icon-horizontaltopbordertop0"
-	},
-/area/f13/wasteland)
 "bEB" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/f13Cash/random/ncr/low,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
+"bEP" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housebase"
+	},
+/area/f13/radiation)
+"bER" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "bEX" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
@@ -2598,10 +2667,6 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
-"bFr" = (
-/obj/structure/simple_door/tent,
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "bFA" = (
 /obj/structure/bed/mattress{
@@ -2633,12 +2698,27 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"bFY" = (
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "bFZ" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"bGu" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housebase"
+	},
+/area/f13/radiation)
 "bGw" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/dirt,
@@ -2658,27 +2738,18 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"bHt" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/dirt,
+"bHr" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
-"bHF" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/protectron,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+"bHZ" = (
+/obj/machinery/light{
+	dir = 1
 	},
-/area/f13/building)
-"bHX" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetbrown";
-	tag = "icon-sheetbrown"
-	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/holofloor/carpet,
 /area/f13/building)
 "bIh" = (
 /turf/closed/wall/f13/wood/house,
@@ -2686,14 +2757,21 @@
 "bIp" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/brotherhood)
-"bIV" = (
-/turf/open/floor/plasteel/floorgrime,
+"bIO" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/obj/effect/spawner/lootdrop/clothing_high,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "bIX" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblecorner"
 	},
+/area/f13/wasteland)
+"bJe" = (
+/obj/structure/flora/tree/joshua,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "bJo" = (
 /obj/structure/fence/corner/wooden{
@@ -2718,10 +2796,10 @@
 	},
 /area/f13/building)
 "bKs" = (
-/mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+	dir = 4;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (EAST)"
 	},
 /area/f13/wasteland)
 "bKv" = (
@@ -2741,18 +2819,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"bLa" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/flashlight{
-	icon_state = "seclite"
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "bLL" = (
 /obj/structure/table/snooker{
 	dir = 9
@@ -2760,6 +2826,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"bLX" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	tag = "icon-wooden_chair_new (NORTH)"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "bMe" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2817,15 +2893,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"bOH" = (
-/obj/machinery/light/small{
-	dir = 1
+"bOG" = (
+/obj/machinery/light/sign/oasis,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright3"
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	tag = "icon-housewood4-broken"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "bOO" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2840,36 +2913,35 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "bPj" = (
-/obj/machinery/light/small/broken{
-	dir = 4
+/obj/structure/table/wood/fancy/black,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = 30
 	},
-/turf/open/floor/plasteel/floorgrime,
+/obj/item/modular_computer/laptop/preset/civillian,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel/grimy,
 /area/f13/building)
 "bPk" = (
-/obj/machinery/light/small/broken{
-	dir = 8
+/obj/structure/table/wood/fancy/black,
+/obj/structure/decoration/clock/active{
+	pixel_y = 30
 	},
-/turf/open/floor/wood,
+/obj/item/reagent_containers/pill/patch/turbo{
+	layer = 2.4
+	},
+/turf/open/floor/plasteel/grimy,
 /area/f13/building)
 "bPH" = (
-/obj/structure/bed,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/structure/table/wood/fancy/black,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = 30
 	},
-/obj/item/bedsheet/brown,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/wasteland)
-"bPU" = (
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
-/obj/item/storage/trash_stack,
-/turf/open/floor/plating,
-/area/f13/caves)
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/turf/open/floor/plasteel/grimy,
+/area/f13/building)
 "bQh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2884,24 +2956,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"bQy" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/shreds{
-	pixel_x = -6;
-	pixel_y = -12
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"bQB" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/tunnel)
 "bQI" = (
 /obj/item/flag/bos,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -2918,14 +2972,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"bQU" = (
-/obj/structure/table,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "bRz" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -2934,17 +2980,11 @@
 	},
 /area/f13/ncr)
 "bRF" = (
-/obj/structure/table/wood,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/pen,
-/obj/item/pen,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1{
-	layer = 2.1
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
 "bRG" = (
 /obj/structure/disposalpipe/broken{
@@ -2956,25 +2996,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"bSk" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+"bSg" = (
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalcorroded"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
-"bSE" = (
-/obj/structure/table,
-/obj/item/kitchen/knife,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "bSR" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
@@ -3015,26 +3044,14 @@
 /obj/machinery/mineral/wasteland_vendor/medical,
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
-"bUF" = (
-/obj/structure/closet/crate/trashcart{
-	name = "corpse cart"
+"bVq" = (
+/obj/structure/table/wood/poker,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = 30
 	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
-"bUR" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft1"
-	},
-/area/f13/wasteland)
-"bVp" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "bVT" = (
 /obj/structure/window/fulltile/house{
@@ -3053,22 +3070,6 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
-"bWt" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0";
-	tag = "icon-verticalrightborderright0"
-	},
-/area/f13/wasteland)
-"bWx" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 9;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "bWB" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/road{
@@ -3076,9 +3077,21 @@
 	},
 /area/f13/wasteland)
 "bWF" = (
-/obj/machinery/trading_machine/ammo,
-/turf/open/floor/f13/wood,
+/obj/structure/table/wood/poker,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = 30
+	},
+/turf/open/floor/wood/f13/carpet,
 /area/f13/building)
+"bWL" = (
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontal"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/tunnel)
 "bWS" = (
 /obj/machinery/shower{
 	dir = 4
@@ -3099,6 +3112,23 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"bXC" = (
+/obj/structure/table/wood/poker,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = 30
+	},
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/building)
+"bXG" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = 25;
+	pixel_y = 18
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "bXM" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -3117,15 +3147,18 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
-"bZU" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+"bZq" = (
+/obj/structure/table/wood/poker,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = 30
 	},
-/obj/structure/closet/cabinet,
-/obj/item/gun/ballistic/automatic/pistol/m1911,
-/obj/item/ammo_box/magazine/m45,
-/turf/open/floor/f13/wood,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_x = 30
+	},
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "caa" = (
 /mob/living/simple_animal/hostile/ghoul,
@@ -3137,17 +3170,25 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"cai" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/f13/building)
+"caj" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plating,
+/area/f13/radiation)
 "cam" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland)
-"caq" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/building)
+"cau" = (
+/obj/machinery/power/smes,
+/turf/open/floor/plating,
+/area/f13/radiation)
 "cbf" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/road{
@@ -3176,15 +3217,12 @@
 	},
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/wasteland)
-"ccf" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gibleg"
+"ccj" = (
+/obj/machinery/computer/operating,
+/obj/item/disk/surgery,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
 	},
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "ccF" = (
 /obj/structure/bed,
@@ -3192,15 +3230,6 @@
 	icon_state = "sheetgrey"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"ccG" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/chem_pile{
-	pixel_x = -10;
-	pixel_y = -1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/supermart,
 /area/f13/building)
 "cdc" = (
 /turf/open/indestructible/ground/outside/road{
@@ -3213,23 +3242,14 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
-"cdL" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8
+"cdQ" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	tag = "icon-wooden_chair_new (NORTH)"
 	},
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/storage/pill_bottle/chem_tin/radx,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
-"cek" = (
-/obj/structure/toilet{
-	pixel_y = 13
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/city)
+/obj/machinery/light/small,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "ces" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -3237,18 +3257,20 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
-"ceL" = (
-/obj/structure/simple_door/tentflap_cloth,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+"cex" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner"
+	},
+/area/f13/wasteland)
 "ceT" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"cfd" = (
-/obj/structure/flora/wasteplant/wild_broc,
+"cfc" = (
+/obj/structure/barricade/tentclothedge,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/building)
 "cfn" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -3264,37 +3286,25 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/water,
 /area/f13/caves)
-"cfS" = (
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"cgi" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermainleft";
-	tag = "icon-horizontaloutermainleft"
-	},
-/area/f13/wasteland)
-"cgy" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"cgA" = (
-/obj/item/reagent_containers/glass/bucket,
+"cgC" = (
+/obj/structure/chair/wood,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
-	icon_state = "dirt";
-	tag = "icon-dirt (SOUTHEAST)"
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"cgY" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "cht" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"chK" = (
-/obj/structure/flora/wasteplant/wild_feracactus,
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
+	},
 /area/f13/wasteland)
 "chM" = (
 /obj/structure/window/fulltile/house{
@@ -3316,6 +3326,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"chX" = (
+/obj/item/flag/oasis,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland)
 "cia" = (
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/outside/dirt{
@@ -3339,15 +3355,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
-"ciL" = (
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "cjf" = (
 /obj/machinery/light/sign/chiken_ranch,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3367,14 +3374,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "cjG" = (
-/obj/structure/flora/wasteplant/wild_fungus,
-/turf/open/indestructible/ground/outside/desert,
+/obj/item/flag/oasis,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
 /area/f13/wasteland)
 "cjS" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"cjU" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/building)
 "cjV" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
@@ -3383,10 +3400,6 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/village)
-"ckf" = (
-/obj/machinery/power/smes,
-/turf/open/floor/plating,
-/area/f13/radiation)
 "ckt" = (
 /obj/structure/sink/puddle,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3435,24 +3448,18 @@
 /obj/structure/closet/crate/wicker,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
-"cly" = (
-/obj/structure/simple_door/bunker,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+"cmj" = (
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
+/turf/open/floor/plasteel/grimy,
 /area/f13/building)
-"clO" = (
-/obj/structure/simple_door/house{
-	icon_state = "interior";
-	tag = "icon-interior"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/city)
+"cmF" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/folder/blue,
+/obj/item/pen,
+/turf/open/floor/plasteel/grimy,
+/area/f13/building)
 "cmR" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -3485,6 +3492,11 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"con" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "cos" = (
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
@@ -3517,16 +3529,25 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"cpJ" = (
-/obj/structure/chair/office/dark{
-	dir = 4;
-	icon_state = "officechair_dark"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "cpK" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"cpL" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowbottom"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
+"cpY" = (
+/obj/structure/bed,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "cqe" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light{
@@ -3549,33 +3570,35 @@
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"crd" = (
-/obj/item/trash/cheesie,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
 "crp" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"crW" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "post_wood"
+"crA" = (
+/obj/item/flag/followers,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
 	},
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "csk" = (
 /turf/open/water,
 /area/f13/caves)
+"csl" = (
+/obj/structure/musician/piano{
+	desc = "What a wierd piano..";
+	name = "minimoog"
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/building)
+"csm" = (
+/mob/living/simple_animal/hostile/wolf,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2";
+	tag = "icon-verticalleftborderright2"
+	},
+/area/f13/wasteland)
 "csO" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
@@ -3612,14 +3635,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
-"ctT" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/building)
 "ctZ" = (
 /obj/structure/fence/corner{
 	dir = 4;
@@ -3630,20 +3645,17 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"cuf" = (
-/obj/structure/chair/wood/modern{
-	dir = 1;
-	tag = "icon-wooden_chair_new (NORTH)"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "cuv" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cuz" = (
+/obj/structure/fence{
+	dir = 1;
+	icon_state = "straight"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "cuG" = (
 /turf/open/indestructible/ground/outside/water{
 	density = 1;
@@ -3656,13 +3668,6 @@
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/water,
 /area/f13/caves)
-"cuZ" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
-	tag = "icon-dirt"
-	},
-/area/f13/wasteland)
 "cvp" = (
 /obj/structure/chair/comfy/plywood{
 	dir = 4
@@ -3676,28 +3681,44 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"cvE" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/building)
 "cvH" = (
 /obj/structure/table/wood/settler,
 /obj/item/pickaxe,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"cvI" = (
-/obj/structure/simple_door/room,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"cwS" = (
+"cwg" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleftbottom";
-	tag = "icon-verticalleftborderleftbottom"
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"cwW" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+"cwB" = (
+/obj/structure/table/wood/poker,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_x = 30
+	},
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/building)
+"cwO" = (
+/turf/open/floor/plasteel/chapel{
+	dir = 9
+	},
+/area/f13/building)
+"cxy" = (
+/turf/open/floor/plasteel/chapel{
+	dir = 5
 	},
 /area/f13/building)
 "cxL" = (
@@ -3715,6 +3736,21 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"cyJ" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/legion)
+"cyU" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "czx" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -3723,10 +3759,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"czA" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plating,
-/area/f13/caves)
 "czE" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibtorso"
@@ -3736,10 +3768,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"czR" = (
-/mob/living/simple_animal/hostile/wolf,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "czU" = (
 /obj/item/reagent_containers/food/snacks/grown/chili,
 /mob/living/simple_animal/hostile/wolf/alpha,
@@ -3755,20 +3783,34 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
+"cAJ" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "cAM" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cBb" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/knife/cosmicdirty,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
 /area/f13/building)
 "cBh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"cBB" = (
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "cBS" = (
 /obj/machinery/light/small/broken,
@@ -3784,13 +3826,32 @@
 /mob/living/simple_animal/hostile/raider/thief,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"cDk" = (
-/obj/item/clothing/suit/armor/f13/rustedcowboy,
-/obj/item/clothing/head/helmet/f13/rustedcowboyhat,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+"cDf" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/building)
+"cEm" = (
+/obj/structure/closet,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs/cable,
+/obj/item/restraints/handcuffs/cable,
+/obj/item/restraints/legcuffs/bola,
+/turf/open/floor/plating,
+/area/f13/radiation)
+"cEo" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland)
 "cFe" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/destructible/tribal_torch/lit,
@@ -3799,27 +3860,28 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"cFx" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_y = 12
-	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 5
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+"cFg" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"cFO" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
+"cGb" = (
+/obj/structure/table/wood/settler,
+/obj/item/flashlight/lamp,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "cGj" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -3838,6 +3900,9 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
+"cGJ" = (
+/turf/closed/wall/f13/wood/house,
+/area/f13/wasteland)
 "cGL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -3861,6 +3926,17 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
+"cGW" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outermaincornerouter";
+	tag = "icon-outermaincornerouter (WEST)"
+	},
+/area/f13/wasteland)
 "cHk" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/ruins{
@@ -3874,10 +3950,6 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"cHH" = (
-/obj/structure/flora/wasteplant/wild_punga,
-/turf/open/water,
-/area/f13/wasteland)
 "cIh" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -3886,8 +3958,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cIm" = (
-/obj/structure/table/wood/bar,
-/turf/open/floor/f13/wood,
+/obj/item/twohanded/required/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/grimy,
 /area/f13/building)
 "cIL" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -3899,6 +3971,9 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"cJZ" = (
+/turf/open/floor/plasteel/grimy,
+/area/f13/building)
 "cKg" = (
 /obj/structure/window/fulltile/wood/broken{
 	desc = "Feed me! FEED ME!";
@@ -3915,22 +3990,17 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
-"cKp" = (
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "cKC" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/f13/wood,
+/obj/machinery/light/small/broken,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/building)
-"cLk" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/floor/f13/wood,
+"cKN" = (
+/obj/structure/table/wood/poker,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = -30
+	},
+/turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "cLo" = (
 /obj/structure/bookcase,
@@ -3938,10 +4008,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"cLD" = (
-/obj/machinery/vending/cola/random,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "cLP" = (
 /obj/item/paper,
 /obj/machinery/light/small{
@@ -3983,16 +4049,47 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "cNE" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"cNJ" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/structure/table/wood/poker,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_x = 30
 	},
-/obj/item/storage/toolbox/mechanical/old,
-/turf/open/floor/plasteel/dark,
+/obj/item/radio/intercom{
+	name = "radio station intercom";
+	pixel_y = -30
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/building)
+"cNF" = (
+/obj/structure/table/reinforced,
+/obj/item/taperecorder,
+/obj/item/pda/engineering,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/ncr)
+"cNH" = (
+/turf/open/floor/plasteel/chapel{
+	dir = 6
+	},
+/area/f13/building)
+"cOg" = (
+/obj/structure/table/wood/settler,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
+"cOi" = (
+/obj/structure/chair/comfy{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "cOk" = (
 /obj/structure/car/rubbish1,
@@ -4021,32 +4118,20 @@
 /obj/structure/sink/puddle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"cOW" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/hatchet,
-/obj/item/clothing/gloves/botanic_leather,
-/obj/item/cultivator,
-/obj/item/shovel/spade,
-/obj/item/reagent_containers/spray/pestspray,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner";
-	tag = "icon-dirtcorner"
-	},
-/area/f13/wasteland)
-"cPg" = (
-/obj/machinery/light/small,
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "cPn" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"cPB" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "cPF" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -4056,15 +4141,6 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"cPI" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbroken";
-	tag = "icon-housewindowbroken"
-	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "cPR" = (
 /obj/structure/chair/wood/fancy,
 /obj/machinery/light/small/broken{
@@ -4072,12 +4148,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"cPV" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress6"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "cPZ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -4095,19 +4165,39 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"cQM" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+"cQU" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "cRh" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"cRk" = (
+/obj/structure/dresser,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "cRH" = (
-/obj/structure/table/wood/fancy,
-/obj/item/restraints/handcuffs,
-/obj/item/melee/chainofcommand/tailwhip/kitty,
-/turf/open/floor/f13/wood,
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken (NORTHEAST)"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
+"cRJ" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "cRM" = (
 /obj/structure/debris/v3,
@@ -4130,6 +4220,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"cSh" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetcmo";
+	tag = "icon-sheetcmo"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cSA" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -4142,16 +4240,15 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
-"cSF" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2bottom";
-	tag = "icon-verticalleftborderleft2bottom"
-	},
-/area/f13/wasteland)
 "cSH" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cSO" = (
+/obj/structure/fence/corner,
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "cST" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/dirt,
@@ -4164,6 +4261,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
+"cTc" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_x = -1
+	},
+/obj/structure/curtain,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/building)
 "cTp" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/desert,
@@ -4193,12 +4300,20 @@
 /obj/item/trash/f13/cram,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"cVw" = (
-/obj/structure/cable,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
+"cVj" = (
+/obj/structure/simple_door/tentflap_cloth{
+	pixel_y = -3
 	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
+"cVw" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/building)
 "cVx" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -4218,20 +4333,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"cVV" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
+"cVK" = (
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench_center"
 	},
-/area/f13/wasteland)
-"cVW" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "cWq" = (
 /obj/structure/closet/crate/freezer/blood{
 	pixel_y = -5
@@ -4243,14 +4351,14 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "cWB" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
+/obj/structure/sink{
 	dir = 4;
-	icon_state = "dirt"
+	pixel_x = 12
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/building)
 "cWG" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -4275,6 +4383,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"cXh" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
 "cXj" = (
 /obj/structure/simple_door/tent,
 /obj/structure/decoration/rag,
@@ -4287,16 +4405,9 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"cXP" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/city)
+"cXB" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland)
 "cXU" = (
 /obj/machinery/door/airlock/hatch{
 	req_access_txt = "120"
@@ -4309,6 +4420,11 @@
 	icon_state = "redmark"
 	},
 /area/f13/building)
+"cYH" = (
+/obj/structure/closet/cabinet,
+/obj/item/dildo,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cYL" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -4318,6 +4434,12 @@
 /obj/structure/sign/poster/contraband/pinup_vixen,
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
+"cYT" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/building)
 "cYY" = (
 /obj/machinery/vending/coffee,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4332,12 +4454,29 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"cZT" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "prospectorladder";
+	layer = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/building)
 "cZW" = (
 /obj/machinery/vending/cola/random,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"dau" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "daB" = (
 /obj/structure/chair/wood/worn{
 	dir = 4
@@ -4351,36 +4490,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "daM" = (
-/obj/structure/simple_door/metal/fence,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/simple_door/glass,
+/turf/open/floor/wood,
+/area/f13/building)
 "daU" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"daW" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3";
-	tag = "icon-horizontaltopbordertop3"
+"dba" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/area/f13/wasteland)
-"daY" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/turf/open/floor/wood/f13/oak,
+/obj/item/storage/toolbox/drone,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "dbh" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/structure/simple_door/interior,
+/turf/open/floor/wood,
+/area/f13/building)
 "dbt" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4442,6 +4571,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"dcW" = (
+/obj/machinery/door/airlock/glass_large{
+	name = "Followers Clinic"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "dcY" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4454,22 +4591,28 @@
 /obj/item/trash/f13/dog,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ddf" = (
-/obj/structure/fence{
-	dir = 4
-	},
+"ddR" = (
+/obj/item/twohanded/required/kirbyplants/dead,
+/obj/item/reagent_containers/pill/fixer,
+/obj/item/reagent_containers/pill/insulin,
+/turf/open/floor/wood,
+/area/f13/building)
+"dea" = (
+/obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
+	dir = 4;
+	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
 	},
 /area/f13/wasteland)
+"deb" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/wood,
+/area/f13/building)
 "def" = (
-/obj/structure/table/wood/settler,
-/obj/item/lighter,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
+/obj/item/twohanded/required/kirbyplants/dead,
+/turf/open/floor/wood,
 /area/f13/building)
 "deE" = (
 /obj/structure/chair/wood/modern{
@@ -4479,9 +4622,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "deQ" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/turf/open/floor/f13/wood,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "deU" = (
 /obj/structure/barricade/sandbags,
@@ -4498,14 +4645,19 @@
 /area/f13/caves)
 "dfx" = (
 /obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetblue"
+/obj/item/bedsheet,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/machinery/light/small/broken{
-	dir = 1
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
+"dfL" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "dfQ" = (
 /obj/structure/fence{
 	dir = 4
@@ -4522,18 +4674,24 @@
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"dgt" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "dgB" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "dgG" = (
-/obj/structure/decoration/clock/old{
-	pixel_y = 32
+/obj/structure/simple_door/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "dgK" = (
 /obj/effect/landmark/start/f13/shaman,
@@ -4547,22 +4705,15 @@
 	},
 /area/f13/wasteland)
 "dhB" = (
-/obj/structure/rack,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/tomato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/sugarcane,
-/obj/item/seeds/sugarcane,
-/obj/machinery/light/small/broken{
-	dir = 1
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench";
+	tag = "icon-bench (EAST)"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "dhC" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -4572,6 +4723,12 @@
 /obj/structure/reagent_dispensers/barrel/two,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"dhE" = (
+/obj/structure/bed/mattress,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "dhL" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/light/small/broken{
@@ -4579,11 +4736,6 @@
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"dim" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/fancy/candle_box,
-/turf/open/floor/holofloor/carpet,
-/area/f13/building)
 "dit" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/building)
@@ -4610,6 +4762,9 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"diJ" = (
+/turf/open/floor/wood/f13/oakbroken3,
+/area/f13/legion)
 "diK" = (
 /obj/structure/table/reinforced,
 /obj/structure/decoration/clock{
@@ -4639,23 +4794,19 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"djH" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0";
-	tag = "icon-verticalinnermain0"
-	},
-/area/f13/wasteland)
+"djk" = (
+/obj/structure/simple_door/interior,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "djK" = (
 /obj/item/storage/backpack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"djY" = (
-/mob/living/simple_animal/chick,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"dkf" = (
-/obj/machinery/workbench,
-/turf/open/floor/wood/f13/oak,
+"dkd" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "dkg" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4671,10 +4822,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"dkE" = (
-/obj/item/clothing/gloves/botanic_leather,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+"dkr" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "dkF" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/machinery/light/small{
@@ -4682,6 +4835,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"dkK" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "dkP" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2top"
@@ -4694,14 +4855,8 @@
 	},
 /area/f13/building)
 "dlb" = (
-/obj/structure/rack,
-/obj/item/shovel/spade,
-/obj/item/shovel,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/cultivator,
-/obj/item/storage/bag/plants,
-/obj/item/scythe,
-/turf/open/floor/f13/wood,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "dlB" = (
 /obj/structure/car/rubbish1,
@@ -4769,18 +4924,33 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"doo" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_y = 12
+"dop" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "doB" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
+/area/f13/building)
+"doF" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/button/door{
+	id = "frontgateshu2t";
+	name = "gate shutters";
+	pixel_x = -5;
+	pixel_y = 32
+	},
+/obj/machinery/button/door{
+	id = "interiorgate2";
+	name = "Interior door button";
+	pixel_x = 6;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "doM" = (
 /obj/structure/ore_box,
@@ -4803,18 +4973,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"doZ" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2right";
-	tag = "icon-horizontaltopborderbottom2right"
-	},
-/area/f13/wasteland)
-"dpc" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland)
 "dpg" = (
 /obj/structure/car/rubbish2,
 /turf/closed/wall/r_wall/rust,
@@ -4827,22 +4985,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"dpA" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/holofloor/carpet,
-/area/f13/building)
-"dpC" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "dpG" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"dpH" = (
+/obj/effect/spawner/lootdrop/crafts,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dpK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/wooden,
@@ -4857,86 +5009,38 @@
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dpZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+"dpS" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters{
+	id = "frontgateshut2";
+	name = "gate shutters"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "dqc" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"dqk" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0";
-	tag = "icon-verticalrightborderright0"
-	},
 /area/f13/wasteland)
 "dqn" = (
 /obj/item/clothing/under/f13/cowboyg,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dqo" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"dqw" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen{
-	pixel_y = 9
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
-"dqD" = (
-/obj/structure/table/wood/settler,
-/obj/item/crafting/abraxo,
-/obj/item/crafting/duct_tape,
-/obj/structure/sink/kitchen{
-	pixel_y = 27
-	},
-/obj/structure/mirror{
-	pixel_x = -26;
-	pixel_y = -1
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/building)
 "dqI" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/caves)
+"dqZ" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "dre" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"dro" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0";
-	tag = "icon-horizontaltopborderbottom0"
-	},
-/area/f13/wasteland)
-"drK" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
-"drN" = (
-/obj/structure/window/fulltile/wood,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "dsh" = (
 /obj/structure/rack,
 /obj/item/clothing/head/sombrero,
@@ -4945,6 +5049,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"dsi" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/wasteland)
 "dsn" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -4955,11 +5068,25 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"dso" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "dss" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"dsA" = (
+/obj/machinery/computer/arcade,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "dsL" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/desert,
@@ -4993,13 +5120,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"dtI" = (
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/structure/table/wood/fancy,
-/obj/effect/spawner/lootdrop/three_course_meal,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "dtJ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "badboys";
@@ -5007,12 +5127,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dtK" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "dtO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -5077,11 +5191,12 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"dvL" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+"dvG" = (
+/obj/machinery/icecream_vat,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "dvQ" = (
 /obj/structure/barricade/bars,
 /obj/structure/window/fulltile/house,
@@ -5093,18 +5208,10 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
-"dwk" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/book/bible,
-/turf/open/floor/holofloor/carpet,
+"dwx" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood/house,
 /area/f13/building)
-"dwG" = (
-/obj/structure/fence/corner,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "dwR" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -5116,18 +5223,25 @@
 	},
 /area/f13/building)
 "dwS" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
 "dxf" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"dxm" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
 "dxo" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
@@ -5144,26 +5258,12 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"dxG" = (
-/obj/structure/railing,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "dxJ" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"dxS" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
-/area/f13/wasteland)
 "dys" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -5174,6 +5274,23 @@
 /obj/structure/closet,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"dyH" = (
+/obj/effect/landmark/start/f13/prospector,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/building)
+"dyO" = (
+/obj/machinery/button/door{
+	id = "prospectorshutters";
+	name = "gate shutters";
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/building)
 "dyQ" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -5182,19 +5299,26 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "dza" = (
-/obj/structure/table/wood,
-/obj/item/pen/fountain,
-/obj/item/pen/fountain,
-/obj/item/pen/fountain,
-/obj/item/pen/fountain,
-/turf/open/floor/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "dzf" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
+/obj/structure/chair/comfy/black,
+/turf/open/floor/wood,
 /area/f13/building)
+"dzm" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/airless,
+/area/f13/legion)
+"dzz" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	tag = "icon-housewindow"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "dzE" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -5254,6 +5378,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"dAX" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/landmark/start/f13/ncrmp,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/ncr)
 "dBa" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -5279,20 +5412,24 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"dCk" = (
-/obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2"
+"dCi" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -10;
+	tag = "icon-sink (WEST)"
 	},
-/area/f13/wasteland)
-"dCx" = (
-/obj/structure/flora/wasteplant/wild_xander,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"dCJ" = (
-/obj/effect/decal/cleanable/generic,
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"dCw" = (
+/obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
+	icon_state = "horizontaltopborderbottom0";
+	tag = "icon-horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
 "dCU" = (
@@ -5340,6 +5477,15 @@
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"dDF" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "dDK" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5368,10 +5514,6 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"dEY" = (
-/obj/structure/fence/corner/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "dFc" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -5385,11 +5527,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"dFM" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "dFQ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left"
@@ -5407,26 +5544,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"dGR" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outermaincornerouter";
-	tag = "icon-outermaincornerouter (WEST)"
-	},
-/area/f13/wasteland)
-"dHl" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner";
-	tag = "icon-dirtcorner (NORTH)"
-	},
-/area/f13/wasteland)
+"dGZ" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/f13/building)
 "dHq" = (
-/obj/structure/window/fulltile/house{
-	dir = 2
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
 "dHN" = (
 /obj/structure/table/wood,
@@ -5435,20 +5561,8 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"dHO" = (
-/obj/structure/wreck/trash/machinepiletwo{
-	layer = 3
-	},
-/obj/item/flag/oasis,
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"dHX" = (
-/obj/structure/table/wood/bar,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/f13/wood,
+"dIN" = (
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
 "dIR" = (
 /obj/structure/bus_door,
@@ -5472,13 +5586,6 @@
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/wood/interior,
 /area/f13/village)
-"dJs" = (
-/obj/structure/lamp_post/quadra,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerbordercorner"
-	},
-/area/f13/wasteland)
 "dJv" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/f13/police,
@@ -5505,10 +5612,10 @@
 	},
 /area/f13/building)
 "dJY" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/obj/item/clothing/under/f13/classdress,
-/turf/open/floor/f13/wood,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
 "dKa" = (
 /obj/machinery/light/small,
@@ -5522,13 +5629,6 @@
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
-"dKt" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	tag = "icon-housewood4-broken"
-	},
-/area/f13/building)
 "dKA" = (
 /obj/structure/table,
 /obj/item/kitchen/knife{
@@ -5543,14 +5643,41 @@
 	},
 /area/f13/building)
 "dKR" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/fork,
-/turf/open/floor/f13/wood,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/f13/building)
+"dKT" = (
+/obj/structure/fence/corner{
+	dir = 6;
+	icon_state = "corner"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"dLa" = (
+/obj/structure/table/wood,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/pen,
+/obj/item/pen,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1{
+	layer = 2.1
+	},
+/turf/open/floor/wood,
 /area/f13/building)
 "dLb" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood,
+/area/f13/building)
+"dLg" = (
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	name = "prewar lounge chair"
+	},
+/turf/open/floor/wood,
 /area/f13/building)
 "dLl" = (
 /obj/structure/table/wood,
@@ -5575,6 +5702,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"dMk" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dMI" = (
 /obj/structure/chair/comfy,
 /obj/machinery/light/small/broken{
@@ -5586,20 +5718,6 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
-"dNg" = (
-/obj/item/ammo_casing/c9mm/ap,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1";
-	tag = "icon-horizontaloutermain1 (NORTH)"
-	},
-/area/f13/wasteland)
-"dNt" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "innermaincornerinner";
-	tag = "icon-innermaincornerinner"
 	},
 /area/f13/wasteland)
 "dNT" = (
@@ -5639,6 +5757,12 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
+"dOi" = (
+/obj/item/mop,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "dOl" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib6-old";
@@ -5664,17 +5788,22 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
-"dPw" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housebase";
-	tag = "icon-housebase"
+"dPF" = (
+/obj/structure/table/wood/poker,
+/obj/machinery/light/small{
+	dir = 8
 	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "dQf" = (
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/table,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"dQD" = (
+/obj/structure/barricade/tentclothcorner,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "dRd" = (
 /obj/item/seeds/pumpkin,
@@ -5700,6 +5829,18 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
+"dRu" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
+"dRG" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "dRI" = (
 /obj/machinery/light{
 	dir = 8
@@ -5707,13 +5848,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"dRN" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	termtag = "Business"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "dRT" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -5722,13 +5856,12 @@
 /obj/item/soap/homemade,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
-"dSx" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1";
-	tag = "icon-verticalinnermain1"
-	},
-/area/f13/wasteland)
+"dSd" = (
+/obj/structure/table/wood,
+/obj/item/phone,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/wood,
+/area/f13/building)
 "dTl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -5737,6 +5870,22 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
+"dTT" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/f13/building)
+"dTY" = (
+/mob/living/simple_animal/hostile/handy,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"dUk" = (
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33";
+	tag = "icon-wasteland33"
+	},
+/area/f13/wasteland)
 "dUv" = (
 /turf/open/floor/carpet/black,
 /area/f13/legion)
@@ -5777,22 +5926,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"dWw" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"dWz" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/wood/f13/oakbroken3,
-/area/f13/building)
 "dWH" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt{
@@ -5800,12 +5933,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
-"dWR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/building)
 "dWZ" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -5829,10 +5956,25 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/village)
+"dXN" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "dXQ" = (
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"dYe" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "dYY" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt{
@@ -5856,9 +5998,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "dZT" = (
-/obj/structure/table/wood/settler,
-/obj/item/toy/cards/deck,
-/turf/open/floor/f13/wood,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "ean" = (
 /obj/structure/table/wood,
@@ -5891,6 +6035,18 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"ebc" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "ebv" = (
 /obj/structure/closet,
 /obj/effect/turf_decal/stripes/white/box,
@@ -5901,6 +6057,14 @@
 /obj/item/trash/cheesie,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ebT" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "ecm" = (
 /obj/structure/table/snooker{
 	dir = 1
@@ -5908,21 +6072,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"ecx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cargocrate,
-/obj/structure/cargocrate{
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
 "ecM" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/tunnel)
+"ecS" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innermaincornerinner";
+	tag = "icon-innermaincornerinner"
+	},
+/area/f13/wasteland)
 "edA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -5942,11 +6103,31 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"edO" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "ees" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"eeC" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft2top";
+	tag = "icon-verticalrightborderleft2top"
+	},
+/area/f13/wasteland)
+"eeJ" = (
+/obj/structure/chair/wood/modern{
+	dir = 8;
+	tag = "icon-wooden_chair_new (WEST)"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "eeO" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/wood/f13,
@@ -5958,15 +6139,23 @@
 	},
 /area/f13/brotherhood)
 "egb" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/smartfridge/bottlerack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "egn" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"egJ" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "egK" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -6012,25 +6201,19 @@
 	},
 /area/f13/wasteland)
 "ehP" = (
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
+/obj/machinery/smartfridge/bottlerack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "ehV" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13/wood,
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
-"eid" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "straight"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+"eip" = (
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "eiB" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/item/reagent_containers/food/drinks/beer/light{
@@ -6067,12 +6250,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"eiJ" = (
-/obj/effect/decal/riverbank{
-	dir = 4
-	},
-/turf/open/water,
-/area/f13/wasteland)
 "ejk" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6097,12 +6274,23 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
 "ejD" = (
-/obj/machinery/seed_extractor,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ejT" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/wasteland)
+"ekp" = (
+/obj/item/instrument/eguitar{
+	anchored = 1;
+	pixel_x = 32
+	},
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "ekI" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/item/flashlight,
@@ -6167,9 +6355,25 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"ems" = (
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_y = 3
+	},
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "emz" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/tunnel)
+"emQ" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "emU" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6177,14 +6381,17 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"emZ" = (
+"enp" = (
 /obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
 	tag = "icon-bluerustychess2"
 	},
-/area/f13/building)
+/area/f13/city)
 "enx" = (
 /obj/structure/decoration/clock/old,
 /turf/closed/wall/f13/store,
@@ -6203,6 +6410,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
+"enR" = (
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "124"
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "eoi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -6221,6 +6437,11 @@
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
+/area/f13/building)
+"eov" = (
+/obj/structure/musician/piano,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "eoA" = (
 /obj/machinery/hydroponics/soil,
@@ -6241,12 +6462,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"epy" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft3";
-	tag = "icon-verticalleftborderleft3"
-	},
-/area/f13/wasteland)
 "epF" = (
 /obj/structure/fence,
 /turf/open/floor/f13{
@@ -6265,12 +6480,22 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"eqo" = (
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33";
-	tag = "icon-wasteland33"
+"eqj" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleftbottom";
+	tag = "icon-verticalleftborderleftbottom"
 	},
 /area/f13/wasteland)
+"eqo" = (
+/obj/structure/chair/stool/f13stool{
+	pixel_x = -8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "eqv" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -6280,16 +6505,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"eqx" = (
-/obj/structure/table/wood/settler,
-/obj/item/storage/box/matches,
-/obj/item/storage/fancy/candle_box,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "eqF" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -6297,14 +6512,6 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "bar"
-	},
-/area/f13/building)
-"eqL" = (
-/obj/structure/simple_door/house{
-	icon_state = "room"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
 "eqN" = (
@@ -6322,8 +6529,9 @@
 	},
 /area/f13/wasteland)
 "esj" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/f13/wood,
+/obj/machinery/jukebox,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "esD" = (
 /obj/structure/table/wood,
@@ -6332,6 +6540,22 @@
 /obj/item/storage/bag/ore,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"esE" = (
+/obj/item/gun/ballistic/shotgun/trench{
+	anchored = 1;
+	pixel_y = 5
+	},
+/obj/item/gun/ballistic/shotgun/hunting{
+	anchored = 1;
+	pixel_y = -3
+	},
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "esP" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2bottom"
@@ -6346,10 +6570,24 @@
 	},
 /area/f13/building)
 "etg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/costumes,
-/turf/open/floor/f13/wood,
+/obj/machinery/light/sign,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
+"etC" = (
+/obj/structure/table,
+/obj/item/pen{
+	pixel_y = 9
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "etG" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -6361,6 +6599,15 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/wasteland)
+"etN" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
 "etV" = (
@@ -6386,19 +6633,28 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"euL" = (
+/obj/structure/table/wood/settler,
+/obj/item/crafting/abraxo,
+/obj/item/crafting/duct_tape,
+/obj/structure/sink/kitchen{
+	pixel_y = 27
+	},
+/obj/structure/mirror{
+	pixel_x = -26;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
+"euO" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "euP" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
 /area/f13/caves)
-"evc" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetcmo";
-	tag = "icon-sheetcmo"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "evs" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -6408,16 +6664,6 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"evz" = (
-/obj/structure/table,
-/obj/item/kitchen/knife/butcher,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/city)
 "evL" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -6427,13 +6673,6 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
-"evP" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "evU" = (
 /obj/machinery/grill,
 /turf/open/indestructible/ground/outside/desert,
@@ -6447,20 +6686,18 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"ewa" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/building)
 "ewd" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
+"ewY" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "exj" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -6475,12 +6712,12 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland)
-"exn" = (
+"exp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2";
-	tag = "icon-horizontaltopbordertop2"
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/caves)
 "exS" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/ruins{
@@ -6494,37 +6731,24 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
 "eyg" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "shopladder"
 	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eyi" = (
 /obj/item/trash/f13/steak,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"eyp" = (
-/obj/structure/closet/crate/trashcart{
-	name = "corpse cart"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "eyI" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"eyN" = (
-/obj/structure/chair{
-	dir = 4;
-	tag = "icon-chair (EAST)"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/item/clothing/under/pants/f13/ghoul,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eyV" = (
@@ -6565,6 +6789,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ezE" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/reagent_containers/medspray/sterilizine,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -30
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "ezG" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -6572,6 +6808,19 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"ezR" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/hatchet,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/obj/item/reagent_containers/spray/pestspray,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner"
+	},
+/area/f13/wasteland)
 "ezX" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/ncr)
@@ -6587,12 +6836,20 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
-"eAo" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+"eAK" = (
+/obj/machinery/button/door{
+	id = "shopouter";
+	name = "gate shutters";
+	pixel_y = 32
 	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"eAS" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "eBc" = (
 /obj/structure/table/wood/settler,
@@ -6629,6 +6886,11 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"eCi" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "eCr" = (
 /obj/structure/rack,
 /obj/item/clothing/under/suit_jacket/navy,
@@ -6637,12 +6899,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eCJ" = (
-/obj/structure/fence/corner,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermainleft";
-	tag = "icon-horizontaloutermainleft"
-	},
-/area/f13/wasteland)
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/structure/rack,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "eCK" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13{
@@ -6666,27 +6933,42 @@
 	},
 /area/f13/building)
 "eDx" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Armory";
-	req_access_txt = "121"
+/obj/machinery/button/door{
+	id = "countershutters";
+	name = "counter shutters";
+	pixel_x = 6;
+	pixel_y = 30
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
+/obj/machinery/button/door{
+	id = "storeshutters";
+	name = "store shutters";
+	pixel_x = -6;
+	pixel_y = 30
 	},
-/area/f13/wasteland)
-"eDz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/wasteland_vendor/mining,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_y = 32
+	},
+/obj/structure/rack,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"eDT" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "eEt" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
+/obj/structure/fence{
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "eEz" = (
@@ -6696,11 +6978,12 @@
 	},
 /area/f13/wasteland)
 "eEC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/item/book/granter/trait/chemistry,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eEI" = (
@@ -6715,9 +6998,10 @@
 	},
 /area/f13/building)
 "eEK" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
 /area/f13/building)
 "eEL" = (
 /obj/machinery/light/small/broken{
@@ -6738,16 +7022,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"eFs" = (
-/obj/structure/chair/stool{
-	dir = 8;
-	icon_state = "bench";
-	tag = "icon-bench (WEST)"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "eFA" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -6757,13 +7031,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"eFL" = (
-/mob/living/simple_animal/hostile/wolf,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright2";
-	tag = "icon-verticalleftborderright2"
-	},
-/area/f13/wasteland)
 "eFW" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -6772,12 +7039,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "eGo" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerbordercorner";
-	tag = "icon-outerbordercorner (EAST)"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/area/f13/wasteland)
+/area/f13/building)
+"eGp" = (
+/obj/structure/table/wood/poker,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "eGs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -6786,25 +7058,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"eGt" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/knife/butcher,
-/obj/item/clothing/suit/apron/chef,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
-"eGu" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "eGz" = (
 /obj/structure/table,
 /obj/machinery/chem_master{
@@ -6834,10 +7087,11 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "eHB" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/crafting/goodparts/five,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "eHQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6845,6 +7099,19 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"eHZ" = (
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"eIg" = (
+/obj/effect/landmark/start/f13/prospector,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "eIC" = (
 /obj/item/flag/ncr,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6881,6 +7148,17 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
+"eJr" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"eJu" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
 "eJN" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -6905,15 +7183,6 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"eKz" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	tag = "icon-housewindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "eKB" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -6934,20 +7203,12 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"eLd" = (
-/obj/structure/table,
-/obj/item/kitchen/fork,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "eLe" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/f13/wood,
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "radio"
+	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
 "eLo" = (
 /obj/item/clothing/under/jabroni,
@@ -6955,11 +7216,37 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
+"eLu" = (
+/obj/structure/table/optable,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
+"eLJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/workbench,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "eMs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/debris/v3,
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
+"eMB" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/legion)
 "eMD" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertopright"
@@ -6992,11 +7279,22 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"eMZ" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 8
+"eNs" = (
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/chair,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"eNC" = (
+/obj/structure/table/wood,
+/obj/item/pen/fountain,
+/obj/item/pen/fountain,
+/obj/item/pen/fountain,
+/obj/item/pen/fountain,
+/turf/open/floor/wood,
 /area/f13/building)
 "eNT" = (
 /obj/machinery/light/small{
@@ -7007,6 +7305,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"eOc" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "eOd" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7029,16 +7336,20 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
-"eOY" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "eOZ" = (
 /obj/structure/table/wood,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"ePh" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood,
+/area/f13/building)
+"ePw" = (
+/obj/structure/table/wood,
+/obj/item/papercutter,
+/turf/open/floor/wood,
 /area/f13/building)
 "ePz" = (
 /obj/machinery/light,
@@ -7050,6 +7361,16 @@
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/f13/wood/house,
 /area/f13/village)
+"ePQ" = (
+/obj/structure/chair/comfy{
+	dir = 4;
+	tag = "icon-comfychair (EAST)"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "eQb" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -7087,6 +7408,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"eQw" = (
+/obj/machinery/trading_machine/medical,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "eQx" = (
 /obj/structure/table/wood,
 /obj/item/storage/toolbox/mechanical/old,
@@ -7118,6 +7445,20 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"eRC" = (
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "eRJ" = (
 /obj/structure/fence{
 	dir = 4
@@ -7125,21 +7466,21 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"eRK" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 4;
+	icon_state = "innermaincornerinner";
+	tag = "icon-innermaincornerinner (EAST)"
+	},
+/area/f13/wasteland)
+"eRO" = (
+/turf/open/floor/plasteel/chapel{
+	dir = 10
+	},
+/area/f13/building)
 "eRT" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/wood/f13,
-/area/f13/building)
-"eRU" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/reinforced/fulltile{
-	layer = 2.8
-	},
-/obj/structure/fence{
-	pixel_x = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
 /area/f13/building)
 "eSh" = (
 /obj/structure/barricade/sandbags,
@@ -7152,21 +7493,6 @@
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"eSC" = (
-/turf/open/indestructible/ground/outside/road{
-	dir = 4;
-	icon_state = "innermaincornerouter";
-	tag = "icon-innermaincornerouter (EAST)"
-	},
-/area/f13/wasteland)
-"eSF" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
 "eST" = (
 /obj/structure/rack,
 /obj/item/claymore/machete/warclub,
@@ -7184,18 +7510,6 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"eTJ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
-/area/f13/building)
-"eTL" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/building)
 "eTO" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -7205,13 +7519,11 @@
 	},
 /area/f13/building)
 "eTZ" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/eyebot{
-	faction = list("neutral");
-	name = "PE-A"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+/obj/structure/table/wood/settler,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/building)
 "eUg" = (
@@ -7231,6 +7543,12 @@
 /obj/item/bedsheet/black,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"eUp" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
+	},
+/area/f13/wasteland)
 "eUz" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -7248,26 +7566,47 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/village)
-"eVb" = (
-/obj/structure/holohoop{
-	dir = 4
+"eUQ" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
-	},
-/area/f13/wasteland)
-"eVh" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"eVb" = (
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"eVh" = (
+/obj/structure/toilet{
+	dir = 8;
+	tag = "icon-toilet00 (WEST)"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"eVj" = (
+/obj/structure/table/wood,
+/obj/item/melee/curator_whip{
+	desc = "It stings like hell to be hit by.";
+	name = "Slave whip"
+	},
+/obj/item/melee/curator_whip{
+	desc = "It stings like hell to be hit by.";
+	name = "Slave whip"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "eVQ" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/bundle/costume/chicken,
@@ -7307,6 +7646,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"eXb" = (
+/obj/structure/simple_door/interior,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/clinic)
 "eXw" = (
 /mob/living/simple_animal/hostile/raider/baseball,
 /turf/open/indestructible/ground/outside/dirt,
@@ -7380,10 +7725,6 @@
 /obj/structure/closet,
 /obj/item/reagent_containers/pill/patch/jet,
 /obj/item/reagent_containers/pill/patch/jet,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"eZr" = (
-/obj/item/trash/can,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eZs" = (
@@ -7470,54 +7811,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fbH" = (
-/obj/effect/decal/waste{
-	pixel_x = 18;
-	pixel_y = 12
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outermaincornerinner"
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
-"fbM" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
 "fck" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/f13/caves)
-"fcr" = (
-/obj/structure/destructible/tribal_torch{
-	pixel_y = 20
-	},
-/obj/structure/wreck/trash/three_barrels,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
-"fcw" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/computer/terminal{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"fcA" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "fcE" = (
 /obj/structure/reagent_dispensers/barrel/three{
 	pixel_x = -14
@@ -7570,13 +7875,13 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"fej" = (
-/obj/structure/barricade/wooden,
+"feg" = (
+/obj/structure/simple_door/tentflap_cloth,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
+	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "fek" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -7597,17 +7902,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"feM" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetcmo"
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "feR" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -7627,10 +7921,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"ffw" = (
-/obj/structure/car/rubbish1,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "ffA" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/mineral/random/low_chance,
@@ -7649,6 +7939,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"ffT" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "ffY" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7685,10 +7981,6 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"fgn" = (
-/mob/living/simple_animal/hostile/handy,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "fgp" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -7697,6 +7989,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"fgI" = (
+/obj/machinery/microwave/stove,
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters button";
+	pixel_y = 32;
+	req_one_access_txt = "28"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "fgL" = (
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/f13,
@@ -7712,17 +8014,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
-"fhs" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "clinicdesk";
-	name = "counter shutters"
-	},
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
 "fhG" = (
 /obj/structure/simple_door/metal/fence{
 	door_type = "fence_wood";
@@ -7737,6 +8028,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"fiN" = (
+/obj/machinery/plantgenes,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "fjg" = (
 /obj/item/stack/rods/ten,
 /turf/open/floor/f13/wood,
@@ -7758,14 +8055,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"fjN" = (
-/obj/machinery/light/sign,
-/obj/structure/barricade/wooden,
-/obj/effect/decal/fakelattice,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3"
-	},
-/area/f13/wasteland)
 "fjR" = (
 /obj/item/kitchen/knife/butcher,
 /turf/open/floor/f13/wood,
@@ -7784,6 +8073,14 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
+"fkd" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHEAST)"
+	},
+/area/f13/wasteland)
 "fkj" = (
 /obj/structure/barricade/bars,
 /obj/structure/window/fulltile/house,
@@ -7803,30 +8100,9 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"fkW" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+"flP" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
-"flj" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Secret"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
-"flI" = (
-/obj/structure/fence/wooden{
-	dir = 1
-	},
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "fmm" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
@@ -7849,8 +8125,7 @@
 /area/f13/village)
 "fmO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "fmP" = (
 /obj/machinery/light/small{
@@ -7865,24 +8140,20 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"fmV" = (
-/obj/structure/mirror{
-	pixel_y = 30
-	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/clinic)
 "fmW" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"fmX" = (
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/machinery/door/poddoor/shutters{
+	id = "barshutters"
+	},
+/obj/structure/table/wood/settler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "fnB" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -7921,12 +8192,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"foB" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
 "foM" = (
 /obj/structure/chair/wood,
 /obj/machinery/light/small/broken{
@@ -7935,19 +8200,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "foN" = (
-/obj/item/toy/beach_ball/holoball,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+/obj/structure/chair/stool/retro/backed{
+	dir = 8
 	},
-/area/f13/wasteland)
-"foX" = (
-/obj/structure/fence/wooden{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "fpg" = (
 /obj/machinery/light/small{
@@ -7969,11 +8225,6 @@
 	dir = 1
 	},
 /turf/open/floor/f13,
-/area/f13/building)
-"fps" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "fpt" = (
 /obj/item/clothing/suit/armor/f13/kit,
@@ -8015,11 +8266,12 @@
 	},
 /area/f13/legion)
 "fqS" = (
-/obj/structure/holohoop{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "frr" = (
 /obj/machinery/mineral/wasteland_vendor/crafting{
 	icon_state = "parts_idle"
@@ -8027,29 +8279,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fru" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
-/area/f13/radiation)
-"frv" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood/f13/oakbroken,
 /area/f13/building)
 "frx" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/floor/f13/wood{
-	icon_state = "housebase"
-	},
-/area/f13/radiation)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "frz" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
-	tag = "icon-housewood2-broken"
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
 	},
-/area/f13/radiation)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "frB" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
@@ -8068,10 +8309,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
-"frO" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+"frY" = (
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "fsl" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8094,12 +8338,10 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/water,
 /area/f13/caves)
-"fsO" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
-	tag = "icon-housewood2-broken"
-	},
+"fsQ" = (
+/obj/effect/decal/cleanable/generic,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "fsU" = (
 /obj/structure/table/wood/settler,
@@ -8116,6 +8358,22 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
+"ftN" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft3";
+	tag = "icon-verticalleftborderleft3"
+	},
+/area/f13/wasteland)
+"fuc" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "fug" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8150,11 +8408,19 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"fuN" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housebase"
+"fuy" = (
+/obj/structure/rack,
+/obj/item/storage/box/disks_plantgene,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/area/f13/radiation)
+/area/f13/building)
+"fuN" = (
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "fuU" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -8163,11 +8429,31 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"fvi" = (
+/obj/structure/wreck/car,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"fvt" = (
+/obj/effect/landmark/start/f13/shopkeeper,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/building)
+"fvw" = (
+/turf/open/floor/wood/f13/oakbroken4,
+/area/f13/legion)
 "fvz" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2bottom"
 	},
 /area/f13/wasteland)
+"fvX" = (
+/obj/machinery/light/small,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fws" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
@@ -8190,6 +8476,24 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"fxe" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
+"fxf" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/building)
 "fxx" = (
 /obj/item/picket_sign,
 /turf/open/indestructible/ground/outside/road{
@@ -8211,18 +8515,15 @@
 "fyf" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"fyI" = (
-/obj/structure/chair/wood{
-	dir = 1
+"fyo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/obj/effect/landmark/start/f13/ncrheavytrooper,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
+/area/f13/building)
 "fyO" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/machinery/light/small/broken{
@@ -8283,26 +8584,15 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"fAB" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
+"fAP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/building)
-"fAG" = (
-/obj/structure/curtain,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"fAN" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2";
-	tag = "icon-horizontalinnermain2"
-	},
-/area/f13/wasteland)
 "fBl" = (
 /obj/structure/rack,
 /obj/item/camera,
@@ -8320,16 +8610,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"fBs" = (
-/obj/structure/bonfire,
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outermaincornerouter"
-	},
-/area/f13/wasteland)
 "fBx" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden,
@@ -8357,19 +8637,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"fBO" = (
-/obj/item/stack/sheet/mineral/wood,
+"fCe" = (
+/obj/structure/rack,
+/obj/item/clothing/head/hardhat,
+/obj/item/storage/bag/ore,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/building)
-"fBT" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/clinic)
 "fCg" = (
 /obj/structure/billboard/ritas,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8395,10 +8672,11 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"fCW" = (
-/obj/structure/flora/wasteplant/wild_punga,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+"fCT" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/ketchup,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "fDi" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/floor/f13/wood,
@@ -8410,9 +8688,10 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"fDp" = (
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
+"fDx" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood,
+/area/f13/building)
 "fDG" = (
 /obj/structure/fence/wooden{
 	dir = 1;
@@ -8420,6 +8699,30 @@
 	},
 /turf/open/floor/wood/f13/stage_br,
 /area/f13/wasteland)
+"fEg" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/chapel{
+	dir = 5
+	},
+/area/f13/building)
+"fEi" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/table,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
+"fFd" = (
+/obj/structure/table,
+/obj/structure/table,
+/obj/item/wirecutters{
+	icon_state = "cutters";
+	tag = "icon-cutters"
+	},
+/turf/open/floor/plating,
+/area/f13/caves)
 "fFu" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/desert,
@@ -8451,6 +8754,12 @@
 /obj/item/bedsheet/black,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"fFT" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
+/area/f13/building)
 "fGc" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8474,72 +8783,37 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"fGj" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/building)
-"fGl" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/landmark/start/f13/ncrmp,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/ncr)
 "fGr" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"fGA" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
+"fGS" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbrokenvertical"
 	},
-/obj/effect/spawner/lootdrop/trash,
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"fGC" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/city)
-"fGS" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt";
-	tag = "icon-dirt (SOUTHWEST)"
-	},
-/area/f13/wasteland)
 "fHx" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3"
+/obj/structure/simple_door/house{
+	icon_state = "glass";
+	tag = "icon-glass"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"fIa" = (
-/obj/structure/simple_door/bunker,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/building)
-"fIk" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/landmark/start/f13/ncrmp,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/area/f13/ncr)
+/area/f13/building)
+"fHF" = (
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gibtorso"
+	},
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "fIn" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -8561,18 +8835,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"fIV" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outermaincornerinner";
-	tag = "icon-outermaincornerinner (WEST)"
-	},
-/area/f13/wasteland)
 "fJj" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "fJl" = (
 /obj/structure/bonfire,
@@ -8590,17 +8858,22 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
-"fKJ" = (
-/obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/condiment/yeast,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/crafting/wonderglue,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+"fKq" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/building)
+"fKt" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/building)
 "fKN" = (
@@ -8612,57 +8885,42 @@
 /obj/item/lighter,
 /turf/open/floor/f13,
 /area/f13/building)
-"fKW" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
-	},
-/area/f13/building)
 "fLc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"fLB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken4,
+/area/f13/legion)
 "fLC" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32"
 	},
 /area/f13/wasteland)
-"fLJ" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "fLN" = (
 /obj/structure/rack,
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"fLR" = (
-/obj/effect/spawner/lootdrop/trash,
+"fMj" = (
+/obj/structure/simple_door/house,
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "fMu" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
-"fMv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken,
-/area/f13/legion)
-"fMy" = (
-/obj/structure/simple_door/tentflap_cloth,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/building)
+"fML" = (
+/obj/machinery/hydroponics/soil,
+/mob/living/simple_animal/chick,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "fMO" = (
 /obj/item/ammo_casing/c10mm/ap{
 	dir = 5
@@ -8682,14 +8940,14 @@
 /obj/structure/chair,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"fNz" = (
-/obj/structure/fence{
-	dir = 4;
-	tag = "icon-metal_fence3"
+"fNE" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "fNP" = (
@@ -8700,6 +8958,15 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"fOe" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/obj/item/soap/deluxe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "fOf" = (
 /obj/structure/sign/poster/prewar/poster90,
@@ -8717,6 +8984,13 @@
 	icon_state = "horizontalbottomborderbottom2right"
 	},
 /area/f13/wasteland)
+"fOy" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "fOC" = (
 /obj/structure/sign/poster/prewar/poster90,
 /turf/closed/wall/r_wall/rust,
@@ -8725,16 +8999,6 @@
 /obj/machinery/light/broken,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"fOQ" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"fPl" = (
-/obj/effect/decal/riverbank,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
 "fPL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/hydroponics{
@@ -8752,14 +9016,6 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"fPP" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "fPT" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -8772,16 +9028,15 @@
 /obj/item/twohanded/spear,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
-"fQc" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0";
-	tag = "icon-verticalleftborderleft0"
-	},
-/area/f13/wasteland)
 "fQr" = (
 /obj/effect/decal/riverbank,
 /turf/open/water,
 /area/f13/wasteland)
+"fQt" = (
+/obj/effect/landmark/start/f13/barkeep,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "fQu" = (
 /obj/machinery/hydroponics/soil{
 	mutmod = 2;
@@ -8789,20 +9044,18 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"fQv" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "fQz" = (
 /obj/structure/table/wood/poker{
 	name = "felt table"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
-"fQV" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/desert,
+"fQE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/retro/backed{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "fQW" = (
 /obj/item/folder/yellow,
@@ -8835,13 +9088,6 @@
 /obj/structure/table,
 /turf/open/floor/f13,
 /area/f13/building)
-"fRM" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "133"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "fRR" = (
 /obj/structure/disposalpipe/broken,
 /obj/effect/decal/cleanable/oil{
@@ -8862,19 +9108,26 @@
 	icon_state = "verticalleftborderright2top"
 	},
 /area/f13/wasteland)
-"fSD" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain3";
-	tag = "icon-verticalinnermain3"
+"fSz" = (
+/obj/structure/chair/booth{
+	dir = 4
 	},
-/area/f13/wasteland)
-"fTj" = (
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontaltopborderbottom2left";
-	tag = "icon-horizontaltopborderbottom2left (WEST)"
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"fSE" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"fTl" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "fTn" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood{
@@ -8907,17 +9160,23 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "fTW" = (
-/obj/structure/fence/corner,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavement"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "fUb" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"fUu" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
 "fUZ" = (
@@ -8947,19 +9206,6 @@
 /obj/item/reagent_containers/food/condiment/soymilk,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"fVZ" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housebase"
-	},
-/area/f13/radiation)
-"fWi" = (
-/obj/structure/table/wood,
-/obj/item/clothing/suit/armor/f13/raider/raidermetal,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "fWj" = (
 /obj/item/ammo_casing/caseless{
 	dir = 6
@@ -8996,12 +9242,31 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"fXA" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "fXO" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"fXP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"fXY" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "fYa" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9018,16 +9283,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"fYv" = (
-/obj/structure/chair/wood/modern{
-	dir = 1;
-	tag = "icon-wooden_chair_new (NORTH)"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "fYP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/hydronutrients,
@@ -9040,14 +9295,14 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
-"fYZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+"fZm" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Sheriff Office";
+	req_one_access_txt = "62"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "fZv" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -9060,17 +9315,6 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
-"gan" = (
-/obj/structure/closet,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"gaF" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "gaV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt{
@@ -9078,24 +9322,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"gaZ" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "gbd" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/f13,
 /area/f13/building)
-"gbl" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "gbn" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights,
@@ -9126,11 +9356,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"gbS" = (
-/turf/open/floor/plating/f13/outside/road{
-	icon_state = "cross1"
-	},
-/area/f13/wasteland)
 "gbW" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -9143,14 +9368,21 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
-"gck" = (
-/obj/structure/closet,
-/obj/item/storage/box/gloves,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "gcK" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"gdl" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "gdN" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/desert,
@@ -9182,14 +9414,10 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
-"geR" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2bottom";
-	tag = "icon-verticalleftborderleft2bottom"
-	},
-/area/f13/wasteland)
+"gfc" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/r_wall/rust,
+/area/f13/building)
 "gfB" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -9197,11 +9425,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gfR" = (
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "interiorgate2"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
 "gfY" = (
 /obj/structure/barricade/tentclothedge{
@@ -9214,17 +9441,6 @@
 	dir = 8
 	},
 /turf/open/floor/f13,
-/area/f13/building)
-"ggk" = (
-/obj/structure/closet,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/disk/surgery/oasis,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "ggo" = (
 /obj/structure/car,
@@ -9261,22 +9477,53 @@
 	},
 /area/f13/wasteland)
 "ghx" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner";
-	tag = "icon-dirtcorner (EAST)"
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
 "ghD" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small/broken,
 /turf/open/water,
 /area/f13/caves)
+"ghE" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"ghG" = (
+/obj/effect/landmark/start/f13/shopkeeper,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"ghH" = (
+/obj/machinery/shower{
+	dir = 4;
+	icon_state = "shower"
+	},
+/obj/structure/decoration/hatch,
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "ghX" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"gim" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/building)
 "gin" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
@@ -9303,14 +9550,15 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"giH" = (
-/obj/structure/table/wood,
-/obj/structure/wreck/trash/halftire{
-	pixel_y = -21
-	},
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+"giG" = (
+/obj/structure/wreck/trash/two_tire,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/clinic)
+"giQ" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft3";
+	tag = "icon-verticalleftborderleft3"
 	},
 /area/f13/wasteland)
 "giX" = (
@@ -9370,6 +9618,16 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"gjM" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/eyebot{
+	faction = list("neutral");
+	name = "PE-A"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/building)
 "gjP" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/village)
@@ -9391,30 +9649,9 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
-"gks" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
+"gkZ" = (
+/turf/open/floor/plasteel/chapel,
 /area/f13/building)
-"gkv" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft2bottom";
-	tag = "icon-verticalrightborderleft2bottom"
-	},
-/area/f13/wasteland)
-"gkS" = (
-/obj/effect/decal/remains/human,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
-"gld" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/f13/radiation)
 "gln" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -9433,45 +9670,56 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"gmB" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2right";
+	tag = "icon-horizontaltopborderbottom2right"
+	},
+/area/f13/wasteland)
 "gmQ" = (
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/r_wall/rust,
 /area/f13/ncr)
 "gmR" = (
-/obj/machinery/vending/cola/space_up,
-/obj/effect/decal/cleanable/glass{
-	pixel_x = 12
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"gmW" = (
+/obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/area/f13/wasteland)
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "gmX" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland)
 "gmZ" = (
-/obj/machinery/light/sign/oasis,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright3"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
+"gne" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
 "gnf" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2"
 	},
 /area/f13/wasteland)
-"gnj" = (
-/obj/structure/spider/stickyweb,
-/obj/structure/table,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "gnk" = (
 /turf/open/floor/f13,
 /area/f13/building)
@@ -9484,16 +9732,18 @@
 /obj/structure/decoration/clock/active,
 /turf/closed/wall/f13/wood,
 /area/f13/brotherhood)
-"gon" = (
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+"gof" = (
+/obj/structure/simple_door/room,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
+"gok" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/obj/structure/decoration/hatch,
-/obj/structure/window{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/f13/building)
 "goC" = (
 /obj/structure/chair/comfy{
@@ -9502,16 +9752,19 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"goK" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = 30
+"goG" = (
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/obj/item/modular_computer/laptop/preset/civillian,
-/obj/item/flashlight/lamp,
-/turf/open/floor/plasteel/grimy,
-/area/f13/building)
+/area/f13/city)
+"goK" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "goO" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -9541,21 +9794,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
-"gpv" = (
-/obj/structure/table/wood/poker,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"gpz" = (
-/obj/structure/bed,
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "gpC" = (
 /obj/structure/debris/v3,
 /turf/closed/mineral/random/low_chance,
@@ -9597,28 +9835,37 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"gqj" = (
-/obj/machinery/light/lampost{
-	dir = 1;
-	pixel_x = -32
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0";
-	tag = "icon-verticalrightborderright0"
+"gqd" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"gqo" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "gqz" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
+"gqE" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife/cosmicdirty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
+"gqO" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"gqR" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/meatsalted,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "grc" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
@@ -9629,20 +9876,21 @@
 /obj/structure/chair/right,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
+"grj" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/white{
+	desc = "It's a strangely clean little white rodent.";
+	name = "Algernon"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "grp" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottomright"
 	},
 /area/f13/wasteland)
 "grC" = (
-/obj/structure/table/wood/fancy/black,
-/obj/structure/decoration/clock/active{
-	pixel_y = 30
-	},
-/obj/item/reagent_containers/pill/patch/turbo{
-	layer = 2.4
-	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood/f13/oakbroken3,
 /area/f13/building)
 "gsa" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -9679,11 +9927,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"gsy" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "gsB" = (
 /obj/machinery/washing_machine,
 /obj/item/crafting/abraxo,
@@ -9692,16 +9935,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"gsP" = (
-/obj/structure/bed/mattress/pregame,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "gsV" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "gtj" = (
 /obj/structure/simple_door/metal/fence{
@@ -9734,13 +9971,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"gue" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
+"gtY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
+	dir = 8;
+	light_color = "#008000";
+	name = "light tube"
 	},
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "guh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -9753,6 +9993,13 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/village)
+"gur" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 4;
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter (EAST)"
+	},
+/area/f13/wasteland)
 "guw" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9792,17 +10039,19 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"gvN" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass/fifty,
+"gvp" = (
+/obj/machinery/door/morgue,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gvN" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "gvW" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
@@ -9812,15 +10061,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "gwn" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = 30
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
 	},
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
-/turf/open/floor/plasteel/grimy,
-/area/f13/building)
+/area/f13/wasteland)
 "gws" = (
 /obj/machinery/shower{
 	dir = 4
@@ -9857,19 +10102,6 @@
 /obj/structure/cross,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"gxv" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Gatehouse";
-	req_one_access_txt = "62"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"gxK" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "gxO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -9900,10 +10132,6 @@
 "gyh" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/workbench,
-/obj/item/book/granter/crafting_recipe/blueprint/r84,
-/obj/item/book/granter/crafting_recipe/blueprint/r82,
-/obj/item/book/granter/crafting_recipe/blueprint/service,
-/obj/item/book/granter/crafting_recipe/blueprint/m1garand,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -9918,6 +10146,26 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/brotherhood)
+"gyG" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/building)
+"gza" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	termtag = "Business"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
+"gzj" = (
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "gzq" = (
 /obj/machinery/hydroponics/soil{
 	mutmod = 2;
@@ -9925,10 +10173,39 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"gzQ" = (
+"gzD" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Store Backroom";
+	req_one_access_txt = "34"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"gzG" = (
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/shutters{
+	id = "countershutters";
+	name = "counter shutters"
+	},
+/obj/structure/barricade/bars,
+/obj/structure/railing,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"gzM" = (
+/obj/structure/bed/mattress,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
+"gzQ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
 "gzW" = (
@@ -9950,13 +10227,6 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
-"gAv" = (
-/obj/structure/chair/bench,
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "gAU" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -9975,6 +10245,13 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
+"gBj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/building)
 "gBu" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9982,6 +10259,12 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"gBT" = (
+/obj/structure/chair/wood,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/building)
 "gBW" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -9992,14 +10275,6 @@
 /obj/structure/closet/crate/miningcar,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"gCc" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/building)
 "gCd" = (
 /obj/structure/fence{
 	dir = 4
@@ -10011,6 +10286,27 @@
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"gCp" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain2top";
+	tag = "icon-verticaloutermain2top"
+	},
+/area/f13/wasteland)
+"gCq" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"gCu" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "gCw" = (
 /obj/structure/car/rubbish1,
 /turf/closed/wall/r_wall/rust,
@@ -10020,8 +10316,19 @@
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
 "gCN" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/wasteland_vendor/mining,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
+"gDl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "gDn" = (
 /obj/structure/fence{
@@ -10034,13 +10341,6 @@
 "gDs" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
-"gDJ" = (
-/obj/structure/tires/five,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2top";
-	tag = "icon-verticalleftborderleft2top"
-	},
 /area/f13/wasteland)
 "gDZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -10075,27 +10375,38 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"gET" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/closet/crate/trashcart{
+	name = "corpse cart"
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
 "gEY" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"gFA" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "gFR" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
+"gFV" = (
+/obj/structure/fluff/broken_flooring,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
 "gGp" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "gGt" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 5
-	},
+/turf/open/floor/plasteel/stairs/old,
 /area/f13/building)
 "gGu" = (
 /obj/structure/simple_door/metal/store{
@@ -10135,6 +10446,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"gHP" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/f13/building)
 "gHT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -10147,10 +10464,6 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
-"gHW" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "gHX" = (
 /obj/structure/chair/stool{
 	icon_state = "bench"
@@ -10160,6 +10473,16 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"gIy" = (
+/obj/structure/fence/corner/wooden{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"gIA" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/wood,
+/area/f13/building)
 "gIE" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/police,
@@ -10167,9 +10490,20 @@
 /obj/item/clothing/shoes/combat,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"gJx" = (
+/obj/item/instrument/guitar,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "gJI" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "gJP" = (
 /obj/structure/table,
@@ -10181,26 +10515,30 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"gJW" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "gJY" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
 /area/f13/building)
-"gKg" = (
-/obj/structure/table/wood,
-/obj/item/ammo_casing/shotgun/buckshot,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+"gKG" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "gKP" = (
 /obj/effect/decal/riverbankcorner,
 /turf/open/water,
 /area/f13/wasteland)
+"gLH" = (
+/obj/structure/window/fulltile/house,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "gLX" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -10226,6 +10564,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"gMS" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "gMV" = (
 /obj/structure/table/wood,
 /obj/item/pen,
@@ -10250,6 +10592,13 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"gNB" = (
+/obj/structure/flora/grass/wasteland{
+	layer = 4.2;
+	pixel_x = -3
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "gND" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -10263,6 +10612,12 @@
 	icon_state = "housebase"
 	},
 /area/f13/radiation)
+"gOs" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "gOD" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/simple_door/metal/ventilation,
@@ -10294,12 +10649,27 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"gPo" = (
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/structure/table/wood/fancy,
+/obj/effect/spawner/lootdrop/three_course_meal,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "gPy" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
 /area/f13/bar)
+"gPG" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gPK" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -10313,10 +10683,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "gPQ" = (
-/obj/structure/pondlily_small,
-/obj/effect/decal/riverbank,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/structure/simple_door/house{
+	icon_state = "interioropening";
+	tag = "icon-interioropening"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "gPR" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -10335,6 +10710,14 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"gPX" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "gQp" = (
 /obj/machinery/processor,
 /turf/open/floor/f13{
@@ -10350,18 +10733,10 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13,
 /area/f13/building)
-"gQA" = (
-/mob/living/simple_animal/hostile/raider,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "gQL" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"gQO" = (
-/obj/item/stack/f13Cash/random/med,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "gQQ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -10370,27 +10745,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"gQW" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/building)
 "gRa" = (
 /obj/structure/barricade/bars,
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland)
-"gRf" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "gRk" = (
@@ -10405,6 +10764,30 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"gRs" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "gSf" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -10418,18 +10801,6 @@
 /obj/structure/chair/bench,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"gSp" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 25
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"gSq" = (
-/obj/structure/table/wood,
-/obj/item/clothing/suit/armor/f13/raider/sadist,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "gSt" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerpavementcorner"
@@ -10439,6 +10810,18 @@
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
+"gSI" = (
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"gSZ" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetbrown";
+	tag = "icon-sheetbrown"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gTz" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/combat,
@@ -10449,6 +10832,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"gTC" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = 25;
+	pixel_y = 18
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "gTD" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/wood,
@@ -10470,21 +10861,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"gUb" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "gUq" = (
 /turf/open/floor/carpet/airless,
 /area/f13/legion)
 "gVd" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = 30
+/obj/structure/chair/booth{
+	dir = 4
 	},
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/wood/f13/carpet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "gVh" = (
 /obj/structure/fence/wooden,
@@ -10502,6 +10887,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"gVE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken4,
+/area/f13/building)
 "gVQ" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -10509,30 +10898,15 @@
 /obj/item/instrument/harmonica,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
-"gVV" = (
-/turf/open/floor/plating/f13/outside/road{
-	icon_state = "cross2"
-	},
-/area/f13/wasteland)
-"gWm" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2top";
-	tag = "icon-verticalleftborderleft2top"
-	},
-/area/f13/wasteland)
+"gWh" = (
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "gWo" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
-"gWF" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt";
-	tag = "icon-dirt (WEST)"
-	},
-/area/f13/building)
 "gWG" = (
 /obj/item/gun/ballistic/revolver/single_shotgun,
 /turf/open/floor/f13/wood{
@@ -10617,6 +10991,13 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gYi" = (
+/obj/item/trash/f13/sugarbombs,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "gYp" = (
 /obj/structure/closet,
 /obj/item/stack/sheet/plasteel/twenty,
@@ -10624,6 +11005,9 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gYu" = (
+/turf/open/floor/plating,
+/area/f13/radiation)
 "gYA" = (
 /obj/structure/rack,
 /obj/item/cultivator,
@@ -10636,34 +11020,28 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"gYL" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -10;
-	tag = "icon-sink (WEST)"
-	},
-/obj/structure/mirror{
-	pixel_x = -32
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/city)
 "gZi" = (
 /obj/structure/mirelurkegg,
 /turf/open/water,
 /area/f13/caves)
-"gZx" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
+"gZD" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall/rust,
 /area/f13/building)
-"gZJ" = (
-/obj/structure/chair/wood{
-	dir = 4
+"gZM" = (
+/obj/structure/fence{
+	dir = 1;
+	icon_state = "straight"
 	},
-/turf/open/floor/wood/f13/oakbroken2,
+/obj/structure/fence/corner{
+	dir = 8;
+	icon_state = "corner"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"gZW" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "hab" = (
 /obj/structure/chair/left{
@@ -10691,14 +11069,6 @@
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"haN" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetgrey";
-	tag = "icon-sheetgrey"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "haP" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/dirt,
@@ -10718,25 +11088,17 @@
 /obj/structure/window/fulltile/wood,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
-"hbG" = (
-/obj/machinery/light/small{
-	dir = 1
+"hbK" = (
+/obj/structure/fence{
+	dir = 4
 	},
-/obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/food,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "hbO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -10776,17 +11138,18 @@
 /obj/structure/mirror,
 /turf/closed/wall/r_wall/rust,
 /area/f13/ncr)
-"hdi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/f13/building)
 "hdr" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/cash_legion_low,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"hdT" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
 /area/f13/building)
 "hej" = (
 /obj/structure/fence{
@@ -10817,6 +11180,12 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"hfk" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertopright";
+	tag = "icon-horizontalbottombordertopright"
+	},
+/area/f13/wasteland)
 "hft" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
@@ -10828,14 +11197,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"hfK" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
 "hfV" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -10888,14 +11249,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"hgJ" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = 30
-	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/building)
 "hgM" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -10916,6 +11269,18 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"hhe" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/item/stack/sheet/cardboard,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "hhC" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -10936,11 +11301,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"hhQ" = (
-/mob/living/simple_animal/hostile/raider/baseball,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+"hhK" = (
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleftbottom"
 	},
 /area/f13/wasteland)
 "hio" = (
@@ -10952,19 +11316,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"hiB" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
-	tag = "icon-housewood3-broken"
-	},
-/area/f13/building)
 "hiG" = (
-/mob/living/simple_animal/hostile/wolf{
-	faction = list("hostile","wolf","raider");
-	name = "raider dog"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1";
+	tag = "icon-verticalinnermain1"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/area/f13/wasteland)
 "hiS" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -10979,10 +11336,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
-"hiX" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2";
-	tag = "icon-verticalinnermain2"
+"hjb" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
 "hjc" = (
@@ -11006,6 +11367,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"hjP" = (
+/obj/machinery/trading_machine,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hke" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -11023,6 +11388,14 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"hkz" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
+	},
+/area/f13/caves)
 "hkA" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/barber{
@@ -11030,33 +11403,11 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"hkG" = (
-/obj/effect/decal/riverbank{
-	dir = 5
-	},
-/turf/open/water,
-/area/f13/wasteland)
-"hkL" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
 "hkW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft3"
 	},
 /area/f13/wasteland)
-"hlh" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/building)
 "hlo" = (
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
@@ -11071,14 +11422,16 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"hmc" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = 30
+"hlQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/wood/f13/carpet,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"hmc" = (
+/obj/machinery/trading_machine/ammo,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "hmd" = (
 /obj/structure/car/rubbish4,
@@ -11116,31 +11469,37 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"hnq" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = 30
+"hnk" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 1
 	},
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_x = 30
-	},
-/obj/item/flashlight/lamp,
-/turf/open/floor/wood/f13/carpet,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
-"hnx" = (
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain3"
-	},
-/area/f13/wasteland)
 "hnB" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right";
 	tag = "icon-horizontaloutermain2right"
 	},
 /area/f13/wasteland)
+"hoe" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/closet/fridge,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/food,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "hom" = (
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
@@ -11149,32 +11508,24 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/tunnel)
-"hop" = (
-/obj/structure/barricade/tentclothedge,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+"hoX" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters{
+	id = "prospectorshutters"
 	},
-/area/f13/building)
-"hoG" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 8
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
-"hoS" = (
-/obj/machinery/vending/nukacolavend,
-/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "hpc" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "hpj" = (
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/wood,
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "hpm" = (
 /obj/item/storage/trash_stack,
@@ -11208,15 +11559,10 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"hpJ" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3"
-	},
-/area/f13/wasteland)
+"hpY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
 "hqr" = (
 /obj/machinery/vending/games,
 /turf/open/floor/f13/wood,
@@ -11231,12 +11577,12 @@
 	},
 /area/f13/building)
 "hqC" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt";
-	tag = "icon-dirt (EAST)"
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel/chapel{
+	dir = 6
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "hqL" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11255,28 +11601,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"hqQ" = (
-/obj/structure/fence{
-	dir = 4;
-	tag = "icon-metal_fence3"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0";
-	tag = "icon-verticalleftborderleft0"
-	},
-/area/f13/wasteland)
-"hrs" = (
-/obj/structure/chair/stool{
-	dir = 4;
-	icon_state = "bench";
-	tag = "icon-bench (EAST)"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1";
-	tag = "icon-horizontaloutermain1 (NORTH)"
-	},
-/area/f13/wasteland)
 "hrx" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13,
@@ -11296,15 +11620,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"hsc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/iv_drip,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "hsh" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -11315,13 +11630,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"hsk" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/holofloor/carpet,
-/area/f13/building)
 "hsy" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -11348,10 +11656,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "hsP" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical";
-	tag = "icon-housewindowvertical (NORTHEAST)"
-	},
+/obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2";
 	tag = "icon-housewood2"
@@ -11385,6 +11690,16 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"htp" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
+	},
+/area/f13/caves)
 "htx" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -11400,6 +11715,13 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/water,
 /area/f13/caves)
+"htQ" = (
+/obj/structure/chair/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "hul" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/head/helmet/gladiator,
@@ -11412,12 +11734,11 @@
 	icon_state = "shadowright"
 	},
 /area/f13/wasteland)
-"huA" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermaintop";
-	tag = "icon-verticaloutermaintop"
-	},
-/area/f13/wasteland)
+"huU" = (
+/obj/structure/table/wood/settler,
+/obj/item/flashlight/lantern,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "huW" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood{
@@ -11451,6 +11772,16 @@
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet/green,
 /area/f13/ncr)
+"hwn" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "hwr" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -11472,6 +11803,25 @@
 /obj/structure/fence,
 /turf/closed/wall/f13/tunnel,
 /area/f13/wasteland)
+"hxk" = (
+/obj/item/mop{
+	icon_state = "mopbucket";
+	tag = "icon-mopbucket"
+	},
+/obj/item/mop,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"hxn" = (
+/obj/machinery/shower{
+	dir = 8;
+	tag = "icon-shower (WEST)"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "hxp" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/f13{
@@ -11509,11 +11859,22 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hxQ" = (
-/obj/item/flag/oasis,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
+"hxU" = (
+/obj/machinery/vending/boozeomat{
+	density = 0;
+	pixel_x = -32
+	},
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "hxX" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -11569,12 +11930,6 @@
 	icon_state = "horizontalbottomborderbottomright"
 	},
 /area/f13/wasteland)
-"hzq" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2left"
-	},
-/area/f13/wasteland)
 "hzr" = (
 /obj/structure/table/wood,
 /obj/structure/table/wood,
@@ -11606,22 +11961,19 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"hzX" = (
-/obj/structure/table/wood,
-/obj/item/trash/sosjerky{
-	icon_state = "plate";
-	tag = "icon-plate"
-	},
-/obj/item/kitchen/fork{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "hAC" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33"
+	},
+/area/f13/wasteland)
+"hAN" = (
+/obj/structure/wreck/trash/five_tires,
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner"
 	},
 /area/f13/wasteland)
 "hAV" = (
@@ -11629,8 +11981,13 @@
 /turf/open/floor/carpet/green,
 /area/f13/ncr)
 "hAX" = (
-/turf/open/floor/plating/f13/outside/road{
-	icon_state = "cross3"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outermaincornerouter"
 	},
 /area/f13/wasteland)
 "hBr" = (
@@ -11641,6 +11998,10 @@
 	icon_state = "verticalleftborderright2top"
 	},
 /area/f13/wasteland)
+"hBW" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "hCa" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -11665,6 +12026,15 @@
 	icon_state = "verticalinnermaintop"
 	},
 /area/f13/wasteland)
+"hCv" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "hCF" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -11672,28 +12042,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"hDe" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
 "hDf" = (
 /obj/structure/simple_door/interior,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
-"hDr" = (
-/obj/structure/fence{
-	dir = 4;
-	tag = "icon-metal_fence3"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland)
 "hDC" = (
 /obj/structure/decoration/shock,
 /turf/closed/wall/r_wall/rust,
@@ -11718,16 +12070,11 @@
 	},
 /area/f13/building)
 "hEa" = (
-/obj/item/flag/oasis,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
+/obj/structure/flora/grass/wasteland{
+	pixel_x = -3
 	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"hEe" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "hEm" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/metal{
@@ -11737,6 +12084,18 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"hEq" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2";
+	tag = "icon-horizontaltopborderbottom2"
+	},
+/area/f13/wasteland)
+"hET" = (
+/obj/structure/wreck/trash/two_tire,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/wasteland)
 "hFb" = (
 /obj/structure/sink{
 	dir = 8
@@ -11745,27 +12104,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"hFi" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/f13/radiation)
 "hFl" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
-"hFz" = (
-/obj/structure/fence{
-	dir = 4;
-	tag = "icon-metal_fence3"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0";
-	tag = "icon-horizontaloutermain0"
-	},
-/area/f13/wasteland)
 "hFM" = (
 /obj/structure/chair/wood/worn{
 	dir = 4
@@ -11782,13 +12124,15 @@
 	},
 /area/f13/legion)
 "hFY" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_x = -30
+/obj/structure/barricade/wooden,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
 	},
-/turf/open/floor/plasteel/grimy,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left"
+	},
+/area/f13/wasteland)
 "hGr" = (
 /obj/machinery/shower{
 	dir = 4
@@ -11798,13 +12142,12 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"hGx" = (
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontaltopborderbottom2right";
-	tag = "icon-horizontaltopborderbottom2right (WEST)"
+"hGs" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "hGJ" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalbottom"
@@ -11813,6 +12156,12 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"hGX" = (
+/obj/structure/table/wood/settler,
+/obj/item/stack/sheet/cloth,
+/obj/item/candle/infinite,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hHk" = (
 /obj/structure/simple_door/fakeglass,
 /turf/open/floor/wood/f13/oak,
@@ -11825,10 +12174,6 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"hHs" = (
-/mob/living/simple_animal/hostile/stalker,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "hHC" = (
 /obj/structure/closet,
 /obj/machinery/light/small{
@@ -11839,12 +12184,20 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"hHD" = (
+/obj/machinery/trading_machine/weapon,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hHH" = (
 /obj/structure/decoration/hatch,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"hHR" = (
+/obj/structure/chair/bench,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hHS" = (
 /obj/structure/fence/wooden{
 	dir = 1
@@ -11861,6 +12214,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"hIb" = (
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "hIB" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/green,
@@ -11871,18 +12228,9 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/brotherhood)
-"hIY" = (
-/obj/structure/decoration/hatch,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop3";
-	tag = "icon-horizontalbottombordertop3"
-	},
-/area/f13/wasteland)
 "hJd" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/trading_machine/armor,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "hJf" = (
 /obj/structure/bed/dogbed,
@@ -11914,10 +12262,6 @@
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
-"hJM" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "hJQ" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
@@ -11948,10 +12292,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
-"hKQ" = (
-/obj/structure/chair/stool,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "hKY" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
@@ -11963,22 +12303,15 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
-"hLs" = (
-/obj/structure/fence{
-	dir = 4;
-	tag = "icon-metal_fence3"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outermaincornerouter";
-	tag = "icon-outermaincornerouter (WEST)"
-	},
-/area/f13/wasteland)
 "hLv" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2"
 	},
+/area/f13/wasteland)
+"hMs" = (
+/obj/structure/rack,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "hMz" = (
 /obj/structure/stone_tile/block/burnt,
@@ -12021,27 +12354,6 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
-"hNw" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/item/clothing/under/f13/shiny,
-/obj/item/clothing/under/f13/shiny,
-/obj/item/clothing/under/f13/settler,
-/obj/item/clothing/under/f13/settler,
-/obj/item/clothing/under/f13/relaxedwear,
-/obj/item/clothing/under/f13/relaxedwear,
-/obj/item/clothing/under/f13/spring,
-/obj/item/clothing/under/f13/spring,
-/obj/structure/closet/cabinet,
-/obj/item/holybeacon,
-/obj/item/clothing/accessory/pocketprotector/cosmetology,
-/obj/item/clothing/under/rank/chaplain,
-/obj/item/clothing/shoes/sneakers/black,
-/obj/item/clothing/head/nun_hood,
-/obj/item/storage/backpack/cultpack,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "hNC" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/desert,
@@ -12053,11 +12365,11 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "hNY" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/folder/blue,
-/obj/item/pen,
-/turf/open/floor/plasteel/grimy,
-/area/f13/building)
+/obj/machinery/mineral/wasteland_vendor/attachments{
+	icon_state = "weapon_idle"
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "hNZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
@@ -12071,24 +12383,8 @@
 	},
 /area/f13/wasteland)
 "hOs" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowbottom"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/building)
-"hOC" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
-/area/f13/building)
-"hOD" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/turf/open/floor/wood/f13/oakbroken2,
+/area/f13/legion)
 "hOJ" = (
 /obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13/wood,
@@ -12098,9 +12394,21 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "hPL" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken2,
-/area/f13/legion)
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"hPV" = (
+/obj/machinery/mineral/wasteland_vendor/crafting{
+	icon_state = "parts_idle"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "hQr" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerturn"
@@ -12112,43 +12420,16 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"hQS" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/f13/attachments,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "hRl" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"hRA" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft1";
-	tag = "icon-verticalrightborderleft1"
-	},
-/area/f13/wasteland)
-"hRF" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "hRU" = (
 /obj/structure/closet/fridge/cannibal,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"hRZ" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "hSD" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -12161,6 +12442,16 @@
 	icon_state = "horizontaltopbordertop2"
 	},
 /area/f13/wasteland)
+"hTh" = (
+/obj/structure/chair/wood{
+	dir = 4;
+	tag = "icon-wooden_chair_settler (EAST)"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "hTj" = (
 /obj/machinery/light{
 	dir = 8;
@@ -12183,6 +12474,14 @@
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"hTS" = (
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "hTV" = (
 /obj/structure/tires/two,
 /turf/open/floor/f13/wood,
@@ -12203,20 +12502,19 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
-"hUm" = (
-/obj/effect/spawner/lootdrop/crafts,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+"hUr" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0";
+	tag = "icon-verticalrightborderleft0"
+	},
+/area/f13/wasteland)
 "hUv" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building)
-"hUG" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "hUK" = (
 /obj/structure/table/wood/fancy,
@@ -12236,12 +12534,6 @@
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
-"hUW" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/wasteland)
 "hVb" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/indestructible/ground/outside/road{
@@ -12249,11 +12541,13 @@
 	},
 /area/f13/wasteland)
 "hVd" = (
-/obj/structure/musician/piano{
-	desc = "What a wierd piano..";
-	name = "minimoog"
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/floor/wood/f13/carpet,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "hVp" = (
 /mob/living/simple_animal/hostile/handy,
@@ -12286,6 +12580,17 @@
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland)
+"hWq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "hWJ" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -12300,16 +12605,11 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"hXu" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "hXv" = (
-/turf/open/floor/plating/f13/outside/road{
-	dir = 8;
-	icon_state = "crossborder"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hXP" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/outside/road{
@@ -12323,6 +12623,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"hYe" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "hYh" = (
 /obj/item/clothing/shoes/laceup,
 /turf/open/floor/f13/wood,
@@ -12346,47 +12651,41 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"hYI" = (
-/obj/structure/chair/wood/modern{
-	dir = 1;
-	icon_state = "wooden_chair_settler";
-	tag = "icon-wooden_chair_settler (NORTH)"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
-/area/f13/building)
 "hYJ" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"hYR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "barwindowshutters";
+	name = "bar window shutters button";
+	pixel_x = 6;
+	pixel_y = -32;
+	req_one_access_txt = "28"
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters button";
+	pixel_x = -6;
+	pixel_y = -32;
+	req_one_access_txt = "28"
+	},
+/obj/machinery/light/small,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "hYZ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"hZm" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8;
-	tag = "icon-comfychair (WEST)"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"hZs" = (
-/obj/effect/decal/riverbank{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "hZv" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
-	tag = "icon-housewood3-broken"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/village)
 "hZw" = (
 /obj/structure/fence/corner/wooden{
@@ -12444,21 +12743,42 @@
 /obj/structure/stone_tile/block/cracked,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ibg" = (
-/obj/structure/rack,
-/obj/item/kitchen/fork{
-	pixel_x = 8;
-	pixel_y = 2
+"iaQ" = (
+/obj/structure/chair/booth{
+	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"ibs" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Bar";
+	req_one_access_txt = "28"
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_y = 32
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "barshutters"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
+"ibt" = (
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ibA" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ibB" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "ibD" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/fprostitute,
@@ -12468,12 +12788,29 @@
 /obj/item/clothing/under/f13/mprostitute,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"ibO" = (
+/obj/effect/decal/remains/human,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "ibZ" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
+"icm" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "icu" = (
 /obj/structure/decoration/clock/old,
 /turf/closed/wall/f13/supermart,
@@ -12517,7 +12854,7 @@
 "idC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/legion)
+/area/f13/caves)
 "idE" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -12542,16 +12879,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/ncr)
-"iec" = (
-/obj/structure/fence/corner/wooden{
-	dir = 1
-	},
-/obj/structure/fence/corner/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "iem" = (
 /obj/structure/fence{
 	dir = 1
@@ -12564,11 +12891,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ier" = (
-/obj/structure/wreck/trash/two_tire,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "iez" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/oil{
@@ -12603,12 +12929,17 @@
 	},
 /area/f13/village)
 "ifs" = (
-/obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
+/obj/structure/table/wood/settler,
+/obj/item/dildo{
+	icon_state = "dildo";
+	layer = 1.1
 	},
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"ifu" = (
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/caves)
 "ifQ" = (
 /obj/effect/landmark/start/f13/ncrcombatmedic,
 /turf/open/floor/f13{
@@ -12626,12 +12957,6 @@
 /obj/structure/sign/poster/contraband/pinup_bed,
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
-"igy" = (
-/obj/structure/wreck/trash/five_tires,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/building)
 "igz" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -12643,6 +12968,10 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ihm" = (
+/obj/machinery/light,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "iic" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/kitchen{
@@ -12674,6 +13003,19 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"iiG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"iiH" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "iiN" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -12689,23 +13031,15 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
-"ijl" = (
-/obj/structure/closet/cabinet,
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/syringe/medx,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"ijs" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "interiorgate2"
+"ijm" = (
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
-"ijv" = (
-/obj/structure/statue/wood/headstonewood,
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner (EAST)"
+	},
 /area/f13/wasteland)
 "ijO" = (
 /obj/structure/table/wood,
@@ -12717,6 +13051,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"ikj" = (
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/building)
 "iku" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -12737,17 +13078,34 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ilh" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_2"
+"ilc" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermaintop"
 	},
-/turf/open/water,
+/area/f13/wasteland)
+"ilh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "ill" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
 /turf/closed/mineral/random/low_chance,
 /area/f13/brotherhood)
+"ilq" = (
+/obj/structure/simple_door/house,
+/obj/machinery/door/poddoor/shutters{
+	id = "storeshutters";
+	name = "store shutters"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ilu" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -12763,6 +13121,18 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"ilI" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowleft";
+	layer = 2
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "storeshutters";
+	name = "store shutters"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ilL" = (
 /obj/structure/fence{
 	dir = 4
@@ -12772,11 +13142,23 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ilM" = (
-/obj/structure/chair/office/dark{
-	dir = 4
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright";
+	layer = 2
 	},
-/turf/open/floor/wood/f13/carpet,
+/obj/machinery/door/poddoor/shutters{
+	id = "storeshutters";
+	name = "store shutters"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
+"imd" = (
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "ime" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12788,6 +13170,13 @@
 	icon_state = "verticalrightborderleft2"
 	},
 /area/f13/wasteland)
+"imq" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "ims" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/wasteland)
@@ -12817,12 +13206,11 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
-"inj" = (
-/obj/structure/fence{
-	dir = 1
-	},
+"ing" = (
+/obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
+	icon_state = "verticalleftborderleft2top";
+	tag = "icon-verticalleftborderleft2top"
 	},
 /area/f13/wasteland)
 "inl" = (
@@ -12844,13 +13232,6 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2"
 	},
-/area/f13/wasteland)
-"inI" = (
-/obj/structure/fence/corner{
-	dir = 6;
-	icon_state = "corner"
-	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "inO" = (
 /obj/machinery/light/small{
@@ -12874,40 +13255,24 @@
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
-"ioQ" = (
-/obj/structure/flora/grass/wasteland{
-	layer = 4.2;
-	pixel_x = -3
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "hole";
-	tag = "icon-hole"
-	},
-/area/f13/wasteland)
 "ioU" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outermaincornerinner";
 	tag = "icon-outermaincornerinner"
 	},
 /area/f13/wasteland)
-"ioV" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"ioY" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
-"ipm" = (
-/obj/structure/chair/stool{
-	icon_state = "bench_center"
+"ipj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
 	},
-/obj/machinery/light/small{
-	dir = 1
+/area/f13/wasteland)
+"ipl" = (
+/obj/structure/chair/wood/modern,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "ipn" = (
 /obj/structure/chair/wood/fancy{
@@ -12920,12 +13285,12 @@
 /obj/item/storage/backpack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"ipG" = (
-/obj/machinery/light/broken{
-	dir = 4
+"ipS" = (
+/obj/item/flag,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/area/f13/wasteland)
 "iqx" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice,
@@ -12937,10 +13302,6 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
-"iqF" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "iqH" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical/old,
@@ -12965,12 +13326,6 @@
 /obj/structure/stone_tile/surrounding/burnt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"irf" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
-/area/f13/building)
 "irk" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -12993,6 +13348,25 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"ish" = (
+/obj/structure/destructible/tribal_torch{
+	layer = 3.1;
+	pixel_y = 20
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
+"ism" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken (NORTHEAST)"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "isy" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood{
@@ -13006,14 +13380,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "isL" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_x = 30
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/end{
+	dir = 4
 	},
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "isO" = (
 /obj/item/radio/intercom{
 	frequency = 1891;
@@ -13046,6 +13420,15 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"itI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left"
+	},
+/area/f13/wasteland)
 "itJ" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -13057,28 +13440,10 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"itU" = (
-/obj/structure/kitchenspike,
-/obj/structure/decoration/hatch{
-	dir = 1;
-	layer = 2.5
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
 "itY" = (
 /obj/structure/table/wood,
 /obj/item/lighter,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"iub" = (
-/obj/structure/decoration/sign{
-	desc = "It's a portrait of a person you don't know anything about.";
-	icon_state = "painting_president";
-	name = "portrait"
-	},
-/turf/closed/wall/f13/wood,
 /area/f13/building)
 "iul" = (
 /obj/structure/chair/comfy/black{
@@ -13093,10 +13458,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
-"iuG" = (
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "iuS" = (
 /obj/structure/chair/wood/modern{
 	dir = 4;
@@ -13104,6 +13465,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"iuW" = (
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/clinic)
 "ivi" = (
 /obj/structure/chair/wood/modern{
 	dir = 1;
@@ -13111,6 +13484,11 @@
 	tag = "icon-wooden_chair_settler (NORTH)"
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"ivz" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "ivJ" = (
 /obj/structure/table/glass,
@@ -13155,20 +13533,6 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ixu" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
-"ixC" = (
-/obj/structure/table/wood,
-/obj/structure/wreck/trash/one_tire{
-	pixel_x = -7;
-	pixel_y = 8
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
-	},
-/area/f13/wasteland)
 "ixG" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13,
@@ -13184,9 +13548,27 @@
 /mob/living/simple_animal/hostile/wolf/alpha,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"iyo" = (
+/obj/effect/decal/cleanable/generic,
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
+"iys" = (
+/obj/machinery/power/solar_control{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
 "iyu" = (
-/obj/structure/chair/bench,
-/turf/open/floor/f13/wood,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood,
 /area/f13/building)
 "iyv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13203,6 +13585,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"iyJ" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-2";
+	tag = "icon-0-2"
+	},
+/turf/open/floor/plating,
+/area/f13/caves)
 "iyR" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -13236,12 +13626,23 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"iAm" = (
-/obj/structure/chair/booth{
-	dir = 4
+"iAr" = (
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/structure/closet/crate/medical/anchored,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/building)
+"iAw" = (
+/obj/structure/bed/dogbed{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "iAz" = (
 /obj/structure/bed,
 /turf/open/floor/f13/wood,
@@ -13259,17 +13660,6 @@
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"iAX" = (
-/obj/structure/cable{
-	icon_state = "0-5";
-	tag = "icon-0-5"
-	},
-/obj/structure/cable{
-	icon_state = "0-9";
-	tag = "icon-0-9"
-	},
-/turf/open/floor/plating,
-/area/f13/caves)
 "iBo" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -13277,8 +13667,11 @@
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
 "iBv" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/light/small/broken,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
 "iBF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13299,16 +13692,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"iBO" = (
-/obj/structure/bed/mattress/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "iBT" = (
-/obj/machinery/mineral/wasteland_vendor/attachments{
-	icon_state = "weapon_idle"
+/obj/structure/toilet{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/machinery/light/small/broken,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "iCx" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13327,13 +13719,6 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"iDJ" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "iEg" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -13343,28 +13728,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"iEn" = (
-/obj/structure/fence{
-	dir = 4;
-	tag = "icon-metal_fence3"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt";
-	tag = "icon-dirt (EAST)"
-	},
-/area/f13/wasteland)
 "iEp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"iEQ" = (
-/obj/machinery/icecream_vat,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/city)
 "iEX" = (
 /obj/structure/rack,
 /obj/item/storage/fancy/cracker_pack,
@@ -13387,13 +13755,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "iFr" = (
-/obj/machinery/mineral/wasteland_vendor/crafting{
-	icon_state = "parts_idle"
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "iFI" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/brotherhood)
@@ -13419,20 +13791,20 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
+"iGd" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "iGi" = (
 /obj/machinery/light,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
-"iGk" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
 	},
 /area/f13/building)
 "iGE" = (
@@ -13455,18 +13827,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iGP" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_y = 12
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "hole"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "iGS" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/wood/f13/carpet,
@@ -13499,12 +13867,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"iHr" = (
-/obj/structure/wreck/trash/five_tires,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
-	},
-/area/f13/wasteland)
 "iHt" = (
 /obj/structure/bed/mattress,
 /obj/effect/landmark/start/f13/pusher,
@@ -13522,13 +13884,6 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
-"iHP" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
 	},
 /area/f13/building)
 "iHQ" = (
@@ -13560,12 +13915,13 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"iIc" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "hole";
-	tag = "icon-hole"
+"iHX" = (
+/obj/structure/chair/wood/modern{
+	dir = 8;
+	icon_state = "wooden_chair_settler"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "iIi" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_tl,
@@ -13582,6 +13938,18 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/ncr)
+"iIz" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/f13/caravaneer,
+/obj/item/clothing/under/f13/caravaneer,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "iID" = (
 /obj/structure/chair/booth{
 	dir = 8
@@ -13605,12 +13973,13 @@
 	},
 /area/f13/wasteland)
 "iIS" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/barricade/bars,
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/food/drinks/flask,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "iJc" = (
 /obj/structure/closet,
@@ -13625,16 +13994,6 @@
 /obj/item/clothing/under/f13/raiderharness,
 /turf/open/floor/f13,
 /area/f13/building)
-"iJw" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
-"iJG" = (
-/obj/item/instrument/guitar,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "iJJ" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/small/broken{
@@ -13647,14 +14006,6 @@
 /obj/item/clothing/under/f13/raiderrags,
 /turf/open/floor/f13,
 /area/f13/building)
-"iJS" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
 "iJW" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -13662,6 +14013,13 @@
 /obj/effect/landmark/start/f13/vetlegionary,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
+"iJZ" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
 "iKm" = (
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood,
@@ -13686,6 +14044,20 @@
 /obj/item/clothing/under/f13/female/tribal,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"iLc" = (
+/obj/structure/simple_door/house{
+	icon_state = "room"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"iLr" = (
+/obj/effect/decal/riverbank{
+	dir = 5
+	},
+/turf/open/water,
+/area/f13/wasteland)
 "iLD" = (
 /obj/item/seeds/cannabis,
 /obj/item/seeds/cannabis,
@@ -13701,38 +14073,27 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "iMc" = (
-/obj/effect/decal/riverbank{
-	dir = 9
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
-"iMd" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/carpet/airless,
-/area/f13/legion)
-"iMi" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/obj/structure/chair/stool/retro,
+/turf/open/floor/holofloor/carpet,
 /area/f13/building)
-"iMl" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+"iMi" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
+"iMV" = (
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_x = -32
 	},
-/area/f13/city)
-"iMJ" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/pill/patch/turbo,
-/obj/item/reagent_containers/pill/patch/turbo,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
+	anchored = 1;
+	pixel_x = -28
 	},
+/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
+	anchored = 1;
+	pixel_x = -36
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "iNb" = (
 /obj/machinery/light/small{
@@ -13788,12 +14149,9 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
-"iNO" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+"iNN" = (
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "iNQ" = (
 /obj/structure/simple_door/interior,
@@ -13801,9 +14159,23 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"iNR" = (
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "iNU" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
+"iNX" = (
+/obj/structure/bonfire,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright1"
+	},
 /area/f13/wasteland)
 "iOg" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -13827,22 +14199,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"iOv" = (
-/obj/effect/decal/riverbank,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "iOB" = (
 /obj/effect/landmark/poster_spawner/prewar,
 /turf/closed/wall/f13/store,
 /area/f13/village)
 "iOF" = (
-/obj/structure/table/wood/settler,
-/obj/item/flashlight/lamp,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "iOM" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13877,24 +14241,19 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
-"iPN" = (
-/obj/structure/decoration/hatch{
-	dir = 1;
-	layer = 2.5
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
-	},
-/area/f13/wasteland)
-"iPY" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "iQs" = (
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood/f13,
+/area/f13/building)
+"iQK" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "iQR" = (
 /obj/structure/decoration/rag,
@@ -13955,25 +14314,12 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/village)
-"iRz" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "iRC" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
 	icon_state = "innermaincornerinner"
 	},
-/area/f13/wasteland)
-"iRE" = (
-/obj/item/twohanded/required/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/grimy,
-/area/f13/building)
-"iRN" = (
-/obj/structure/closet/crate/wicker,
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "iRT" = (
 /obj/structure/curtain{
@@ -14027,11 +14373,29 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "iSE" = (
-/turf/open/floor/plasteel/grimy,
-/area/f13/building)
+/obj/structure/wreck/trash/machinepiletwo{
+	layer = 3
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
+"iSV" = (
+/obj/structure/wreck/trash/machinepile{
+	layer = 3
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "iTk" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"iTt" = (
+/obj/structure/chair/wood/modern{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iTB" = (
@@ -14067,28 +14431,22 @@
 /obj/item/clothing/under/f13/pinkdress,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"iTV" = (
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/obj/structure/fence/corner/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "iTX" = (
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"iVc" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+"iVd" = (
+/obj/structure/bonfire,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
+"iVn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "iVE" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -14113,9 +14471,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "iWi" = (
-/obj/structure/simple_door/glass,
-/turf/open/floor/wood,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "iWV" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/helmet/f13/raider/eyebot,
@@ -14123,24 +14483,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"iWW" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	layer = 2;
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/reagent_dispensers/barrel/three,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "iXi" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "iXz" = (
-/obj/machinery/light/small/broken,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "iXX" = (
 /obj/structure/rack,
 /obj/item/clothing/neck/tie,
@@ -14168,15 +14520,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"iYP" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowvertical";
-	tag = "icon-housewindowvertical"
-	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "iYY" = (
 /obj/structure/chair/sofa/corp/corner,
 /obj/effect/decal/cleanable/dirt,
@@ -14196,17 +14539,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"iZE" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/city)
 "jae" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -14310,25 +14642,10 @@
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"jcn" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "jcp" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"jcu" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/knife,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
-/area/f13/building)
 "jcB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
@@ -14336,14 +14653,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"jde" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "jdg" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/ruins{
@@ -14351,12 +14660,17 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
-"jdv" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+"jdB" = (
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "post_wood"
 	},
-/area/f13/building)
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "jdE" = (
 /obj/machinery/light{
 	dir = 8
@@ -14366,17 +14680,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
-"jdK" = (
-/obj/structure/spider/stickyweb,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "jei" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -14402,6 +14705,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"jeX" = (
+/obj/structure/lamp_post/quadra,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "jfu" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/wolf/alpha{
@@ -14416,9 +14723,6 @@
 	dir = 4;
 	icon_state = "post_wood"
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "jfD" = (
@@ -14426,6 +14730,19 @@
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/wood,
 /area/f13/village)
+"jfV" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
+"jfW" = (
+/obj/structure/closet,
+/obj/item/storage/box/gloves,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "jgq" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -14476,7 +14793,6 @@
 	pixel_x = 25;
 	pixel_y = 18
 	},
-/obj/effect/decal/riverbank,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "jhe" = (
@@ -14497,12 +14813,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
-"jhB" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertopleft";
-	tag = "icon-horizontaltopbordertopleft"
+"jia" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "jix" = (
 /obj/machinery/autolathe/constructionlathe,
 /obj/machinery/light{
@@ -14518,13 +14836,14 @@
 	},
 /area/f13/ncr)
 "jiP" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = -30
+/obj/structure/fence{
+	dir = 8
 	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "jiR" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -14540,21 +14859,25 @@
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/rust,
 /area/f13/caves)
-"jiX" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+"jjd" = (
+/obj/structure/cable{
+	icon_state = "1-10";
+	tag = "icon-1-10"
+	},
+/turf/open/floor/plating,
+/area/f13/caves)
+"jjT" = (
+/obj/structure/chair/stool/retro/tan,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "jjU" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"jkh" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
+"jkj" = (
+/obj/structure/simple_door/metal/dirtystore,
+/turf/open/floor/wood,
 /area/f13/building)
 "jkk" = (
 /obj/structure/fence/wooden{
@@ -14591,19 +14914,22 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"jkY" = (
-/obj/machinery/light/small,
-/obj/effect/decal/remains/human,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/city)
 "jlB" = (
-/obj/structure/chair/wood/worn{
-	dir = 1
+/obj/structure/table/wood/settler,
+/obj/item/kitchen/knife,
+/obj/item/mining_scanner,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
+"jlH" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/item/seeds/cannabis,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jlT" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14614,22 +14940,21 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"jmm" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_y = 12
+"jlW" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"jml" = (
+/obj/structure/kitchenspike,
+/obj/structure/decoration/hatch{
+	dir = 1;
+	layer = 2.5
 	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/obj/effect/decal/cleanable/glass{
-	pixel_x = 12
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "hole"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "jmq" = (
 /obj/item/clothing/head/f13/rastacap,
 /obj/structure/closet/cabinet,
@@ -14659,13 +14984,24 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"jmY" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 10
+"jmz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike,
+/obj/structure/decoration/hatch{
+	dir = 1;
+	layer = 2.5
 	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"jmC" = (
+/obj/machinery/mineral/unloading_machine,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
 /area/f13/building)
 "jmZ" = (
 /obj/structure/table,
@@ -14718,15 +15054,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"jnV" = (
-/obj/structure/decoration/clock{
-	pixel_y = 21
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
 "jnW" = (
 /obj/structure/rack,
 /obj/item/restraints/handcuffs,
@@ -14749,25 +15076,14 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_r,
 /area/f13/bar)
-"jpd" = (
-/obj/structure/table,
-/obj/item/pen{
-	pixel_y = 9
+"jpg" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (EAST)"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/city)
-"jpr" = (
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "jps" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
@@ -14793,6 +15109,16 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland)
+"jqa" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	tag = "icon-wooden_chair_new (NORTH)"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "jqe" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
@@ -14807,12 +15133,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"jqM" = (
-/mob/living/simple_animal/hostile/cazador/young,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "jrx" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14831,16 +15151,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"jsw" = (
-/obj/machinery/smartfridge/drying_rack,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"jsX" = (
-/obj/structure/wreck/trash/engine,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+"jsP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "jtc" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -14865,6 +15181,17 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"jtu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
 "juc" = (
@@ -14895,25 +15222,18 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/ncr)
-"jvt" = (
-/obj/structure/barricade/tentclothedge,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
+"juV" = (
+/obj/effect/landmark/start/f13/ncrlogisticsofficer,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/ncr)
 "jvw" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"jvN" = (
-/obj/structure/chair,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
 "jvT" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -15032,22 +15352,19 @@
 /obj/effect/landmark/start/f13/decanvet,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"jyl" = (
-/obj/structure/wreck/car,
+"jyf" = (
+/obj/structure/barricade/tentclothedge,
 /turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "jyC" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
-"jyF" = (
-/obj/structure/campfire,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "jzn" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -15070,57 +15387,64 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"jzC" = (
-/obj/machinery/microwave/stove,
-/obj/effect/decal/cleanable/salt,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
 "jzN" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_x = 30
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = -30
-	},
-/turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "jAf" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowleft";
-	layer = 2
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	layer = 2;
+	pixel_x = -8;
+	pixel_y = 7
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "storeshutters";
-	name = "store shutters"
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"jAh" = (
+/obj/structure/fence{
+	dir = 1
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "jAi" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"jAn" = (
+/obj/structure/table,
+/obj/item/kitchen/knife/butcher,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "jAG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
 /area/f13/brotherhood)
-"jAK" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "jAZ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -15158,12 +15482,12 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"jCg" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+"jCh" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "jCC" = (
 /obj/structure/musician/piano,
 /turf/open/floor/f13{
@@ -15174,6 +15498,17 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
+"jDD" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
+"jDE" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "jEb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -15185,59 +15520,43 @@
 	},
 /area/f13/caves)
 "jEd" = (
-/obj/effect/decal/riverbankcorner{
-	dir = 1
+/obj/structure/bonfire,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
-"jEl" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/knife,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outermaincornerouter"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "jEp" = (
-/obj/structure/weightlifter,
+/obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"jEP" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+"jEX" = (
+/obj/structure/sign/poster/prewar/poster82{
+	pixel_x = 32
+	},
+/obj/structure/chair/stool/retro,
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
+"jFb" = (
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/building)
-"jEX" = (
-/obj/structure/fermenting_barrel{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/structure/fermenting_barrel{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
-"jFb" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
 "jFl" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"jGl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
 /area/f13/wasteland)
 "jGz" = (
 /obj/effect/decal/cleanable/dirt{
@@ -15247,6 +15566,13 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
+"jGJ" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/landmark/start/f13/campfollower,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "jGV" = (
 /obj/structure/table,
 /obj/item/kitchen/knife/butcher,
@@ -15300,6 +15626,12 @@
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"jJa" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/legion)
 "jJb" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/desert,
@@ -15323,35 +15655,10 @@
 /obj/item/clothing/suit/f13/sexymaid,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"jKq" = (
-/obj/structure/chair/stool{
-	dir = 8;
-	icon_state = "bench";
-	tag = "icon-bench (WEST)"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1";
-	tag = "icon-horizontaloutermain1 (NORTH)"
-	},
-/area/f13/wasteland)
-"jKx" = (
-/obj/structure/closet/cabinet,
-/obj/item/storage/backpack{
-	icon_state = "satchel"
-	},
-/obj/item/storage/backpack{
-	icon_state = "satchel"
-	},
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "jKV" = (
-/obj/structure/fence/corner/wooden{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/simple_door/house,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "jLK" = (
 /obj/structure/closet,
 /obj/item/clothing/gloves/combat,
@@ -15363,19 +15670,19 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"jLV" = (
+/obj/structure/window/fulltile/wood,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jMj" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/radiation)
-"jMy" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gibtorso"
+"jMz" = (
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
 	},
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "jMC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -15387,29 +15694,50 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/village)
-"jMO" = (
-/obj/structure/decoration/hatch{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
-	},
-/area/f13/wasteland)
-"jNj" = (
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+"jMT" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/vomit,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/building)
+"jMW" = (
+/obj/machinery/mineral/processing_unit{
+	input_dir = 8;
+	output_dir = 4
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
+"jNj" = (
+/obj/structure/wreck/trash/bus_door,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2left"
+	},
+/area/f13/wasteland)
 "jNl" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"jNs" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/white/box,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/stack/crafting/armor_plate/ten,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/ncr)
 "jNt" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -15439,29 +15767,30 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"jOw" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "jOH" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/shovel,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"jPE" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright2";
-	tag = "icon-verticalrightborderright2"
-	},
-/area/f13/wasteland)
 "jPG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/structure/lamp_post/quadra,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerbordercorner"
+	},
 /area/f13/wasteland)
 "jPN" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "jQd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15471,18 +15800,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"jQq" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/obj/item/stack/sheet/cardboard,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
 "jQt" = (
 /obj/machinery/washing_machine{
 	pixel_y = 7
@@ -15521,6 +15838,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"jQE" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "jQH" = (
 /obj/machinery/light{
 	dir = 8;
@@ -15543,35 +15867,25 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"jRv" = (
-/obj/structure/lamp_post/quadra,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland)
-"jRC" = (
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "jRQ" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"jRU" = (
-/obj/structure/chair/comfy{
-	dir = 1
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
 "jRV" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/mug/coco,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"jRW" = (
+/obj/structure/chair/wood/modern{
+	dir = 8;
+	icon_state = "wooden_chair_old";
+	tag = "icon-wooden_chair_old (WEST)"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jRX" = (
@@ -15621,22 +15935,17 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"jTQ" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+"jTT" = (
+/obj/structure/cable{
+	icon_state = "0-5";
+	tag = "icon-0-5"
 	},
-/area/f13/building)
-"jTR" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1";
-	tag = "icon-horizontalinnermain1"
+/obj/structure/cable{
+	icon_state = "0-9";
+	tag = "icon-0-9"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plating,
+/area/f13/caves)
 "jTX" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/button{
@@ -15674,18 +15983,9 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13,
 /area/f13/building)
-"jUv" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/building)
-"jUw" = (
-/obj/structure/chair/wood/modern,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
-	tag = "icon-housewood3-broken"
-	},
+"jUR" = (
+/obj/structure/sign/poster/prewar/poster88,
+/turf/closed/wall/f13/supermart,
 /area/f13/building)
 "jUS" = (
 /obj/structure/car,
@@ -15693,11 +15993,6 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
-"jVg" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "jVl" = (
 /obj/structure/fence/corner/wooden{
 	dir = 8
@@ -15734,11 +16029,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/brotherhood)
-"jVZ" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
-	},
-/area/f13/building)
 "jWa" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -15767,32 +16057,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
-"jWk" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/condiment/yeast,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
 "jWx" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
+/obj/structure/cargocrate,
+/obj/structure/cargocrate{
+	pixel_x = 2;
+	pixel_y = 32
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "jWM" = (
 /obj/item/reagent_containers/pill/patch/turbo,
 /obj/item/storage/trash_stack,
@@ -15820,13 +16092,6 @@
 "jXj" = (
 /turf/open/indestructible,
 /area/f13/tcoms)
-"jXm" = (
-/obj/structure/chair/stool{
-	dir = 4;
-	icon_state = "bench_center"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "jXu" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15836,21 +16101,39 @@
 /obj/item/stack/rods,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"jXw" = (
+"jXJ" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
+"jXV" = (
+/obj/structure/fence{
+	dir = 1
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertopright";
-	tag = "icon-horizontaltopbordertopright"
+	dir = 4;
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"jYg" = (
+/obj/machinery/conveyor/auto{
+	dir = 6
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "jYn" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building)
-"jYo" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "jYw" = (
 /obj/machinery/seed_extractor,
@@ -15863,6 +16146,15 @@
 	icon_state = "rubblepillar"
 	},
 /area/f13/wasteland)
+"jYG" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/legion)
 "jYO" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15879,22 +16171,14 @@
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"jZg" = (
-/obj/structure/tires/two{
-	pixel_x = -5;
-	pixel_y = 6
+"jZk" = (
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
-"jZk" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
 "jZx" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -15908,22 +16192,28 @@
 	},
 /area/f13/wasteland)
 "jZL" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "jZM" = (
-/obj/structure/dresser,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/f13/building)
-"kaj" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft2";
-	tag = "icon-verticalrightborderleft2"
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
 "kas" = (
@@ -15964,18 +16254,26 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"kby" = (
+/obj/structure/closet,
+/obj/item/door_key{
+	id = 2;
+	name = "wasteland jail key"
+	},
+/turf/open/floor/plating,
+/area/f13/radiation)
 "kbQ" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "kbS" = (
-/obj/effect/decal/remains/human,
-/obj/item/clothing/suit/armor/f13/slavelabor,
-/obj/item/clothing/under/f13/legslavef,
-/obj/item/clothing/shoes/f13/rag,
-/obj/effect/landmark/start/f13/slave,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "kbU" = (
 /obj/structure/bed/mattress/pregame,
 /mob/living/simple_animal/hostile/ghoul/reaver,
@@ -15988,6 +16286,27 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"kcc" = (
+/obj/machinery/vending/snack,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
+"kcw" = (
+/obj/structure/table/wood/settler,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/spray/pestspray,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "kcD" = (
 /obj/machinery/light{
 	dir = 1
@@ -16003,15 +16322,29 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"kcQ" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbroken";
-	tag = "icon-housewindowbroken (NORTHEAST)"
-	},
-/obj/structure/barricade/wooden/planks/pregame,
+"kcP" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/pill/patch/turbo,
+/obj/item/reagent_containers/pill/patch/turbo,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2";
 	tag = "icon-housewood2"
+	},
+/area/f13/building)
+"kcQ" = (
+/obj/structure/table/wood/settler,
+/obj/machinery/microwave,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
+"kcT" = (
+/obj/effect/mine/stun,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/building)
 "kcX" = (
@@ -16022,22 +16355,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"kcY" = (
-/obj/item/twohanded/required/kirbyplants/dead,
-/turf/open/floor/wood,
-/area/f13/building)
 "kcZ" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/processor/chopping_block,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "kdg" = (
 /obj/structure/chair/wood/modern{
 	dir = 4;
@@ -16049,27 +16373,26 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kdi" = (
-/turf/open/floor/plasteel/chapel,
+/obj/structure/table/wood/settler,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "kdJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermaintop"
 	},
 /area/f13/wasteland)
-"kdS" = (
-/obj/item/flag,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
+"kel" = (
+/obj/structure/simple_door/tentflap_cloth{
+	pixel_y = -3
 	},
-/area/f13/wasteland)
-"keg" = (
-/obj/item/ammo_casing/caseless{
-	dir = 10;
-	icon_state = "sS-casing";
-	tag = "icon-sS-casing (SOUTHWEST)"
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/legion)
 "kex" = (
 /obj/item/clothing/head/helmet/f13/brahmincowboyhat,
 /obj/item/clothing/suit/armor/f13/brahmin_leather_duster,
@@ -16085,12 +16408,26 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"keV" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/f13/caves)
 "keW" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"kfh" = (
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "kfo" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -16103,8 +16440,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "kfx" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood,
+/obj/machinery/light/small,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "kfz" = (
 /obj/structure/fence/corner/wooden{
@@ -16122,10 +16462,10 @@
 	},
 /area/f13/building)
 "kfJ" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/light/small/broken,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/obj/item/storage/trash_stack,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/building)
 "kfU" = (
@@ -16139,14 +16479,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
-"kgd" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/phone,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "kgy" = (
 /obj/structure/sign/sing/ratnest,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16198,14 +16530,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"khJ" = (
-/obj/structure/bed/mattress,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/building)
 "khU" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood{
@@ -16224,29 +16548,44 @@
 /obj/structure/chair,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
-"kiB" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderrightbottom";
-	tag = "icon-verticalrightborderrightbottom"
+"kin" = (
+/obj/structure/table/wood/settler,
+/obj/item/storage/backpack/satchel/leather/withwallet,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/f13/wasteland)
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "kiL" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
-"kiW" = (
-/obj/structure/fence/corner,
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"kjF" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+"kiP" = (
+/obj/structure/decoration/vent,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/wasteland)
+/area/f13/building)
+"kiW" = (
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"kjB" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "kjI" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/attachments,
@@ -16263,15 +16602,6 @@
 "kjR" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"kjX" = (
-/obj/structure/table,
-/obj/structure/table,
-/obj/item/wirecutters{
-	icon_state = "cutters";
-	tag = "icon-cutters"
-	},
-/turf/open/floor/plating,
-/area/f13/caves)
 "kkD" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
@@ -16285,6 +16615,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"klx" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/obj/structure/debris/v3,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermaintop"
+	},
+/area/f13/wasteland)
 "klA" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
@@ -16298,6 +16637,13 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/village)
+"klI" = (
+/obj/structure/window/fulltile/wood,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "kmv" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -16313,11 +16659,25 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"kne" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
-	tag = "icon-dirt"
+"kmQ" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/building)
+"kmX" = (
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
+"knw" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop3"
 	},
 /area/f13/wasteland)
 "koc" = (
@@ -16329,14 +16689,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"kom" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbrokenvertical"
+"koe" = (
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32";
+	tag = "icon-wasteland32"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "kow" = (
 /obj/machinery/processor,
 /turf/open/floor/f13{
@@ -16372,6 +16730,9 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kpo" = (
+/turf/open/floor/wood/f13/oakbroken,
+/area/f13/legion)
 "kpr" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/barber{
@@ -16404,6 +16765,14 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
+"kpL" = (
+/obj/machinery/light/sign,
+/obj/structure/barricade/wooden,
+/obj/effect/decal/fakelattice,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop3"
+	},
+/area/f13/wasteland)
 "kpM" = (
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/desert,
@@ -16425,6 +16794,17 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"kqe" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/obj/effect/decal/fakelattice,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop3"
+	},
+/area/f13/wasteland)
 "kqk" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/f13/wood,
@@ -16456,6 +16836,16 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"krd" = (
+/obj/structure/wreck/trash/machinepiletwo{
+	layer = 3
+	},
+/obj/item/flag/oasis,
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "krk" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -16469,6 +16859,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kru" = (
+/obj/structure/tires{
+	pixel_x = -8;
+	pixel_y = 15
+	},
+/obj/structure/lamp_post/quadra,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland)
 "krJ" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16481,25 +16881,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"krR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
 "krS" = (
 /obj/structure/fence/wooden{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"ksp" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "ktB" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
@@ -16510,14 +16897,21 @@
 	},
 /area/f13/wasteland)
 "ktX" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/structure/wreck/trash/four_barrels,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
 	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+/area/f13/wasteland)
+"kuh" = (
+/obj/structure/chair{
+	dir = 1
 	},
-/area/f13/building)
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "kur" = (
 /obj/structure/table/wood/fancy,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -16548,38 +16942,41 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"kuZ" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"kve" = (
-/obj/item/clothing/under/f13/tribal,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"kvr" = (
-/obj/structure/simple_door/tentflap_cloth{
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+"kvv" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/carpet/airless,
+/area/f13/legion)
 "kvB" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"kvC" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+"kvT" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/wasteland)
+"kvZ" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "kwe" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = -1
+/obj/structure/decoration/hatch{
+	dir = 1;
+	layer = 2.5
 	},
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "kwi" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass,
@@ -16587,22 +16984,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"kws" = (
-/obj/effect/decal/marking{
-	icon_state = "doublehorizontalcorroded"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/wasteland)
-"kwy" = (
-/obj/effect/decal/cleanable/glass{
-	pixel_x = 12
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "kwA" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/xeno,
@@ -16634,11 +17015,13 @@
 	},
 /area/f13/wasteland)
 "kxq" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "botany";
+	name = "Botany shutters"
 	},
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
 "kxv" = (
@@ -16663,24 +17046,19 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"kyh" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "kyt" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
-"kyu" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	tag = "icon-housewood4-broken"
-	},
-/area/f13/building)
-"kyA" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1";
-	tag = "icon-horizontaloutermain1 (NORTH)"
 	},
 /area/f13/wasteland)
 "kyT" = (
@@ -16692,16 +17070,14 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"kzl" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"kzr" = (
-/obj/structure/table/wood/settler,
-/obj/item/flashlight/lantern,
-/turf/open/floor/f13/wood,
+"kzj" = (
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "124"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "kzs" = (
 /obj/effect/decal/cleanable/dirt{
@@ -16746,11 +17122,6 @@
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"kzW" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/building)
 "kAa" = (
 /obj/structure/chair/wood/worn{
 	dir = 8
@@ -16790,9 +17161,29 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
-"kBa" = (
-/obj/structure/sign/departments/medbay,
-/turf/closed/wall/f13/supermart,
+"kBr" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "clinicoutsideladder"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/building)
+"kBs" = (
+/obj/structure/simple_door/house{
+	icon_state = "interior";
+	tag = "icon-interior"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
+"kBC" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
 /area/f13/building)
 "kBG" = (
 /obj/effect/decal/marking{
@@ -16805,6 +17196,10 @@
 "kBU" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
+"kBW" = (
+/obj/structure/simple_door/tentflap_cloth,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "kCs" = (
 /obj/item/ammo_casing/a50MG,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16817,25 +17212,32 @@
 	icon_state = "verticalleftborderright2bottom"
 	},
 /area/f13/wasteland)
+"kCx" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"kCA" = (
+/obj/structure/wreck/trash/five_tires,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/building)
+"kCD" = (
+/obj/structure/simple_door/house{
+	icon_state = "interioropening";
+	tag = "icon-interioropening"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "kCH" = (
 /obj/structure/pondlily_small,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"kCS" = (
-/obj/structure/table/wood/settler,
-/obj/item/stack/sheet/cloth,
-/obj/item/candle/infinite,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"kDd" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters{
-	id = "frontgateshut";
-	name = "gate shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "kDj" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -16870,6 +17272,16 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"kEh" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical";
+	tag = "icon-housewindowvertical (NORTHEAST)"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "kEi" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -16911,10 +17323,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"kFf" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "kFi" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/f13/wood,
@@ -16938,13 +17346,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
-"kFW" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerborder";
-	tag = "icon-outerborder (EAST)"
-	},
-/area/f13/wasteland)
 "kGc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 7;
@@ -16963,36 +17364,10 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"kGI" = (
-/mob/living/simple_animal/hostile/handy/protectron,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "kGL" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"kGP" = (
-/obj/item/clothing/suit/f13/duster,
-/obj/item/clothing/suit/f13/autumn,
-/obj/item/clothing/gloves/f13/leather,
-/obj/item/clothing/head/f13/cowboy,
-/obj/item/clothing/under/f13/cowboyb,
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/obj/item/clothing/head/collectable/police/cos{
-	name = "Chief of Police Hat"
-	},
-/obj/item/clothing/suit/armor/vest/leather,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/glasses/orange,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "kGV" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
@@ -17003,6 +17378,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
+"kHf" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kHj" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
@@ -17025,12 +17404,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"kHQ" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/effect/decal/remains/human,
-/obj/item/clothing/suit/armor/f13/tribal,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "kHU" = (
 /obj/structure/table/wood,
 /obj/item/binoculars,
@@ -17044,29 +17417,29 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"kIq" = (
-/obj/structure/chair/wood/modern{
-	dir = 8;
-	icon_state = "wooden_chair_settler"
+"kIn" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "kIs" = (
 /obj/machinery/workbench,
 /obj/item/instrument/trumpet,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"kIM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/f13/building)
 "kIZ" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
+"kJj" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 4
 	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "kJu" = (
 /obj/structure/anvil/obtainable/basic,
@@ -17078,16 +17451,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"kJP" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/obj/item/storage/backpack/satchel/leather,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "kKe" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -17115,13 +17478,25 @@
 	},
 /area/f13/legion)
 "kKZ" = (
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"kLh" = (
-/obj/structure/closet/crate/coffin,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/building)
+"kLk" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/landmark/start/f13/auxilia,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
+"kLm" = (
+/obj/structure/chair/stool,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "kLv" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -17154,12 +17529,6 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
-"kMs" = (
-/mob/living/simple_animal/hostile/raider/firefighter,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "kMu" = (
 /obj/structure/fermenting_barrel,
 /obj/effect/decal/fakelattice{
@@ -17182,10 +17551,14 @@
 /obj/machinery/mineral/wasteland_vendor/clothing,
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
-"kND" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/wood/f13/oak,
+"kNH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cargocrate,
+/obj/structure/cargocrate{
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "kNT" = (
 /obj/structure/table/wood,
@@ -17199,14 +17572,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"kOi" = (
-/obj/machinery/power/tracker,
+"kNV" = (
+/obj/machinery/power/solar,
 /obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
+	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
 "kOx" = (
@@ -17220,29 +17593,16 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"kOH" = (
+/obj/item/clothing/under/f13/female/tribal,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "kOW" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
-"kPF" = (
-/obj/structure/bed/mattress,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/building)
-"kPI" = (
-/obj/machinery/door/morgue,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"kPT" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "kPX" = (
 /obj/structure/fence/corner/wooden{
 	dir = 8
@@ -17253,17 +17613,12 @@
 	},
 /area/f13/wasteland)
 "kPZ" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/f13/building)
-"kQe" = (
-/obj/structure/bus_door,
-/turf/open/indestructible/ground/outside/road{
-	dir = 4;
-	icon_state = "innermaincornerouter";
-	tag = "icon-innermaincornerouter (EAST)"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
 "kQq" = (
@@ -17272,9 +17627,27 @@
 /turf/open/water,
 /area/f13/brotherhood)
 "kQC" = (
-/obj/structure/lamp_post/quadra,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 9;
+	icon_state = "outerpavement"
+	},
 /area/f13/wasteland)
+"kQE" = (
+/obj/structure/table/wood/settler,
+/obj/item/shovel,
+/obj/item/shovel{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "kQJ" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/metal{
@@ -17285,10 +17658,6 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"kRf" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "kRD" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -17320,12 +17689,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"kTz" = (
-/obj/structure/fence/wooden{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "kTP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -17396,14 +17759,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"kVm" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbrokenvertical"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "kVq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -17412,13 +17767,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
-"kVO" = (
-/obj/structure/chair/wood/modern{
-	dir = 4;
-	icon_state = "wooden_chair_settler"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "kVS" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -17430,11 +17778,25 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kWx" = (
+/obj/machinery/vending/nukacolavend,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "kWC" = (
 /obj/structure/table/wood,
 /obj/item/storage/backpack/satchel/leather,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kWT" = (
+/obj/effect/spawner/lootdrop/crafts,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "kXa" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -17443,13 +17805,17 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"kXv" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "prospectorladder";
-	layer = 2
+"kXj" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/area/f13/building)
+"kXv" = (
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
@@ -17470,12 +17836,29 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"kYv" = (
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing";
+	tag = "icon-glassclosing"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "kYz" = (
 /obj/structure/chair/stool{
 	dir = 4;
 	icon_state = "bench"
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"kYB" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
 /area/f13/building)
 "kYH" = (
 /obj/structure/chair/comfy/brown{
@@ -17505,8 +17888,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "kZh" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/wood,
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbrokenvertical";
+	tag = "icon-housewindowbrokenvertical (NORTHEAST)"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "kZp" = (
 /obj/structure/rack,
@@ -17529,12 +17918,13 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
-"laC" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 4
+"lav" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
 "laZ" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -17547,27 +17937,22 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
-"lbx" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt";
-	tag = "icon-dirt (NORTHWEST)"
+"lbo" = (
+/obj/structure/table,
+/obj/item/kitchen/fork,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/area/f13/wasteland)
-"lcg" = (
-/obj/structure/simple_door/tentflap_cloth{
-	pixel_y = -3
+/area/f13/building)
+"lbZ" = (
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/legion)
-"lcq" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft2top";
-	tag = "icon-verticalrightborderleft2top"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "lda" = (
 /obj/structure/decoration/clock{
 	pixel_y = 30
@@ -17598,6 +17983,14 @@
 	icon_state = "horizontalbottomborderbottom2right"
 	},
 /area/f13/wasteland)
+"ldI" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "ldL" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -17671,15 +18064,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"lfu" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "lfG" = (
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -17732,6 +18116,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"lgI" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "lgX" = (
 /obj/structure/table/reinforced,
 /obj/item/phone,
@@ -17743,22 +18136,9 @@
 /obj/structure/chair/wood/worn,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"lhk" = (
-/obj/structure/rack,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/spray/plantbgone,
-/obj/item/reagent_containers/spray/plantbgone,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"lhp" = (
-/obj/structure/chair/stool/retro,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
+"lhz" = (
+/obj/item/trash/f13/fancylads,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "lhA" = (
 /obj/structure/closet/crate/internals,
@@ -17766,7 +18146,15 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "lhN" = (
-/turf/closed/wall/rust,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"lil" = (
+/obj/machinery/processor,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "liv" = (
 /obj/structure/car/rubbish2,
@@ -17775,12 +18163,13 @@
 	},
 /area/f13/wasteland)
 "liO" = (
-/obj/structure/simple_door/metal/dirtystore,
-/turf/open/floor/wood,
-/area/f13/building)
-"ljA" = (
-/obj/machinery/grill,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "busladder"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2right"
+	},
 /area/f13/wasteland)
 "ljF" = (
 /obj/structure/reagent_dispensers/barrel/two,
@@ -17809,15 +18198,6 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland)
-"lkz" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "lkE" = (
 /obj/structure/rack,
 /obj/item/seeds/chili,
@@ -17842,19 +18222,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"llz" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "llG" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottomleft"
-	},
-/area/f13/wasteland)
-"llP" = (
-/obj/structure/tires/five{
-	pixel_x = -19;
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "lmc" = (
@@ -17866,11 +18244,30 @@
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"lmw" = (
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "lmN" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"lmU" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermainleft";
+	tag = "icon-horizontaloutermainleft"
+	},
+/area/f13/wasteland)
+"lmV" = (
+/obj/structure/closet/crate/trashcart{
+	name = "corpse cart"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
 "lmY" = (
@@ -17885,15 +18282,18 @@
 "lnc" = (
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"lnm" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "lnw" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"lny" = (
-/turf/open/floor/wood/f13/oakbroken3,
-/area/f13/legion)
 "lnX" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -17911,22 +18311,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "loo" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/wood,
-/area/f13/building)
+/obj/structure/closet/crate/trashcart{
+	name = "corpse cart"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "los" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
-"lox" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0";
-	tag = "icon-horizontaloutermain0"
-	},
-/area/f13/wasteland)
 "loU" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/f13{
@@ -17944,19 +18340,29 @@
 	},
 /area/f13/wasteland)
 "lpd" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 8
+/obj/machinery/vending/cola/space_up,
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 12
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "lpu" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/box/dice,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"lpH" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "lpK" = (
 /obj/structure/toilet{
 	dir = 1
@@ -17969,6 +18375,10 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"lqi" = (
+/obj/structure/statue/wood/headstonewood,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "lqp" = (
 /obj/structure/bed/mattress/pregame,
 /obj/item/restraints/handcuffs{
@@ -18022,15 +18432,28 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"lrq" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "lrB" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_y = 12
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
 	},
-/area/f13/building)
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 12
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole"
+	},
+/area/f13/wasteland)
 "lrG" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18041,13 +18464,6 @@
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab"
 	},
-/area/f13/wasteland)
-"lrY" = (
-/obj/structure/fence{
-	dir = 1;
-	icon_state = "straight"
-	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "lsg" = (
 /obj/structure/chair/booth{
@@ -18069,6 +18485,10 @@
 "lsB" = (
 /obj/structure/sign/poster/contraband/pinup_funk,
 /turf/closed/wall/f13/wood/house,
+/area/f13/building)
+"lsC" = (
+/obj/structure/sign/departments/medbay,
+/turf/closed/wall/f13/supermart,
 /area/f13/building)
 "lsD" = (
 /obj/machinery/light/small{
@@ -18094,19 +18514,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"lsW" = (
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"ltb" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plating,
-/area/f13/radiation)
 "ltl" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -18115,19 +18522,26 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"ltq" = (
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "ltv" = (
 /obj/item/chair/stool/retro,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
-"ltD" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
+"ltZ" = (
+/obj/item/trash/cheesie,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
 "luc" = (
@@ -18145,6 +18559,15 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
+"lun" = (
+/obj/structure/chair,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "luy" = (
 /obj/structure/table_frame/wood,
 /obj/item/crowbar/crude,
@@ -18154,14 +18577,12 @@
 	},
 /area/f13/brotherhood)
 "luD" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/trading_machine/medical,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "luI" = (
@@ -18171,16 +18592,35 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"lvc" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"lvy" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertopright";
-	tag = "icon-horizontalbottombordertopright"
+"lvp" = (
+/obj/machinery/power/solar,
+/obj/structure/cable,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
+"lvv" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/building)
+"lvw" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
+	},
+/area/f13/building)
+"lvA" = (
+/obj/structure/bed/dogbed{
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "lvF" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -18188,12 +18628,20 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "lvL" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/structure/cable,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
 	},
-/area/f13/building)
+/area/f13/wasteland)
+"lvR" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "lvS" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/beaker/waterbottle,
@@ -18223,8 +18671,7 @@
 	},
 /area/f13/building)
 "lwd" = (
-/obj/structure/simple_door/house,
-/obj/structure/barricade/wooden/planks/pregame,
+/obj/machinery/biogenerator,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2";
 	tag = "icon-housewood2"
@@ -18254,48 +18701,26 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/building)
-"lwG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"lwv" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
-"lwJ" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"lwT" = (
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "innermaincornerouter";
-	tag = "icon-innermaincornerouter (WEST)"
-	},
-/area/f13/wasteland)
+"lwy" = (
+/obj/structure/rack,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "lxe" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2bottom"
 	},
 /area/f13/wasteland)
-"lxk" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetblue"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "lxJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
@@ -18315,6 +18740,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
+"lyk" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "lyo" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/inside/mountain,
@@ -18345,15 +18777,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
-"lzV" = (
-/obj/structure/mirror{
-	pixel_y = 32
+"lzP" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	icon_state = "wooden_chair_settler"
 	},
-/turf/closed/wall/f13/wood/interior,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"lzV" = (
+/obj/structure/table/wood/settler,
+/obj/item/storage/backpack/satchel/leather/withwallet,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "lzW" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/wood/f13/oak,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "lzZ" = (
 /obj/machinery/hydroponics/soil,
@@ -18385,6 +18829,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"lBv" = (
+/obj/machinery/smartfridge/drying_rack,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lBD" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -18395,6 +18843,15 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"lBX" = (
+/obj/effect/decal/remains/human,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "lCc" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -18413,33 +18870,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "lCi" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/simple_door/fakeglass,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "lCo" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/button/door{
-	id = "frontgateshu2t";
-	name = "gate shutters";
-	pixel_x = -5;
-	pixel_y = 32
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHWEST)"
 	},
-/obj/machinery/button/door{
-	id = "interiorgate2";
-	name = "Interior door button";
-	pixel_x = 6;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"lCs" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "lCv" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -18460,17 +18902,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"lCO" = (
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontalinnermain2left";
-	tag = "icon-horizontalinnermain2left (WEST)"
-	},
-/area/f13/wasteland)
 "lDd" = (
-/mob/living/simple_animal/hostile/raider/baseball,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/item/kitchen/knife/butcher,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "lDv" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -18537,32 +18978,19 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"lEx" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters{
-	id = "frontgateshut2";
-	name = "gate shutters"
+"lEo" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter (WEST)"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"lEC" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"lEG" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
-"lFe" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/item/seeds/cannabis,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+"lEG" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "lFf" = (
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/f13/wood{
@@ -18588,6 +19016,18 @@
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
+"lFI" = (
+/obj/structure/barricade/bars,
+/obj/structure/window/reinforced/fulltile{
+	layer = 2.8
+	},
+/obj/structure/fence{
+	pixel_x = -16
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "lFM" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/simple_animal/hostile/mirelurk/baby,
@@ -18605,20 +19045,21 @@
 	},
 /area/f13/legion)
 "lGG" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "lGH" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"lGV" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lGW" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -18655,35 +19096,17 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"lHZ" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderrightbottom";
-	tag = "icon-verticalleftborderrightbottom"
-	},
-/area/f13/wasteland)
 "lIh" = (
 /obj/structure/table/optable,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/ncr)
-"lIq" = (
-/obj/structure/sink{
-	pixel_y = 15
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/effect/spawner/lootdrop/trash,
+"lIX" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	icon_state = "bluedirtychess2"
 	},
-/area/f13/building)
-"lJf" = (
-/obj/structure/fence/wooden{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "lJg" = (
 /obj/structure/table,
@@ -18692,6 +19115,21 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"lJx" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/landmark/start/f13/ncrmp,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/ncr)
+"lJE" = (
+/obj/structure/table/optable,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
 	},
 /area/f13/building)
 "lJL" = (
@@ -18711,9 +19149,18 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "lKK" = (
-/obj/effect/landmark/start/f13/prospector,
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "lKO" = (
@@ -18721,16 +19168,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "lKV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cargocrate,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
-"lLu" = (
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
+/obj/structure/closet,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/disk/surgery/oasis,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lLv" = (
 /mob/living/simple_animal/hostile/wolf,
@@ -18749,13 +19195,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"lLP" = (
-/turf/open/indestructible/ground/outside/road{
-	dir = 4;
-	icon_state = "innermaincornerinner";
-	tag = "icon-innermaincornerinner (EAST)"
-	},
-/area/f13/wasteland)
 "lMn" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/autolathe/ammo,
@@ -18766,6 +19205,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
+"lMp" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "lMr" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -18781,15 +19227,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/village)
-"lMB" = (
-/obj/structure/barricade/bars,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "frontgateshut";
-	name = "gate shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "lNa" = (
 /obj/structure/closet/fridge/standard,
 /turf/open/floor/f13/wood,
@@ -18815,6 +19252,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"lOp" = (
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "lOz" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light{
@@ -18834,27 +19276,18 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
+"lPj" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "lPu" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2"
 	},
 /area/f13/wasteland)
-"lPv" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2";
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
-"lPx" = (
-/obj/item/ammo_casing/caseless{
-	dir = 4;
-	icon_state = "sS-casing";
-	tag = "icon-sS-casing (EAST)"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "lPN" = (
 /obj/structure/fence/corner{
 	dir = 4;
@@ -18868,6 +19301,15 @@
 "lPT" = (
 /turf/closed/wall/f13/wood,
 /area/f13/wasteland)
+"lPU" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "lPY" = (
 /obj/structure/disposalpipe/broken{
 	dir = 4
@@ -18891,20 +19333,18 @@
 	icon_state = "verylittleshadowright"
 	},
 /area/f13/wasteland)
-"lQK" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/city)
 "lRd" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"lRA" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+"lRe" = (
+/obj/structure/table,
+/obj/item/crafting/abraxo,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "lRB" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -18922,17 +19362,18 @@
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"lRT" = (
-/obj/machinery/button/door{
-	id = "prospectorshutters";
-	name = "gate shutters";
-	pixel_x = 32
+"lRQ" = (
+/obj/machinery/mineral/processing_unit_console{
+	machinedir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/building)
+"lRT" = (
+/obj/item/flag,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
+	},
+/area/f13/wasteland)
 "lRU" = (
 /obj/machinery/vending/cola/random,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18953,34 +19394,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"lSf" = (
-/turf/open/floor/wood/f13/oakbroken4,
-/area/f13/legion)
-"lSp" = (
-/turf/closed/wall/f13/ruins,
-/area/f13/radiation)
-"lSz" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"lSB" = (
-/obj/structure/barricade/tentclothcorner,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
 "lSD" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
 	icon_state = "horizontaltopborderbottom2right"
 	},
-/area/f13/wasteland)
-"lSG" = (
-/obj/effect/decal/riverbank{
-	dir = 9
-	},
-/turf/open/water,
 /area/f13/wasteland)
 "lTk" = (
 /obj/machinery/light/small/broken{
@@ -18997,8 +19415,11 @@
 	},
 /area/f13/wasteland)
 "lTx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/machinery/seed_extractor,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "lTG" = (
 /obj/item/ammo_casing/caseless{
@@ -19014,6 +19435,20 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"lTZ" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/f13/leatherarmor,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/item/storage/bag/plants,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "lUa" = (
 /obj/structure/toilet{
 	dir = 8
@@ -19044,10 +19479,15 @@
 	},
 /area/f13/building)
 "lUg" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing"
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 1;
+	output_dir = 2
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
 /area/f13/building)
 "lUk" = (
 /obj/structure/decoration/clock/old/active,
@@ -19071,6 +19511,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"lUY" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lVa" = (
 /obj/structure/table,
 /obj/item/reagent_containers/syringe/medx,
@@ -19089,12 +19538,12 @@
 /obj/item/clothing/under/f13/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"lVR" = (
-/obj/machinery/mineral/unloading_machine,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+"lVu" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
 	},
 /area/f13/building)
 "lWj" = (
@@ -19116,23 +19565,9 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"lWJ" = (
-/obj/structure/fence/corner/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "lWZ" = (
 /obj/structure/billboard/ritas,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"lXd" = (
-/obj/structure/tires{
-	pixel_x = -8;
-	pixel_y = 15
-	},
-/obj/structure/lamp_post/quadra,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
 /area/f13/wasteland)
 "lXl" = (
 /obj/structure/table/wood,
@@ -19154,19 +19589,17 @@
 	},
 /area/f13/wasteland)
 "lYu" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	name = "prewar lounge chair"
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/f13/leatherarmor,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/light/small,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/turf/open/floor/wood,
 /area/f13/building)
-"lYx" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "lZl" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/light{
@@ -19202,16 +19635,22 @@
 /turf/closed/wall/f13/wood,
 /area/f13/village)
 "lZY" = (
-/obj/structure/table/wood,
-/obj/item/phone,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/wood,
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "mar" = (
-/obj/machinery/light/small/broken{
-	dir = 4
+/obj/structure/table/wood/settler,
+/obj/item/paper,
+/obj/item/pen,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
-/turf/open/floor/wood,
 /area/f13/building)
 "may" = (
 /obj/structure/decoration/rag,
@@ -19222,14 +19661,13 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/village)
-"maS" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowvertical"
+"maE" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "maW" = (
 /obj/structure/closet/crate/medical/anchored,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -19250,27 +19688,13 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
-"mbq" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6
+"mbD" = (
+/obj/structure/closet,
+/obj/item/storage/backpack/satchel/leather,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outermaincornerouter"
-	},
-/area/f13/wasteland)
-"mbr" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/obj/effect/decal/fakelattice,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "mco" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/plating/dirt/dark,
@@ -19280,8 +19704,12 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
 "mcz" = (
-/mob/living/simple_animal/hostile/handy,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mcD" = (
 /obj/structure/simple_door/house{
@@ -19295,12 +19723,9 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/wasteland)
 "mdc" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "mdv" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood{
@@ -19315,26 +19740,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "mdE" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
-"mdI" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "shadowright";
-	tag = "icon-shadowright"
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland)
 "mdM" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "mdT" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/dirt,
@@ -19377,6 +19793,15 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"meU" = (
+/obj/structure/tires/five{
+	pixel_x = -19;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland)
 "mfj" = (
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/ruins{
@@ -19385,10 +19810,13 @@
 	},
 /area/f13/wasteland)
 "mfq" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
+	},
+/area/f13/wasteland)
 "mfD" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -19414,36 +19842,45 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"mge" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
 "mgg" = (
 /obj/machinery/autolathe,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"mgu" = (
-/obj/machinery/chem_dispenser/drinks/beer,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
-"mgP" = (
-/obj/machinery/grill,
+"mgo" = (
+/obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0"
+	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
+"mgu" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland)
+"mgV" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Private"
+	},
+/turf/open/floor/wood,
+/area/f13/building)
+"mhI" = (
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "mhJ" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
+	},
+/area/f13/wasteland)
+"mhL" = (
+/obj/structure/bus_door,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
 "mia" = (
@@ -19464,12 +19901,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"miL" = (
-/obj/item/flag,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
 "mjg" = (
 /obj/machinery/button/door{
 	id = "badboys";
@@ -19510,18 +19941,21 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/village)
-"mkV" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0";
-	tag = "icon-horizontaltopbordertop0"
+"mkP" = (
+/obj/structure/chair/bench,
+/obj/effect/landmark/start/f13/settler,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"mlw" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
+"mlz" = (
+/obj/structure/fence/corner,
+/obj/structure/fence{
+	dir = 1;
+	icon_state = "straight"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "mlD" = (
 /obj/structure/table/wood/settler,
 /obj/item/paper_bin,
@@ -19545,6 +19979,15 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mmH" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "mmK" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -19573,12 +20016,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"mmY" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/f13/radiation)
 "mnb" = (
 /mob/living/simple_animal/pet/dog/protectron,
 /obj/machinery/light/small{
@@ -19589,6 +20026,24 @@
 "mnd" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"mne" = (
+/obj/structure/weightlifter,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"mnv" = (
+/obj/structure/barricade/bars,
+/obj/structure/fence{
+	pixel_x = -16
+	},
+/obj/structure/window/reinforced/fulltile{
+	layer = 2.8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
 "mnC" = (
 /obj/structure/flora/grass/wasteland{
@@ -19609,14 +20064,20 @@
 	},
 /area/f13/wasteland)
 "moo" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
+/obj/structure/chair{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
+"mov" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "moA" = (
 /obj/structure/chair{
 	dir = 8;
@@ -19636,12 +20097,42 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
-"moO" = (
-/obj/item/instrument/eguitar{
-	anchored = 1;
-	pixel_x = 32
+"moH" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "clinicdesk";
+	name = "counter shutters"
 	},
-/turf/closed/wall/f13/wood/interior,
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
+"moO" = (
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "clinicfrontdoor";
+	name = "door shutters";
+	pixel_x = -6
+	},
+/obj/machinery/button/door{
+	id = "clinicdesk";
+	name = "desk shutters";
+	pixel_x = 6
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
+"moR" = (
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"moV" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
 /area/f13/building)
 "moX" = (
 /obj/structure/closet/crate{
@@ -19667,34 +20158,10 @@
 /obj/machinery/door/airlock/freezer,
 /turf/open/floor/plasteel/bar,
 /area/f13/ncr)
-"mpI" = (
-/obj/structure/table/wood/settler,
-/obj/item/dildo{
-	icon_state = "dildo";
-	layer = 1.1
-	},
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"mpN" = (
-/obj/machinery/vending/boozeomat{
-	density = 0;
-	pixel_x = -32
-	},
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
 "mpQ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
-"mqn" = (
-/mob/living/simple_animal/hostile/stalkeryoung,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "mqp" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -19707,12 +20174,9 @@
 	},
 /area/f13/ncr)
 "mqy" = (
-/obj/machinery/power/solar,
-/obj/structure/cable,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
-/area/f13/wasteland)
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "mqF" = (
 /obj/machinery/mineral/wasteland_vendor/ammo,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19728,8 +20192,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mrg" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood/house,
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "mri" = (
 /obj/structure/simple_door/metal/store{
@@ -19746,25 +20212,28 @@
 "mrq" = (
 /turf/closed/indestructible/opshuttle,
 /area/f13/building)
+"mrA" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottomright";
+	tag = "icon-horizontalbottomborderbottomright"
+	},
+/area/f13/wasteland)
 "mrB" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"mrQ" = (
-/obj/structure/cargocrate,
-/obj/structure/cargocrate{
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "mrS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/smartfridge/bottlerack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "mrY" = (
 /obj/structure/closet/cabinet,
 /turf/open/indestructible/ground/outside/ruins{
@@ -19822,13 +20291,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"muh" = (
+"mtX" = (
+/obj/structure/fence/corner{
+	dir = 6
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
-	icon_state = "horizontaloutermain1";
-	tag = "icon-horizontaloutermain1 (NORTH)"
+	icon_state = "outerpavementcorner"
 	},
-/area/f13/caves)
+/area/f13/wasteland)
 "muk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -19849,6 +20320,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
+"mus" = (
+/obj/effect/decal/riverbank{
+	dir = 9
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "mvh" = (
 /obj/structure/chair/wood,
 /obj/effect/landmark/start/f13/chief,
@@ -19873,20 +20350,17 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"mvF" = (
+/obj/structure/rack,
+/obj/item/seeds/cannabis,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mvJ" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"mvK" = (
-/obj/structure/closet,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs/cable,
-/obj/item/restraints/handcuffs/cable,
-/obj/item/restraints/legcuffs/bola,
-/turf/open/floor/plating,
-/area/f13/radiation)
 "mvS" = (
 /obj/structure/chair{
 	dir = 1
@@ -19901,9 +20375,16 @@
 	},
 /area/f13/building)
 "mvV" = (
-/obj/machinery/jukebox,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetblue"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"mwa" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating,
 /area/f13/building)
 "mwc" = (
 /obj/machinery/vending/snack,
@@ -19912,13 +20393,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"mwg" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "mwp" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
@@ -19929,16 +20403,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"mxq" = (
-/obj/machinery/conveyor/auto{
-	dir = 4
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "mxO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19968,19 +20432,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"myF" = (
-/obj/structure/chair/wood/modern{
-	dir = 1;
-	tag = "icon-wooden_chair_new (NORTH)"
-	},
-/turf/open/floor/wood/f13/oakbroken3,
-/area/f13/building)
-"mzn" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "mzs" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19998,9 +20449,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
-"mzS" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt,
+"mzC" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0";
+	tag = "icon-horizontaltopbordertop0"
+	},
 /area/f13/wasteland)
 "mzY" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -20019,6 +20472,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"mAl" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mAr" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/indestructible/ground/outside/road{
@@ -20040,17 +20497,6 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"mBA" = (
-/obj/structure/rack,
-/obj/item/shovel,
-/obj/item/storage/bag/ore,
-/obj/item/flashlight,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "mCf" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -20062,42 +20508,73 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"mDf" = (
-/obj/structure/fence{
-	dir = 1
-	},
+"mCO" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavement"
+	icon_state = "horizontaltopbordertop2"
 	},
 /area/f13/wasteland)
+"mDf" = (
+/obj/structure/simple_door/house{
+	icon_state = "interior";
+	tag = "icon-interior"
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "mDn" = (
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
 /area/f13/brotherhood)
+"mDr" = (
+/obj/structure/bonfire,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain3"
+	},
+/area/f13/wasteland)
+"mDO" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/f13/radiation)
+"mEe" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "mEh" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"mEn" = (
-/obj/item/gun/ballistic/shotgun/trench{
-	anchored = 1;
-	pixel_y = 5
+"mEl" = (
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/item/storage/bag/ore,
+/obj/item/flashlight,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/obj/item/gun/ballistic/shotgun/hunting{
-	anchored = 1;
-	pixel_y = -3
-	},
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_y = 3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
+"mEn" = (
+/obj/structure/table/wood,
+/obj/structure/wreck/trash/one_tire{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland)
 "mEy" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
@@ -20126,21 +20603,6 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"mFi" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
-"mFs" = (
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "mGf" = (
 /obj/structure/table/snooker{
 	dir = 6
@@ -20148,10 +20610,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"mGh" = (
-/obj/machinery/light/sign,
-/turf/closed/wall/f13/wood/interior,
-/area/f13/building)
+"mGo" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/matches,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "mGr" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
@@ -20164,12 +20629,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"mGA" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/wasteland)
 "mGC" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
@@ -20190,6 +20649,16 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"mHv" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "mHy" = (
 /obj/structure/closet/cabinet,
 /obj/item/instrument/trumpet,
@@ -20208,6 +20677,14 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"mHY" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "mIi" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/suspenders,
@@ -20224,6 +20701,16 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"mJu" = (
+/obj/structure/table/wood,
+/obj/structure/wreck/trash/halftire{
+	pixel_y = -21
+	},
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "mJG" = (
 /obj/structure/fence{
 	dir = 4
@@ -20232,14 +20719,6 @@
 	icon_state = "verticaloutermainbottom"
 	},
 /area/f13/wasteland)
-"mJW" = (
-/obj/structure/sign/poster/prewar/poster88{
-	pixel_x = -32
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
 "mKe" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -20274,15 +20753,21 @@
 	icon_state = "horizontaloutermainright"
 	},
 /area/f13/wasteland)
-"mLa" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6";
-	pixel_x = -28
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
+"mLe" = (
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2bottom";
+	tag = "icon-verticalleftborderleft2bottom"
 	},
 /area/f13/wasteland)
+"mLh" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "mLj" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/machinery/light/broken,
@@ -20299,11 +20784,6 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"mLC" = (
-/obj/structure/chair/office,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "mLN" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -20311,18 +20791,30 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"mMn" = (
-/obj/structure/chair/stool,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+"mMe" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"mMq" = (
+/obj/structure/bonfire,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"mMI" = (
+/obj/machinery/smartfridge/chemistry,
+/turf/closed/wall/f13/supermart,
+/area/f13/building)
 "mMN" = (
-/obj/machinery/smartfridge/bottlerack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/chem_pile{
+	pixel_x = -10;
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/supermart,
 /area/f13/building)
 "mNi" = (
 /obj/structure/rack,
@@ -20332,6 +20824,27 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"mNB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/supermart,
+/area/f13/building)
+"mNK" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"mNL" = (
+/obj/item/pet_carrier{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "mNS" = (
 /obj/structure/chair{
 	dir = 8
@@ -20353,6 +20866,15 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"mOp" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "mOx" = (
 /obj/item/stack/f13Cash/aureus,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20363,28 +20885,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "mPa" = (
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_y = 3
+/obj/effect/decal/riverbank{
+	dir = 9
 	},
-/turf/closed/wall/f13/wood/interior,
-/area/f13/building)
+/turf/open/water,
+/area/f13/wasteland)
 "mPk" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "shopladder"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/plating,
 /area/f13/building)
 "mPw" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plating,
 /area/f13/building)
 "mPT" = (
 /obj/structure/closet/cabinet,
@@ -20406,17 +20923,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"mRt" = (
-/obj/machinery/mineral/processing_unit{
-	input_dir = 8;
-	output_dir = 4
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "mSs" = (
 /obj/structure/decoration/rag{
 	icon_state = "flag_ncr";
@@ -20428,6 +20934,14 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
+"mSw" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "mSD" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/f13{
@@ -20476,6 +20990,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"mTT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plating,
+/area/f13/building)
 "mUk" = (
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -20485,13 +21007,6 @@
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
-"mUw" = (
-/obj/structure/fence/wooden{
-	dir = 4;
-	icon_state = "post_wood"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "mUx" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20499,10 +21014,9 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"mUy" = (
-/obj/structure/fence/corner/wooden{
-	dir = 1
-	},
+"mUA" = (
+/obj/structure/simple_door/metal/fence,
+/obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mUO" = (
@@ -20511,23 +21025,38 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"mUP" = (
-/obj/item/ammo_casing/shotgun/buckshot,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"mUU" = (
-/obj/machinery/button/door{
-	id = "shopouter";
-	name = "gate shutters";
-	pixel_y = 32
+"mUQ" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
+"mUS" = (
+/obj/structure/fence/corner/wooden{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"mUU" = (
+/obj/structure/fence/wooden{
+	dir = 4;
+	icon_state = "post_wood"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
+"mVc" = (
+/obj/structure/fence/corner/wooden,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "mVh" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"mVn" = (
+/obj/effect/landmark/start/f13/dendoc,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "mVu" = (
 /obj/structure/closet/fridge/standard,
@@ -20569,6 +21098,19 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"mWa" = (
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "124"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "botany";
+	name = "Botany shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "mWn" = (
 /obj/structure/rack,
 /obj/item/clothing/under/pants/jeans{
@@ -20578,6 +21120,10 @@
 /obj/item/clothing/under/f13/greendress,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mWv" = (
+/obj/item/shovel,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "mWy" = (
 /obj/structure/rack,
 /obj/item/kitchen/knife/combat/bone,
@@ -20586,38 +21132,36 @@
 /obj/item/kitchen/knife/combat/bone,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
-"mWG" = (
-/obj/machinery/conveyor/auto{
-	dir = 6
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
-"mWT" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottomleft";
-	tag = "icon-horizontalbottomborderbottomleft"
-	},
-/area/f13/wasteland)
-"mXy" = (
-/obj/structure/closet/cardboard,
-/obj/item/crowbar,
+"mWE" = (
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/area/f13/legion)
 "mXC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/village)
 "mXF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "botany";
+	name = "Botany button";
+	pixel_y = -25
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
+"mXL" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/f13/wood,
+/obj/item/pickaxe,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
 /area/f13/building)
 "mYi" = (
 /obj/structure/fence{
@@ -20657,20 +21201,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mYF" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/matches,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/wasteland)
-"mZk" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0";
-	tag = "icon-verticalrightborderleft0"
-	},
-/area/f13/wasteland)
 "mZD" = (
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -20701,6 +21231,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"naF" = (
+/obj/effect/landmark/observer_start,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "naP" = (
 /obj/structure/chair{
 	dir = 8
@@ -20740,12 +21276,6 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/bar)
-"nby" = (
-/obj/machinery/processor,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
 "nbD" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -20763,6 +21293,12 @@
 /obj/item/clothing/under/f13/brahmin,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"nbX" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	tag = "icon-dirt"
+	},
+/area/f13/wasteland)
 "ncb" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20770,26 +21306,12 @@
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
-"ncC" = (
-/obj/structure/fence{
-	dir = 4;
-	tag = "icon-metal_fence3"
+"ncN" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"ncU" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/city)
+/area/f13/legion)
 "ncX" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -20804,12 +21326,31 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"ndx" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2right";
+	tag = "icon-horizontalinnermain2right"
+	},
+/area/f13/wasteland)
 "ndy" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ndT" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/obj/structure/tires/five{
+	pixel_x = -19;
+	pixel_y = -3
+	},
+/obj/machinery/light/sign/oasis_sign,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "ndV" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -20820,44 +21361,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
-"nev" = (
-/obj/structure/rack,
-/obj/item/seeds/chili,
-/obj/item/seeds/coffee,
-/obj/item/seeds/tea,
-/obj/item/seeds/xander,
-/obj/item/seeds/grass,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/wheat/rice,
-/obj/item/seeds/cotton,
-/obj/item/seeds/grass,
-/obj/item/seeds/wheat,
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"neD" = (
-/obj/effect/mine/stun,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "neN" = (
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/structure/rack,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/machinery/grill,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "neP" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20877,14 +21386,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"neX" = (
-/obj/effect/decal/marking{
-	icon_state = "doublehorizontalright"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/wasteland)
 "neZ" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
@@ -20908,17 +21409,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nfu" = (
-/obj/structure/fence/corner/wooden{
+/obj/structure/barricade/tentclothedge{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"nfv" = (
-/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
+"nfz" = (
+/obj/structure/chair/bench,
+/obj/effect/landmark/start/f13/settler,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
+	icon_state = "horizontalinnermain2"
 	},
-/area/f13/tunnel)
+/area/f13/wasteland)
 "nfH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
@@ -20931,38 +21433,11 @@
 	},
 /area/f13/village)
 "ngg" = (
-/obj/machinery/button/door{
-	id = "countershutters";
-	name = "counter shutters";
-	pixel_x = 6;
-	pixel_y = 30
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/button/door{
-	id = "storeshutters";
-	name = "store shutters";
-	pixel_x = -6;
-	pixel_y = 30
-	},
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_y = 32
-	},
-/obj/structure/rack,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"ngF" = (
-/obj/structure/rack,
-/obj/item/clothing/head/hardhat,
-/obj/item/storage/bag/ore,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ngV" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/f13/wood{
@@ -21002,12 +21477,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"nhv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2"
-	},
-/area/f13/wasteland)
 "nhz" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -21028,6 +21497,15 @@
 	},
 /turf/open/water,
 /area/f13/caves)
+"nhX" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Clinic"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "nip" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -21052,53 +21530,29 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"nji" = (
-/obj/item/chair/stool/retro/black,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"njC" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
-"njK" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
 "nkp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland)
-"nkA" = (
-/obj/effect/decal/remains{
-	icon_state = "remains";
-	tag = "icon-remains"
+"nkq" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/obj/structure/chair/wood/worn{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "nla" = (
 /obj/machinery/workbench/forge,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "nlv" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/attachments,
-/obj/effect/spawner/lootdrop/f13/attachments,
-/obj/effect/spawner/lootdrop/f13/attachments,
-/obj/effect/spawner/lootdrop/f13/attachments,
-/turf/open/floor/f13/wood,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
 "nly" = (
 /obj/machinery/mineral/wasteland_vendor/weapons,
@@ -21106,16 +21560,22 @@
 	icon_state = "verticaloutermaintop"
 	},
 /area/f13/building)
-"nlG" = (
-/obj/structure/legion_extractor,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"nlL" = (
+"nlz" = (
+/obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain2top";
-	tag = "icon-verticaloutermain2top"
+	icon_state = "horizontaloutermainleft";
+	tag = "icon-horizontaloutermainleft"
 	},
 /area/f13/wasteland)
+"nlD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/prewar/poster86{
+	pixel_y = -32
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "nlN" = (
 /obj/structure/window/fulltile/wood_window,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -21137,37 +21597,21 @@
 /obj/structure/sign/poster/contraband/pinup_topless,
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
-"nms" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+"nmv" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop3";
+	tag = "icon-horizontaltopbordertop3"
 	},
-/area/f13/city)
-"nmU" = (
-/obj/structure/table/reinforced,
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters{
-	id = "frontgateshut";
-	name = "gate shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/area/f13/wasteland)
+"nmD" = (
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/clinic)
 "nmZ" = (
 /turf/open/floor/f13{
 	dir = 1;
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
-"nnh" = (
-/obj/structure/fence/corner{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
 "nnn" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/shower{
@@ -21178,11 +21622,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"nnz" = (
-/obj/effect/spawner/lootdrop/crafts,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+"nnA" = (
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "noo" = (
@@ -21195,22 +21638,40 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"noD" = (
-/obj/machinery/light/small,
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "noH" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/structure/sign/poster/prewar/poster88{
+	pixel_x = -32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
 "noK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertopleft"
 	},
 /area/f13/wasteland)
+"npl" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Secret"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
+"npS" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetcmo"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "nqb" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/ruins{
@@ -21229,18 +21690,29 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nqU" = (
-/obj/structure/rack,
-/obj/item/book/granter/trait/chemistry,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/f13/wood,
+/obj/structure/sink{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"nrv" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/book/bible,
+/turf/open/floor/holofloor/carpet,
 /area/f13/building)
 "nrw" = (
 /obj/structure/displaycase,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nrB" = (
+/obj/effect/decal/waste{
+	pixel_x = -4;
+	pixel_y = -7
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "nrS" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -21262,6 +21734,15 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"nso" = (
+/obj/structure/chair/stool{
+	icon_state = "bench_center"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "nss" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 1
@@ -21278,6 +21759,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"ntg" = (
+/obj/structure/fence/corner/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ntl" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood,
@@ -21317,26 +21802,21 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"nuB" = (
-/obj/structure/rack,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/storage/bag/plants,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
-	tag = "icon-dirt"
+"nuV" = (
+/obj/structure/dresser,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
-/area/f13/wasteland)
-"nvc" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "nvr" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
+"nvx" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "nvH" = (
 /obj/structure/closet/crate/freezer/blood{
 	pixel_y = 20
@@ -21351,42 +21831,39 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"nvV" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+"nvP" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2";
+	tag = "icon-verticalleftborderleft2"
 	},
-/area/f13/building)
+/area/f13/wasteland)
+"nwh" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "nwp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+/obj/structure/fence/wooden{
+	dir = 1
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "nwu" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland)
+"nwB" = (
+/obj/structure/tires/two{
+	pixel_x = -5;
+	pixel_y = 6
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/crafting/goodparts/five,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"nwG" = (
-/obj/structure/table/wood/settler,
-/obj/item/shovel,
-/obj/item/shovel{
-	pixel_x = -1;
-	pixel_y = 5
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "nwT" = (
 /obj/structure/closet/crate/bin,
 /turf/open/indestructible/ground/outside/dirt{
@@ -21404,17 +21881,10 @@
 /turf/closed/wall/f13/wood,
 /area/f13/village)
 "nxj" = (
-/obj/item/clothing/suit/armor/f13/slavelabor,
-/obj/item/clothing/under/f13/legslave,
-/obj/item/clothing/shoes/f13/rag,
-/obj/effect/landmark/start/f13/slave,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
-"nxL" = (
-/obj/structure/fence/wooden{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "nxS" = (
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -21443,11 +21913,20 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"nyZ" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/turf/open/floor/plasteel/floorgrime,
+"nzf" = (
+/obj/structure/decoration/sign{
+	desc = "It's a portrait of a person you don't know anything about.";
+	icon_state = "painting_president";
+	name = "portrait"
+	},
+/turf/closed/wall/f13/wood,
 /area/f13/building)
+"nzq" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "nzJ" = (
 /obj/item/seeds/poppy/broc,
 /turf/open/indestructible/ground/outside/dirt,
@@ -21484,6 +21963,10 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/tunnel)
+"nAI" = (
+/obj/structure/railing,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "nAR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/money_stack/legion,
@@ -21514,31 +21997,23 @@
 	tag = "icon-horizontalinnermain2left"
 	},
 /area/f13/wasteland)
-"nCj" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+"nBU" = (
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/area/f13/city)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "nCl" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
-"nCp" = (
-/obj/structure/chair/wood/modern{
-	dir = 8;
-	tag = "icon-wooden_chair_new (WEST)"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "nCx" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "radio"
+/obj/structure/railing,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/building)
+/area/f13/wasteland)
 "nCS" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -21572,6 +22047,13 @@
 /obj/structure/stone_tile/slab/burnt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"nDN" = (
+/obj/machinery/light/lampost,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
+	},
+/area/f13/wasteland)
 "nDY" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Prison Management";
@@ -21579,20 +22061,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"nEa" = (
-/obj/structure/table/wood/poker,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"nEi" = (
-/obj/structure/sign/poster/prewar/poster82{
-	pixel_x = 32
-	},
-/obj/structure/chair/stool/retro,
-/turf/open/floor/holofloor/carpet,
-/area/f13/building)
 "nEn" = (
 /obj/structure/holohoop{
 	dir = 8
@@ -21629,6 +22097,17 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"nGh" = (
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "133"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "clinicfrontdoor";
+	name = "clinic shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "nGq" = (
 /turf/closed/wall/f13/store,
 /area/f13/wasteland)
@@ -21641,17 +22120,16 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"nGJ" = (
-/obj/structure/chair/wood,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+"nHc" = (
+/obj/structure/sacrificealtar,
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "nHi" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/open/floor/wood,
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "133"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "nHC" = (
 /mob/living/simple_animal/hostile/radscorpion,
@@ -21672,9 +22150,23 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"nIj" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "clinicladder"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "nIp" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
+"nIs" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	tag = "icon-wooden_chair_new (NORTH)"
+	},
+/turf/open/floor/wood/f13/oakbroken3,
+/area/f13/building)
 "nIz" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/machinery/light/small/broken{
@@ -21700,16 +22192,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"nIJ" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "nIP" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/building)
@@ -21720,16 +22202,31 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland)
-"nJG" = (
-/obj/structure/chair/stool,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+"nJc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/iv_drip,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"nJz" = (
+/obj/structure/cargocrate,
+/obj/structure/cargocrate{
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "nJM" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "nJW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -21742,20 +22239,28 @@
 /obj/item/clothing/mask/bandana/gold,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nLD" = (
-/obj/structure/table/wood/settler,
-/obj/item/kitchen/knife,
-/obj/item/mining_scanner,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+"nKV" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
 	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "nLL" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
+"nLX" = (
+/obj/structure/bed,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/item/bedsheet/brown,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/ncr)
 "nMd" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/indestructible/ground/outside/desert,
@@ -21777,17 +22282,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"nNm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "clinicoutsideladder"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "nNn" = (
 /obj/item/picket_sign,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -21808,23 +22302,15 @@
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"nNI" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical";
-	tag = "icon-housewindowvertical (NORTHEAST)"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "nNU" = (
 /obj/structure/simple_door/house,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nNZ" = (
-/obj/structure/table/wood,
-/obj/item/papercutter,
-/turf/open/floor/wood,
-/area/f13/building)
+/obj/structure/flora/wasteplant/wild_punga,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "nOm" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road{
@@ -21871,11 +22357,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"nPP" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "nPV" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -21890,6 +22371,27 @@
 /obj/effect/turf_decal/stripes/white/full,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"nQu" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/landmark/start/f13/ncrheavytrooper,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/ncr)
+"nQy" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"nQJ" = (
+/obj/structure/chair,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "nQP" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
@@ -21909,14 +22411,6 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"nRu" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Private"
-	},
-/turf/open/floor/wood,
 /area/f13/building)
 "nRz" = (
 /obj/structure/fence/wooden{
@@ -21961,17 +22455,20 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"nSQ" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
-	tag = "icon-housewood2-broken"
+"nSX" = (
+/mob/living/simple_animal/hostile/wolf,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"nTa" = (
+/obj/structure/fence{
+	dir = 8;
+	icon_state = "straight"
 	},
-/area/f13/building)
-"nTc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
+/obj/structure/fence/corner{
+	dir = 8;
+	icon_state = "corner"
 	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "nTe" = (
 /turf/open/floor/f13/wood{
@@ -22010,21 +22507,16 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/wasteland)
+"nUj" = (
+/obj/structure/flora/wasteplant/wild_punga,
+/turf/open/water,
+/area/f13/wasteland)
 "nUm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
-"nUs" = (
-/obj/structure/spider/stickyweb,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "nUF" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22088,63 +22580,45 @@
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nWl" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_2"
+	},
+/turf/open/water,
+/area/f13/wasteland)
 "nWu" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"nWv" = (
-/obj/structure/table,
-/obj/item/crafting/abraxo,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+"nWC" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
 	},
-/area/f13/city)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "nXd" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"nXl" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/city)
-"nXE" = (
-/obj/structure/table/wood/settler,
-/obj/item/flashlight/lantern,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"nYY" = (
-/obj/structure/chair/comfy{
-	dir = 4;
-	tag = "icon-comfychair (EAST)"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
-"nZd" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0";
-	tag = "icon-horizontaltopborderbottom0"
+	icon_state = "verticalrightborderleft2bottom";
+	tag = "icon-verticalrightborderleft2bottom"
+	},
+/area/f13/wasteland)
+"nYI" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
+"nYX" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
 /area/f13/wasteland)
 "nZr" = (
 /mob/living/simple_animal/hostile/wolf,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"nZs" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "nZJ" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22156,26 +22630,13 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
-"nZT" = (
-/obj/machinery/light/lampost,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2left";
-	tag = "icon-horizontaltopbordertop2left"
-	},
-/area/f13/wasteland)
 "nZV" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -6
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 4
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"oat" = (
+/obj/machinery/workbench,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "oav" = (
 /turf/closed/wall/f13/wood,
@@ -22216,21 +22677,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "obr" = (
-/obj/structure/table/wood/settler,
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/obj/structure/table/wood,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"obz" = (
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "obV" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/obj/machinery/smartfridge/drying_rack,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"oco" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "ocx" = (
 /obj/structure/chair/stool{
@@ -22243,11 +22703,9 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"ocU" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
-	tag = "icon-dirt"
-	},
+"ocy" = (
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ocV" = (
 /obj/structure/sink{
@@ -22255,22 +22713,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"ocX" = (
-/obj/structure/chair/stool{
-	dir = 4;
-	icon_state = "bench";
-	tag = "icon-bench (EAST)"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "odb" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
 /area/f13/bar)
+"odc" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/building)
 "odh" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -22279,29 +22732,6 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/building)
-"odk" = (
-/obj/structure/barricade/bars,
-/obj/structure/fence{
-	pixel_x = -16
-	},
-/obj/structure/window/reinforced/fulltile{
-	layer = 2.8
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
-"odo" = (
-/obj/structure/bed,
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/item/bedsheet{
-	icon_state = "sheetblue"
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "odr" = (
 /obj/structure/flora/grass/wasteland{
@@ -22317,6 +22747,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"odx" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "odJ" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical,
@@ -22324,6 +22762,18 @@
 /obj/item/pickaxe,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"odP" = (
+/obj/structure/toilet,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/clinic)
+"odS" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "odW" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/light,
@@ -22353,29 +22803,32 @@
 /obj/structure/mirelurkegg,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
-"oeq" = (
-/obj/structure/chair/wood/modern{
-	dir = 1;
-	icon_state = "wooden_chair_settler"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "oeL" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ofd" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
+"ofa" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/f13/wood,
 /area/f13/building)
+"ofe" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft1"
+	},
+/area/f13/wasteland)
 "ofh" = (
-/obj/structure/billboard/ritas,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
+	},
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/tires,
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
 "ofL" = (
@@ -22396,27 +22849,28 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
-"ogf" = (
-/obj/item/stack/sheet/mineral/wood/five,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "ogj" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
-"ogB" = (
-/obj/structure/wreck/trash/four_barrels,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
+"ogq" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/syringe/medx,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
+"ogO" = (
+/obj/structure/destructible/tribal_torch{
+	pixel_y = 20
+	},
+/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"ohc" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/f13/doctor,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "ohk" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -22425,19 +22879,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ohp" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress6"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
-"ohH" = (
-/obj/structure/tires/two,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermainleft";
-	tag = "icon-horizontaloutermainleft"
-	},
-/area/f13/wasteland)
+"ohx" = (
+/obj/structure/table,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "ohU" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/broken,
@@ -22471,51 +22920,51 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"oiP" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+"oiz" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"oja" = (
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "ojl" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
-"ojS" = (
-/obj/machinery/smartfridge/drying_rack,
-/turf/open/floor/f13/wood,
+"ojL" = (
+/obj/structure/sink{
+	pixel_y = 28
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"okn" = (
-/obj/machinery/light/small{
-	dir = 4
+"okc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetcmo"
 	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "okt" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/bar)
 "okz" = (
-/obj/structure/sink{
-	pixel_y = 15
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"okJ" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
-	},
-/area/f13/wasteland)
 "okS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/decoration/shock,
@@ -22533,6 +22982,18 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"oll" = (
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"olt" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "olD" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -22560,6 +23021,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"olV" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "olW" = (
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
@@ -22577,21 +23048,12 @@
 	},
 /area/f13/building)
 "omd" = (
-/obj/structure/toilet{
-	dir = 8;
-	tag = "icon-toilet00 (WEST)"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
-"oml" = (
-/obj/structure/table/wood/settler,
-/obj/item/storage/backpack/satchel/leather/withwallet,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
 "omu" = (
@@ -22604,19 +23066,19 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/brotherhood)
-"omV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetcmo"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "one" = (
 /obj/structure/table/wood/settler,
 /obj/item/lipstick/jade,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"onh" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 10
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "onk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
@@ -22646,9 +23108,21 @@
 	},
 /area/f13/ncr)
 "onz" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTHEAST)"
+	},
+/area/f13/wasteland)
+"onD" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "onQ" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/trash,
@@ -22680,6 +23154,11 @@
 /obj/item/roller,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"ook" = (
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
+/area/f13/building)
 "ooq" = (
 /obj/structure/rack,
 /obj/item/seeds/xander,
@@ -22749,11 +23228,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "oqu" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/water,
+/area/f13/wasteland)
+"oqA" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "orm" = (
 /obj/structure/table/wood/settler,
@@ -22761,6 +23243,10 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"orB" = (
+/obj/item/poster/random_contraband,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "orZ" = (
 /obj/structure/table/wood/settler,
 /obj/structure/guillotine,
@@ -22769,10 +23255,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"ose" = (
-/obj/structure/fermenting_barrel,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "osj" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -22801,6 +23283,17 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"osJ" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
+"osT" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "oto" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -22835,18 +23328,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"oua" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
-"oum" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "ouS" = (
 /obj/structure/chair/stool,
 /turf/open/floor/f13{
@@ -22864,6 +23345,17 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ovE" = (
+/obj/structure/rack,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/reagent_containers/spray/plantbgone,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "ovN" = (
 /obj/machinery/camera{
 	dir = 8;
@@ -22879,6 +23371,10 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"ovR" = (
+/obj/effect/landmark/start/f13/farmer,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "owh" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass{
@@ -22948,6 +23444,12 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"oyZ" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "ozh" = (
 /obj/item/tank/internals/anesthetic,
 /obj/item/tank/internals/anesthetic,
@@ -22971,9 +23473,17 @@
 	},
 /area/f13/village)
 "ozI" = (
-/obj/structure/stacklifter,
+/obj/structure/fermenting_barrel{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/structure/fermenting_barrel{
+	pixel_x = 8;
+	pixel_y = -6
+	},
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+	dir = 8;
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "oAe" = (
@@ -22981,26 +23491,31 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
-"oAA" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "oAB" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"oAS" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"oAX" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
+	},
+/area/f13/wasteland)
+"oBu" = (
+/obj/structure/chair/stool/retro,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/building)
 "oBQ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0";
 	tag = "icon-verticalrightborderleft0"
-	},
-/area/f13/wasteland)
-"oCb" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0";
-	tag = "icon-verticalleftborderright0"
 	},
 /area/f13/wasteland)
 "oCg" = (
@@ -23031,12 +23546,31 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
+"oDm" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/suit/armor/f13/leatherarmor,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"oDp" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/f13/radiation)
 "oDC" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"oDR" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "mine"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oEd" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/indestructible/ground/outside/road{
@@ -23044,10 +23578,18 @@
 	},
 /area/f13/wasteland)
 "oEF" = (
-/obj/structure/musician/piano,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
+	},
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole"
+	},
+/area/f13/wasteland)
 "oEU" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -23074,13 +23616,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"oFM" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_y = -11
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "oFP" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
@@ -23104,19 +23639,10 @@
 	icon_state = "verticalrightborderleft2"
 	},
 /area/f13/wasteland)
-"oGL" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6";
-	pixel_x = -28
-	},
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/tires,
-/obj/item/flag/followers,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
+"oGE" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermaintop";
+	tag = "icon-verticalinnermaintop"
 	},
 /area/f13/wasteland)
 "oGS" = (
@@ -23148,25 +23674,29 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"oHo" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "oHu" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"oHw" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "oHK" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 6;
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
-"oHO" = (
-/obj/effect/decal/waste{
-	pixel_x = -4;
-	pixel_y = -7
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "oHR" = (
 /obj/structure/bed,
@@ -23199,6 +23729,12 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"oIF" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland)
 "oIL" = (
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23218,6 +23754,7 @@
 	},
 /area/f13/ncr)
 "oIQ" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "oIR" = (
@@ -23233,21 +23770,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"oJj" = (
-/obj/item/kitchen/knife,
-/obj/structure/dresser,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+"oJe" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "oJm" = (
-/obj/structure/chair/stool/f13stool{
-	pixel_x = -8
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/area/f13/wasteland)
 "oJp" = (
 /obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt,
@@ -23267,21 +23801,6 @@
 /obj/item/kitchen/knife/butcher,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"oJS" = (
-/obj/machinery/light/lampost{
-	dir = 1;
-	pixel_x = -32
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0";
-	tag = "icon-horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland)
-"oKf" = (
-/obj/item/candle/infinite,
-/obj/structure/table/wood,
-/turf/open/floor/carpet/airless,
-/area/f13/legion)
 "oKi" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -23290,26 +23809,27 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"oKq" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetgrey"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
 "oKy" = (
-/obj/machinery/microwave/stove,
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters button";
-	pixel_y = 32;
-	req_one_access_txt = "28"
+/obj/machinery/grill,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+/area/f13/wasteland)
 "oKA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom3"
+	},
+/area/f13/wasteland)
+"oKI" = (
+/obj/effect/landmark/start/f13/dendoc,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
+"oLv" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain2bottom";
+	tag = "icon-verticaloutermain2bottom"
 	},
 /area/f13/wasteland)
 "oLL" = (
@@ -23318,10 +23838,13 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"oLV" = (
-/mob/living/simple_animal/hostile/raider/biker,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+"oLT" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (WEST)"
+	},
+/area/f13/wasteland)
 "oLY" = (
 /obj/structure/chair/wood/worn{
 	dir = 4
@@ -23336,12 +23859,26 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
+"oMj" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "oMn" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"oMA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/settler,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "oMC" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -23354,11 +23891,14 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"oMR" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+"oMP" = (
+/obj/structure/bus_door,
+/turf/open/indestructible/ground/outside/road{
+	dir = 4;
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter (EAST)"
+	},
+/area/f13/wasteland)
 "oMY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
@@ -23401,27 +23941,23 @@
 /obj/item/clothing/head/helmet/f13/raidercombathelmet,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"oOk" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/clothing/head/hardhat,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+"oOG" = (
+/obj/machinery/sleeper{
+	density = 1;
+	dir = 4
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "oON" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "oOZ" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+/obj/structure/closet/crate/trashcart{
+	name = "corpse cart"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "oPB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23430,17 +23966,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"oPJ" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/turf/open/floor/plasteel/dark,
-/area/f13/building)
 "oPO" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop3"
 	},
 /area/f13/wasteland)
+"oPR" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/storage/backpack/satchel/leather,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "oPZ" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -23460,23 +24001,50 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"oQq" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "oQv" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "oQM" = (
 /obj/structure/table/booth,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"oQR" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner (NORTH)"
+	},
+/area/f13/wasteland)
 "oRq" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
+"oRr" = (
+/obj/structure/simple_door/wood,
+/obj/item/lock{
+	id = 2;
+	name = "wasteland jail"
+	},
+/turf/open/floor/plating,
+/area/f13/radiation)
+"oRz" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTHEAST)"
 	},
 /area/f13/wasteland)
 "oRE" = (
@@ -23488,6 +24056,12 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/village)
+"oRQ" = (
+/obj/effect/decal/riverbank{
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/wasteland)
 "oRS" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -23550,44 +24124,37 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
-"oSX" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0";
-	tag = "icon-horizontaloutermain0"
-	},
-/area/f13/wasteland)
-"oTj" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+"oTc" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/suit/armor/f13/raider/yankee,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oTB" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/machinery/door/poddoor/shutters{
-	id = "barshutters"
+/obj/structure/rack,
+/obj/item/shovel/spade,
+/obj/item/shovel,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/cultivator,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/obj/structure/table/wood/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "oUj" = (
-/obj/structure/chair/f13chair2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/obj/structure/closet/crate/wicker,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "oUo" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "oUy" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
+/obj/effect/landmark/start/f13/settler,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
 "oUI" = (
@@ -23596,40 +24163,16 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"oUO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "oUR" = (
-/obj/effect/landmark/start/f13/shopkeeper,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "oUV" = (
 /obj/machinery/mineral/wasteland_vendor/special,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
-"oUY" = (
-/obj/structure/closet,
-/obj/item/door_key{
-	id = 2;
-	name = "wasteland jail key"
-	},
-/turf/open/floor/plating,
-/area/f13/radiation)
-"oVa" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outermaincornerinner";
-	tag = "icon-outermaincornerinner (NORTH)"
-	},
-/area/f13/wasteland)
 "oVb" = (
 /obj/structure/simple_door/metal/fence{
 	door_type = "fence_wood";
@@ -23662,12 +24205,25 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"oVF" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "oVH" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"oVV" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plating,
+/area/f13/radiation)
 "oVZ" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light/small{
@@ -23676,6 +24232,13 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"oWn" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "oWv" = (
@@ -23695,22 +24258,23 @@
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"oWU" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/building)
 "oXd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
+/obj/structure/rack,
+/obj/item/seeds/chili,
+/obj/item/seeds/coffee,
+/obj/item/seeds/tea,
+/obj/item/seeds/xander,
+/obj/item/seeds/grass,
+/obj/item/seeds/grass,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/wheat/rice,
+/obj/item/seeds/cotton,
+/obj/item/seeds/grass,
+/obj/item/seeds/wheat,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "oXe" = (
 /obj/structure/rack,
@@ -23731,51 +24295,34 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"oXp" = (
-/obj/structure/statue/sandstone/mars,
-/turf/open/floor/carpet/airless,
-/area/f13/legion)
-"oXA" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+"oXK" = (
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench";
+	tag = "icon-bench (EAST)"
 	},
-/area/f13/building)
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "oXV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6";
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/destructible/tribal_torch,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "oYb" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/caves)
-"oYd" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"oYh" = (
-/obj/structure/closet,
-/obj/item/storage/backpack/satchel/leather,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/building)
+"oYu" = (
+/obj/structure/simple_door/tent,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "oYI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/workbench,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/lamp_post/quadra,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright2bottom"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/area/f13/wasteland)
 "oYS" = (
 /obj/machinery/jukebox,
 /turf/open/floor/wood/f13/carpet,
@@ -23785,6 +24332,10 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/tunnel)
+"oZf" = (
+/obj/structure/statue/sandstone/mars,
+/turf/open/floor/carpet/airless,
+/area/f13/legion)
 "oZg" = (
 /mob/living/simple_animal/chick,
 /turf/open/indestructible/ground/inside/mountain,
@@ -23795,6 +24346,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
+"oZC" = (
+/obj/structure/legion_extractor,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "par" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -23812,30 +24367,21 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"paY" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermaintop"
-	},
-/area/f13/wasteland)
 "pbg" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/jet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"pbj" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
+"pbr" = (
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"pbu" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop3";
+	tag = "icon-horizontalbottombordertop3"
 	},
 /area/f13/wasteland)
-"pbr" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood,
-/area/f13/building)
 "pbX" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
@@ -23851,10 +24397,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"pck" = (
-/obj/structure/chair/wood,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "pcm" = (
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23862,14 +24404,31 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"pcv" = (
+/obj/structure/table,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "pcG" = (
 /turf/closed/wall/f13/store,
 /area/f13/village)
 "pcP" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 9
-	},
+/obj/machinery/biogenerator,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"pcT" = (
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 12
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "pcV" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -23888,6 +24447,12 @@
 "pdx" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/caves)
+"pdE" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "pea" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -23896,6 +24461,12 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"pei" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "shadowright";
+	tag = "icon-shadowright"
+	},
 /area/f13/wasteland)
 "pek" = (
 /obj/structure/closet/cabinet,
@@ -23912,16 +24483,19 @@
 "peu" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"pey" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "peG" = (
 /obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"peH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken3,
-/area/f13/legion)
 "peX" = (
 /obj/structure/mirror,
 /turf/closed/wall/f13/wood,
@@ -23937,19 +24511,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"pfc" = (
-/obj/structure/chair/stool{
-	dir = 8;
-	icon_state = "bench";
-	tag = "icon-bench (WEST)"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "pfd" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/dirt{
@@ -24012,6 +24573,22 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"pgR" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
+"pgV" = (
+/obj/structure/table,
+/obj/item/storage/belt/medical,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "phu" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -24034,15 +24611,6 @@
 /obj/structure/rack,
 /obj/item/reagent_containers/syringe/medx,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"phF" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
 /area/f13/building)
 "pig" = (
 /obj/structure/chair/bench,
@@ -24077,14 +24645,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"pjn" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner";
-	tag = "icon-dirtcorner (EAST)"
-	},
-/area/f13/wasteland)
 "pjD" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -24093,11 +24653,11 @@
 	},
 /area/f13/building)
 "pjQ" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/chapel{
-	dir = 5
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "pjS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -24131,24 +24691,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"plH" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"pme" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/syringe/medx,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "pmg" = (
 /obj/structure/weightlifter,
 /turf/open/floor/f13/wood,
@@ -24159,6 +24701,14 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"pmM" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "pne" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13{
@@ -24178,11 +24728,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "pnw" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/chapel{
-	dir = 1
+/obj/structure/wreck/trash/five_tires,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "pnz" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -24197,15 +24747,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"pnB" = (
-/obj/machinery/trading_machine/medical,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
 "pok" = (
 /obj/structure/rack,
 /obj/item/seeds/xander,
@@ -24281,12 +24822,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
-"ppN" = (
-/obj/machinery/mineral/processing_unit_console{
-	machinedir = 1
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/building)
 "pqa" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -24324,6 +24859,31 @@
 /obj/item/ammo_casing/c10mm/ap,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
+"pqP" = (
+/obj/structure/noticeboard,
+/turf/closed/wall/f13/wood,
+/area/f13/building)
+"prs" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_y = 12
+	},
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 5
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
 "prw" = (
@@ -24388,6 +24948,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
+"pso" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken,
+/area/f13/legion)
 "psz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -24399,12 +24963,16 @@
 	},
 /area/f13/ncr)
 "psR" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "clinicladder"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/car/bike{
+	pixel_x = -12;
+	pixel_y = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "psT" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/road{
@@ -24426,10 +24994,21 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ptt" = (
-/obj/structure/table/wood/fancy,
-/obj/item/candle,
-/turf/open/floor/holofloor/carpet,
+"pth" = (
+/obj/machinery/light/small,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
+"ptq" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
 /area/f13/building)
 "ptP" = (
 /obj/structure/tires/two,
@@ -24438,25 +25017,22 @@
 "pud" = (
 /turf/closed/wall/f13/wood,
 /area/f13/clinic)
-"puN" = (
-/obj/item/trash/sosjerky{
-	pixel_x = -6
+"puP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "clinicoutsideladder"
 	},
-/obj/item/trash/sosjerky{
-	pixel_x = 1;
-	pixel_y = 10
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
-/obj/item/trash/sosjerky{
-	icon_state = "dr_gibb";
-	pixel_x = 4;
-	pixel_y = -3;
-	tag = "icon-dr_gibb"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/area/f13/wasteland)
 "puX" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 4
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "pvn" = (
@@ -24477,12 +25053,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pvP" = (
-/obj/item/poster/random_contraband,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"pvS" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/rack,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/storage/bag/plants,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	tag = "icon-dirt"
+	},
 /area/f13/wasteland)
 "pwc" = (
 /obj/structure/table,
@@ -24511,17 +25091,6 @@
 /obj/item/hatchet,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
-"pxs" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/structure/fence{
-	dir = 1;
-	pixel_x = -18
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "pxw" = (
 /obj/structure/fence/pole_b,
 /obj/structure/table/wood/settler,
@@ -24540,13 +25109,12 @@
 	},
 /area/f13/building)
 "pya" = (
-/obj/structure/simple_door/house{
-	icon_state = "glass";
-	tag = "icon-glass"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/structure/table/wood,
+/obj/item/kitchen/knife,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "pye" = (
@@ -24560,10 +25128,6 @@
 	dir = 1;
 	icon_state = "outerpavementcorner"
 	},
-/area/f13/wasteland)
-"pyj" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "pyk" = (
 /obj/item/radio/intercom{
@@ -24582,19 +25146,6 @@
 	icon_state = "bench"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"pyM" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
-/obj/structure/tires/five{
-	pixel_x = -19;
-	pixel_y = -3
-	},
-/obj/machinery/light/sign/oasis_sign,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
 /area/f13/wasteland)
 "pyX" = (
 /obj/structure/chair/booth{
@@ -24617,32 +25168,32 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"pzm" = (
+/obj/structure/sink{
+	pixel_y = 18
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "pzJ" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/relaxedwear,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"pzQ" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
+"pzN" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_y = -11
+	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"pzV" = (
-/obj/structure/closet/cabinet,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "pAc" = (
 /obj/item/clothing/head/helmet/f13/motorcycle,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
-"pAd" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "pAg" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/fakelattice{
@@ -24697,11 +25248,15 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
 "pCf" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/effect/decal/riverbank{
+	dir = 1
 	},
+/turf/open/water,
+/area/f13/wasteland)
+"pCi" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "pCy" = (
 /obj/structure/flora/grass/wasteland{
@@ -24710,23 +25265,39 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"pDH" = (
-/obj/structure/toilet,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/clinic)
+"pDd" = (
+/obj/structure/simple_door/tentflap_cloth,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "pDR" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"pDX" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/chapel{
+	dir = 10
+	},
+/area/f13/building)
 "pEk" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
 	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
+"pEs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
 "pEt" = (
@@ -24774,42 +25345,37 @@
 /obj/structure/decoration/rag,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"pFS" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/attachments,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"pFZ" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft3";
-	tag = "icon-verticalleftborderleft3"
+"pGa" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0";
+	tag = "icon-verticalleftborderright0"
 	},
 /area/f13/wasteland)
+"pHc" = (
+/obj/structure/window/fulltile/wood,
+/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "pHh" = (
 /obj/structure/sign/poster/prewar/poster94,
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
 "pHi" = (
-/obj/machinery/mineral/stacking_machine{
-	input_dir = 1;
-	output_dir = 2
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Sheriff Office";
+	req_one_access_txt = "62"
 	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pHm" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetgrey";
-	tag = "icon-sheetgrey"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "pHx" = (
@@ -24828,6 +25394,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"pHJ" = (
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/clinic)
 "pHP" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/f13{
@@ -24865,25 +25436,14 @@
 "pIz" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
-"pIB" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt";
-	tag = "icon-dirt (WEST)"
-	},
-/area/f13/building)
-"pIK" = (
-/obj/structure/table/wood,
+"pIC" = (
+/obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"pIN" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0";
-	tag = "icon-verticalleftborderright0"
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "pIO" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -24905,23 +25465,23 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"pJq" = (
-/obj/machinery/light/small{
-	dir = 1
+"pJt" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
 	},
-/turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/wasteland)
+"pJJ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pJQ" = (
 /obj/structure/simple_door/wood,
 /obj/structure/decoration/rag,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"pJR" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner";
-	tag = "icon-dirtcorner"
-	},
-/area/f13/wasteland)
 "pJT" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24937,10 +25497,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"pKm" = (
-/obj/structure/wreck/trash/five_tires,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "pKq" = (
 /obj/structure/necropolis_gate{
 	desc = "A massive stone gateway with a very heavy stone door.";
@@ -24949,11 +25505,18 @@
 /obj/structure/stone_tile/slab/burnt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"pKP" = (
-/obj/structure/bus_door,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
+"pKF" = (
+/obj/structure/barricade/tentclothcorner,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
 	},
+/area/f13/building)
+"pKP" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_2"
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pKY" = (
 /obj/structure/tires/half,
@@ -24995,12 +25558,12 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "pMf" = (
-/obj/structure/simple_door/house,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/reagent_dispensers/barrel/old,
+/obj/effect/decal/waste{
+	icon_state = "goo5"
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "pMh" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
@@ -25021,13 +25584,10 @@
 "pMI" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland)
-"pNj" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottomright";
-	tag = "icon-horizontalbottomborderbottomright"
-	},
-/area/f13/wasteland)
+"pNk" = (
+/obj/structure/chair/stool/retro,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "pNw" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -25042,12 +25602,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
-"pNN" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "pNP" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25063,12 +25617,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
-"pNY" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom2";
-	tag = "icon-horizontalbottomborderbottom2"
-	},
-/area/f13/wasteland)
 "pOb" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -25076,8 +25624,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"pOe" = (
+/obj/structure/bed,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "pOo" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/structure/fence/wooden{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "pOw" = (
 /obj/machinery/iv_drip,
@@ -25094,6 +25649,18 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"pOL" = (
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
@@ -25121,15 +25688,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"pQF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "pQL" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -25191,14 +25749,6 @@
 	},
 /area/f13/ncr)
 "pSk" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "133"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "clinicfrontdoor";
-	name = "clinic shutters"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pSn" = (
@@ -25208,21 +25758,20 @@
 	},
 /area/f13/wasteland)
 "pSo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/retro/backed{
-	dir = 8
+/obj/structure/simple_door/metal/fence{
+	door_type = "fence_wood";
+	icon_state = "fence_wood"
 	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "pSp" = (
 /obj/structure/table/wood,
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"pSt" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "pSu" = (
 /obj/structure/closet{
 	pixel_y = 10
@@ -25231,11 +25780,15 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "pSC" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 8
+/obj/structure/fence/corner/wooden{
+	dir = 1
 	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/fence/corner/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "pSE" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -25277,12 +25830,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"pUi" = (
-/obj/effect/decal/riverbank{
-	dir = 1
-	},
-/turf/open/water,
-/area/f13/wasteland)
 "pUo" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
@@ -25294,6 +25841,17 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"pUx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "pUA" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -25304,16 +25862,38 @@
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"pUE" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
+"pVl" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
+"pVp" = (
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "pVF" = (
 /obj/machinery/light,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"pVI" = (
-/obj/structure/bed/dogbed,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "pVT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -25348,12 +25928,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
-"pWw" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2";
-	tag = "icon-verticalleftborderleft2"
-	},
-/area/f13/wasteland)
 "pWx" = (
 /obj/structure/table/wood,
 /obj/item/pickaxe,
@@ -25403,30 +25977,10 @@
 /obj/item/reagent_containers/pill/patch/jet,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
-"pYb" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "pYj" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"pYF" = (
-/obj/structure/simple_door/house{
-	icon_state = "interior";
-	tag = "icon-interior"
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/city)
 "pYH" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -25479,8 +26033,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "qbe" = (
-/turf/open/floor/wood/f13/oakbroken,
-/area/f13/building)
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/obj/structure/fence/corner/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "qbl" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25488,12 +26049,16 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
-"qbA" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	tag = "icon-housewindow"
+"qbq" = (
+/obj/structure/table,
+/obj/item/kitchen/knife,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "qbB" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25503,6 +26068,13 @@
 "qbD" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
+"qbL" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
+	},
+/area/f13/building)
 "qbP" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -25524,33 +26096,34 @@
 /obj/effect/decal/marking,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
-"qcq" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/city)
 "qcz" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
-"qcS" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_north"
-	},
-/turf/open/floor/wood/f13/oak,
+"qcL" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/f13/wood,
 /area/f13/building)
-"qcT" = (
-/obj/structure/barricade/tentclothedge,
+"qcS" = (
+/obj/structure/fence/wooden{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
+	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/building)
+/area/f13/wasteland)
+"qcT" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "qcV" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -25610,16 +26183,35 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"qeh" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+"qed" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters{
+	id = "frontgateshut";
+	name = "gate shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"qer" = (
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qeM" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2"
 	},
 /area/f13/wasteland)
+"qfa" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre";
+	req_access_txt = "";
+	req_one_access_txt = ""
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "qfh" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -25632,6 +26224,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
+"qfp" = (
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 5
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/building)
+"qfG" = (
+/obj/structure/simple_door/room,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/clinic)
 "qfV" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
@@ -25684,25 +26288,21 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "qhs" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+/obj/machinery/button/door{
+	id = "interiorgate";
+	name = "Interior door button";
+	pixel_x = 6;
+	pixel_y = 32
 	},
-/area/f13/city)
-"qhD" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"qhE" = (
-/obj/structure/simple_door/tentflap_cloth,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
-"qie" = (
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "frontgateshut";
+	name = "gate shutters";
+	pixel_x = -5;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "qij" = (
 /turf/open/floor/f13/wood,
@@ -25723,10 +26323,27 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"qiJ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/stock_parts/cell,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "qiN" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/wood,
 /area/f13/village)
+"qiU" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2";
+	tag = "icon-verticalleftborderleft2"
+	},
+/area/f13/wasteland)
 "qiV" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13/wood,
@@ -25737,6 +26354,11 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"qjj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "qjm" = (
 /obj/structure/fence{
 	dir = 4
@@ -25760,11 +26382,17 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"qjZ" = (
-/obj/machinery/light/lampost,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0";
-	tag = "icon-verticalleftborderleft0"
+"qjF" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"qjV" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "qka" = (
@@ -25781,15 +26409,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"qkB" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
 "qkO" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25813,17 +26432,24 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
-"qlE" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "qlW" = (
 /obj/structure/decoration/rag,
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"qlX" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
+"qmc" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "qmk" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -25832,6 +26458,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"qmp" = (
+/obj/effect/decal/riverbank,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "qmy" = (
 /obj/structure/closet,
 /obj/item/storage/backpack/satchel/leather,
@@ -25840,6 +26470,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"qmJ" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "qmP" = (
 /obj/structure/toilet{
 	dir = 8
@@ -25877,15 +26513,6 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
-"qob" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/legion)
 "qod" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -25896,11 +26523,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "qoj" = (
-/obj/structure/table,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
+/obj/structure/window/fulltile/wood,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/structure/fence{
+	dir = 1;
+	pixel_x = -18
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "qop" = (
@@ -25914,34 +26544,35 @@
 	},
 /area/f13/village)
 "qot" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"qov" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowvertical";
-	tag = "icon-housewindowvertical"
+/obj/structure/simple_door/metal/fence{
+	door_type = "fence_wood";
+	icon_state = "fence_wood"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"qoJ" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom2left";
-	tag = "icon-horizontalbottomborderbottom2left"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "qoS" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft1"
 	},
 /area/f13/wasteland)
-"qpx" = (
+"qpJ" = (
+/obj/item/clothing/suit/f13/duster,
+/obj/item/clothing/suit/f13/autumn,
+/obj/item/clothing/gloves/f13/leather,
+/obj/item/clothing/head/f13/cowboy,
+/obj/item/clothing/under/f13/cowboyb,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/obj/item/clothing/head/collectable/police/cos{
+	name = "Chief of Police Hat"
+	},
+/obj/item/clothing/suit/armor/vest/leather,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/glasses/orange,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken4,
-/area/f13/legion)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qpM" = (
 /obj/machinery/mineral/wasteland_vendor/general,
 /turf/open/indestructible/ground/outside/desert,
@@ -25957,6 +26588,31 @@
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"qqQ" = (
+/obj/structure/sign/poster/prewar/poster61{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"qre" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
+"qrw" = (
+/obj/effect/landmark/start/f13/sheriff,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"qrJ" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottomleft";
+	tag = "icon-horizontalbottomborderbottomleft"
+	},
+/area/f13/wasteland)
 "qrL" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light/small{
@@ -25992,12 +26648,13 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qsS" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+"qsL" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "qsX" = (
@@ -26015,10 +26672,41 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"qul" = (
+/obj/structure/chair/office,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"quy" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "quV" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/knife/butcher,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"qvu" = (
+/obj/structure/billboard/ritas,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
+	},
+/area/f13/wasteland)
+"qvM" = (
+/obj/structure/spider/stickyweb,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
 /area/f13/building)
 "qvN" = (
 /obj/structure/barricade/wooden,
@@ -26062,27 +26750,20 @@
 "qwi" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/radiation)
-"qwn" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+"qwp" = (
+/turf/open/floor/plasteel/chapel{
+	dir = 8
 	},
 /area/f13/building)
 "qwq" = (
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "qwW" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"qxe" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "qxn" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4;
@@ -26092,6 +26773,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
+"qxu" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "qxA" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -26100,26 +26787,21 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"qxN" = (
+/obj/structure/lamp_post/quadra,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland)
 "qxO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
 	},
 /area/f13/tunnel)
 "qyj" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Sheriff Office";
-	req_one_access_txt = "62"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"qyz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_east_north"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
 "qyH" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood{
@@ -26135,13 +26817,12 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
-"qyU" = (
-/obj/structure/simple_door/house,
-/obj/structure/barricade/wooden/planks,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "qyZ" = (
 /turf/open/floor/wood/f13/stage_b,
+/area/f13/wasteland)
+"qzr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "qzt" = (
 /obj/structure/fence/corner,
@@ -26157,6 +26838,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"qzJ" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "qzL" = (
 /obj/machinery/light{
 	dir = 1
@@ -26173,10 +26863,22 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
 "qAc" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
+"qAi" = (
+/obj/structure/table,
+/obj/machinery/light/small,
+/obj/item/reagent_containers/food/drinks/flask,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/city)
 "qAA" = (
 /obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/indestructible/ground/inside/mountain,
@@ -26193,20 +26895,35 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"qAR" = (
-/obj/item/claymore/machete/training,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"qBf" = (
+"qAS" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"qBq" = (
+/obj/structure/table,
+/obj/machinery/light/fo13colored/Red{
+	bulb_colour = "#008000";
+	desc = "A lighting fixture.";
+	dir = 4;
+	light_color = "#008000";
+	name = "light tube"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Secret"
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+/obj/machinery/light/fo13colored/Red{
+	bulb_colour = "#008000";
+	desc = "A lighting fixture.";
+	dir = 4;
+	light_color = "#008000";
+	name = "light tube"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "qBu" = (
 /obj/structure/closet/crate{
 	anchored = 1;
@@ -26233,24 +26950,12 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"qCu" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1";
-	tag = "icon-horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "qCv" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"qCT" = (
-/obj/structure/closet/fridge/cannibal,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "qCX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -26262,10 +26967,6 @@
 /obj/item/clothing/head/festive,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"qDi" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "qDs" = (
 /obj/structure/chair/stool,
 /turf/open/floor/f13/wood,
@@ -26283,23 +26984,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "qDM" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/r_wall/rust,
-/area/f13/building)
-"qDS" = (
-/obj/structure/table/wood/settler,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/reagent_containers/spray/plantbgone,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/reagent_containers/spray/pestspray,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "qDV" = (
 /obj/item/trash/sosjerky{
@@ -26307,6 +26995,19 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"qDY" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/shreds{
+	pixel_x = -6;
+	pixel_y = -12
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qEb" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26320,8 +27021,10 @@
 	},
 /area/f13/wasteland)
 "qEj" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 25
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qEU" = (
@@ -26348,13 +27051,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
-"qFI" = (
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/city)
 "qFM" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/machinery/light/small/broken{
@@ -26362,6 +27058,35 @@
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"qGa" = (
+/obj/structure/chair/wood/worn{
+	dir = 4
+	},
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"qGr" = (
+/obj/structure/chair/stool,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
+"qGx" = (
+/obj/structure/bed,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/item/bedsheet{
+	icon_state = "sheetblue"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qGZ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outermaincornerinner"
@@ -26378,12 +27103,19 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"qHg" = (
-/obj/effect/decal/riverbankcorner{
-	dir = 1
+"qHn" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"qHq" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "qHu" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -26394,7 +27126,14 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "qHx" = (
-/obj/effect/landmark/start/f13/shopkeeper,
+/obj/structure/closet/cabinet,
+/obj/item/storage/backpack{
+	icon_state = "satchel"
+	},
+/obj/item/storage/backpack{
+	icon_state = "satchel"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qHL" = (
@@ -26423,26 +27162,13 @@
 	},
 /area/f13/brotherhood)
 "qHZ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/building)
+/mob/living/simple_animal/chick,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "qIa" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"qIc" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/legion)
 "qIj" = (
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
@@ -26478,14 +27204,8 @@
 	},
 /area/f13/building)
 "qIE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/ruins,
-/area/f13/building)
-"qJl" = (
-/obj/structure/lamp_post/quadra,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright2bottom"
-	},
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "qJB" = (
 /obj/structure/flora/grass/wasteland{
@@ -26498,25 +27218,25 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "qJR" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/building)
+/obj/structure/fence/wooden{
+	dir = 1
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "qJZ" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"qKz" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating,
-/area/f13/building)
-"qKL" = (
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+"qKe" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "interiorgate2"
 	},
-/area/f13/clinic)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland)
 "qKU" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -26528,6 +27248,12 @@
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"qLv" = (
+/obj/structure/simple_door/metal/fence{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "qLC" = (
 /obj/structure/simple_door/wood,
 /obj/structure/decoration/rag,
@@ -26542,29 +27268,21 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"qLT" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbrokenvertical";
-	tag = "icon-housewindowbrokenvertical (NORTHEAST)"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
-"qLX" = (
-/obj/structure/simple_door/wood,
-/obj/item/lock{
-	id = 2;
-	name = "wasteland jail"
-	},
-/turf/open/floor/plating,
-/area/f13/radiation)
+"qLU" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "qMi" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/village)
+"qMj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland)
 "qMn" = (
 /obj/structure/table,
 /obj/item/healthanalyzer,
@@ -26636,6 +27354,16 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"qOd" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
 "qOm" = (
 /obj/structure/campfire/stove,
 /turf/open/floor/f13/wood{
@@ -26701,12 +27429,15 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
-"qPk" = (
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
+"qPa" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "followersdeskshutters";
+	name = "followers shutters"
 	},
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "qPp" = (
 /obj/structure/rack,
@@ -26728,9 +27459,37 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "qPQ" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 10
+/obj/structure/table/reinforced,
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters{
+	id = "frontgateshut";
+	name = "gate shutters"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"qPS" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2";
+	tag = "icon-verticalleftborderright2"
+	},
+/area/f13/wasteland)
+"qPW" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/item/taperecorder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"qQe" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "qQf" = (
 /obj/structure/rack,
@@ -26750,17 +27509,6 @@
 	icon_state = "verticalrightborderright2"
 	},
 /area/f13/wasteland)
-"qQp" = (
-/obj/structure/spider/stickyweb,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "qQD" = (
 /obj/machinery/deepfryer,
 /obj/machinery/light/small{
@@ -26777,10 +27525,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
-"qQN" = (
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "qQQ" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -26791,6 +27535,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"qQT" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "qQW" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small/broken{
@@ -26818,6 +27571,19 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"qRz" = (
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench";
+	tag = "icon-bench (WEST)"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "qRB" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -26844,6 +27610,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"qSz" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "qSM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/bars,
@@ -26871,9 +27643,12 @@
 	},
 /area/f13/legion)
 "qTa" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 6
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Gatehouse";
+	req_one_access_txt = "62"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "qTe" = (
 /obj/structure/table,
@@ -26883,6 +27658,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"qTr" = (
+/obj/structure/chair/wood/worn{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qTt" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -26907,11 +27688,6 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
-"qTN" = (
-/obj/effect/decal/remains/human,
-/obj/item/clothing/suit/armor/f13/leatherarmor,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "qTP" = (
 /obj/effect/landmark/start/f13/Hhunter,
 /turf/open/indestructible/ground/inside/mountain,
@@ -26929,18 +27705,13 @@
 /area/f13/wasteland)
 "qUC" = (
 /obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
 /area/f13/building)
-"qUK" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical"
-	},
-/obj/structure/barricade/wooden/planks/pregame,
+"qUO" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qUZ" = (
@@ -26954,10 +27725,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"qWg" = (
-/obj/item/trash/pistachios,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "qWp" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -26965,6 +27732,15 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"qWG" = (
+/obj/structure/barricade/bars,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "frontgateshut";
+	name = "gate shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "qWQ" = (
 /obj/structure/fluff/fokoff_sign,
 /turf/open/indestructible/ground/inside/mountain,
@@ -26987,28 +27763,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"qXi" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbroken";
-	tag = "icon-housewindowbroken (NORTHEAST)"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "qXk" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"qXn" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright2";
-	tag = "icon-verticalleftborderright2"
-	},
-/area/f13/wasteland)
 "qXo" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
@@ -27016,8 +27776,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"qXr" = (
-/obj/machinery/light/small,
+"qXJ" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/flashlight{
+	icon_state = "seclite"
+	},
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
@@ -27034,13 +27798,15 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/f13/tunnel,
 /area/f13/wasteland)
+"qZI" = (
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "qZO" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/white{
-	desc = "It's a strangely clean little white rodent.";
-	name = "Algernon"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "ram" = (
 /obj/structure/barricade/wooden,
@@ -27049,15 +27815,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"raq" = (
-/obj/effect/decal/remains/human,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "ras" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -27074,15 +27831,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"rbc" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/wood/settler,
-/obj/item/kitchen/knife,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "rbe" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "hole"
@@ -27102,10 +27850,11 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "rbF" = (
-/obj/machinery/sleeper{
-	density = 1;
-	dir = 4
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "gatehouseladder"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "rbJ" = (
@@ -27117,6 +27866,18 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"rco" = (
+/obj/structure/fireplace{
+	layer = 2.1;
+	level = 1;
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/ash{
+	pixel_x = -11;
+	pixel_y = -7
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rcC" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -27126,18 +27887,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"rcL" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2right";
-	tag = "icon-horizontalinnermain2right"
-	},
-/area/f13/wasteland)
-"rcP" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left";
-	tag = "icon-horizontaloutermain2left"
-	},
-/area/f13/wasteland)
 "rcS" = (
 /obj/item/clothing/suit/armor/f13/metalarmor{
 	icon_state = "armorkit"
@@ -27157,10 +27906,6 @@
 /obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"rdd" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating,
-/area/f13/caves)
 "rdy" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood{
@@ -27168,7 +27913,12 @@
 	},
 /area/f13/building)
 "rdC" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/fulltile/wood{
+	layer = 3
+	},
+/obj/structure/curtain{
+	color = "#845f58"
+	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rdQ" = (
@@ -27182,6 +27932,19 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"rdW" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	termtag = "Secret"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "followersdeskshutters";
+	name = "followers shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "rec" = (
 /turf/closed/indestructible/rock,
 /area/f13/wasteland)
@@ -27198,12 +27961,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"reo" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/f13/caves)
 "rex" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -27217,18 +27974,9 @@
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
-"reU" = (
-/obj/structure/closet/crate/bin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0";
-	tag = "icon-horizontaloutermain0"
-	},
-/area/f13/wasteland)
-"rfx" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/breadhard,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+"rfE" = (
+/turf/closed/wall/f13/ruins,
+/area/f13/radiation)
 "rfP" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/barber{
@@ -27236,12 +27984,19 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"rfR" = (
-/turf/open/floor/wood/f13/oakbroken,
-/area/f13/legion)
+"rgE" = (
+/obj/structure/table/wood,
+/obj/item/instrument/guitar,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "rgI" = (
+/obj/effect/landmark/start/f13/deputy,
+/obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/poster/contraband/pinup_ride{
+	pixel_x = -32
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "rgS" = (
 /obj/structure/window/fulltile/wood,
@@ -27256,11 +28011,6 @@
 /obj/structure/rack,
 /obj/item/clothing/shoes/f13/diesel/alt,
 /obj/item/clothing/shoes/f13/diesel/alt,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"rhp" = (
-/obj/structure/closet/cabinet,
-/obj/item/dildo,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rhr" = (
@@ -27338,6 +28088,13 @@
 /obj/structure/mirror,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"rkQ" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "rkZ" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -27346,9 +28103,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"rlo" = (
-/turf/closed/wall/f13/ruins,
-/area/f13/city)
 "rls" = (
 /obj/structure/toilet,
 /obj/item/stack/f13Cash/random/ncr/low,
@@ -27371,6 +28125,15 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
+"rmy" = (
+/obj/structure/closet/crate/bin,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "rnc" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowdestroyed"
@@ -27380,6 +28143,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"rni" = (
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "rns" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -27411,12 +28180,6 @@
 /obj/structure/window/fulltile/ruins,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"roh" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
-	},
-/area/f13/wasteland)
 "rot" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -27434,25 +28197,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "rpa" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/obj/item/soap/deluxe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/effect/landmark/start/f13/deputy,
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "rpu" = (
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"rpD" = (
-/obj/structure/chair,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
 /area/f13/building)
 "rpF" = (
 /obj/effect/turf_decal/stripes/line{
@@ -27470,18 +28221,6 @@
 	icon_state = "horizontaltopbordertop2right"
 	},
 /area/f13/wasteland)
-"rqx" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "rqW" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -27493,10 +28232,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"rrk" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+"rqZ" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermaintop";
+	tag = "icon-verticaloutermaintop"
+	},
+/area/f13/wasteland)
 "rrl" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -27507,22 +28248,16 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/brotherhood)
-"rrA" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
+"rry" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "followersdeskshutters";
+	name = "followers shutters"
 	},
-/area/f13/wasteland)
-"rrB" = (
-/obj/structure/chair{
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/city)
+/area/f13/building)
 "rrC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/hatch{
@@ -27559,25 +28294,10 @@
 	},
 /turf/open/water,
 /area/f13/caves)
-"rub" = (
-/obj/item/trash/chips,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"ruj" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "ruD" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/turbo,
 /turf/open/floor/wood/f13/carpet,
-/area/f13/building)
-"ruN" = (
-/obj/structure/sign/poster/prewar/poster61{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "rvf" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -27585,22 +28305,15 @@
 	icon_state = "verticalleftborderleft2bottom"
 	},
 /area/f13/village)
-"rvx" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3"
-	},
-/obj/structure/debris/v3,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermaintop"
-	},
-/area/f13/wasteland)
-"rvP" = (
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "innermaincornerinner";
-	tag = "icon-innermaincornerinner (WEST)"
-	},
-/area/f13/wasteland)
+"rvr" = (
+/turf/open/floor/wood,
+/area/f13/building)
+"rvT" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rwv" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/mountain,
@@ -27628,14 +28341,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"rxo" = (
-/obj/structure/chair/wood/modern{
-	dir = 1;
-	tag = "icon-wooden_chair_new (NORTH)"
-	},
-/obj/machinery/light/small,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "rxt" = (
 /obj/structure/sign/poster/contraband/pinup_ride,
 /turf/closed/wall/f13/wood/house,
@@ -27644,14 +28349,11 @@
 /obj/machinery/light/small/broken,
 /turf/open/water,
 /area/f13/caves)
-"rxW" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 8
+"rym" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
-"ryc" = (
-/turf/open/floor/wood/f13/oakbroken3,
 /area/f13/building)
 "ryn" = (
 /obj/structure/table/wood/settler,
@@ -27667,6 +28369,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"ryO" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ryS" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -27685,6 +28394,17 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"rzn" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"rzu" = (
+/obj/machinery/workbench,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "rzR" = (
 /obj/machinery/light{
@@ -27709,6 +28429,29 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"rAf" = (
+/obj/structure/closet/cabinet,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/masks,
+/obj/item/lighter,
+/obj/item/clothing/suit/toggle/labcoat/f13/followers,
+/obj/item/storage/box/pillbottles,
+/obj/item/reagent_containers/syringe/medx,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"rAi" = (
+/obj/machinery/door/airlock/glass_large{
+	name = "Followers Clinic";
+	req_one_access_txt = "124"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "followershutters";
+	name = "followers shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "rAm" = (
 /obj/structure/table/wood,
 /obj/item/paper,
@@ -27765,6 +28508,15 @@
 	icon_state = "verticalrightborderleft2"
 	},
 /area/f13/wasteland)
+"rDd" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/AMinus,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rDj" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -27773,10 +28525,25 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"rDT" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2bottom";
+	tag = "icon-verticalleftborderright2bottom"
+	},
+/area/f13/wasteland)
+"rDU" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "rEc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks,
 /turf/open/floor/plating,
 /area/f13/building)
 "rEd" = (
@@ -27784,10 +28551,6 @@
 /obj/item/pda,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"rEg" = (
-/obj/item/chair/wood,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "rEi" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
@@ -27825,12 +28588,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"rFD" = (
-/obj/machinery/vending/snack,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
 "rGl" = (
 /obj/structure/chalkboard,
 /obj/machinery/light/small/broken{
@@ -27853,27 +28610,11 @@
 /obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"rGT" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing";
-	tag = "icon-glassclosing"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
-"rHA" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/building)
 "rHE" = (
-/obj/structure/chair/booth{
-	dir = 4
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/closed/wall/f13/store,
 /area/f13/building)
 "rHO" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -27885,11 +28626,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "rHT" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/decoration/rag,
+/turf/closed/wall/f13/store,
 /area/f13/building)
+"rHV" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/under/f13/legslavef,
+/obj/item/clothing/shoes/f13/rag,
+/obj/effect/landmark/start/f13/slave,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
+"rIy" = (
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "rIA" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -27899,21 +28653,38 @@
 /obj/structure/cross,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"rJB" = (
-/obj/item/ammo_casing/caseless,
-/turf/open/floor/f13/wood,
+"rJg" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/reagent_containers/medspray/sterilizine,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 25
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
 /area/f13/building)
 "rJO" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/obj/structure/table/wood,
+/obj/item/kitchen/knife,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "rJT" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
 	},
 /obj/structure/decoration/rag,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"rJU" = (
+/obj/structure/table/wood/settler,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/phone,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rKh" = (
@@ -27937,19 +28708,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"rLi" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_south"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"rLn" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerborder";
-	tag = "icon-outerborder (NORTH)"
-	},
-/area/f13/wasteland)
 "rLP" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/small{
@@ -27963,10 +28721,6 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innershade"
 	},
-/area/f13/wasteland)
-"rMd" = (
-/obj/item/shovel,
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "rMq" = (
 /obj/structure/fence/corner/wooden{
@@ -28045,28 +28799,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"rOF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/prewar/poster86{
-	pixel_y = -32
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
-"rOT" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "mine"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "rPM" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Store Backroom";
-	req_one_access_txt = "34"
-	},
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/pipe,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rPR" = (
@@ -28095,37 +28831,31 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"rQE" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_2"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "rQG" = (
-/obj/machinery/power/solar,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
-/area/f13/wasteland)
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/obj/structure/curtain,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rQI" = (
 /obj/structure/closet/crate/large,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"rQL" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "followershutters";
+	name = "followers shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "rQR" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
-"rQU" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "rRi" = (
 /obj/machinery/grill{
 	desc = "I am your captain. You are on guard duty.";
@@ -28133,6 +28863,19 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"rRl" = (
+/obj/structure/sign/poster/prewar/poster85,
+/turf/closed/wall/f13/supermart,
+/area/f13/building)
+"rRo" = (
+/obj/item/retractor,
+/obj/item/hemostat,
+/obj/item/surgicaldrill,
+/obj/item/storage/belt/medical,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rRt" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -28148,10 +28891,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"rRQ" = (
-/obj/item/storage/trash_stack,
-/turf/open/floor/plating,
-/area/f13/caves)
 "rRR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleftbottom"
@@ -28161,15 +28900,30 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"rSf" = (
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-2"
+"rSc" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"rSe" = (
+/obj/structure/spider/stickyweb,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
+"rSf" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rSq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -28201,21 +28955,16 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
-"rTM" = (
-/obj/effect/decal/remains/human,
-/obj/item/clothing/suit/armor/f13/raider/yankee,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "rTY" = (
-/obj/structure/table/wood,
-/obj/machinery/door/poddoor/shutters{
-	id = "countershutters";
-	name = "counter shutters"
+/obj/machinery/vending/cola/random,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"rUj" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertopleft";
+	tag = "icon-horizontaltopbordertopleft"
 	},
-/obj/structure/barricade/bars,
-/obj/structure/railing,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "rUp" = (
 /obj/item/kirbyplants/random{
 	pixel_y = 8
@@ -28227,16 +28976,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"rUC" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright1";
-	tag = "icon-verticalrightborderright1"
+"rVl" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
 "rVr" = (
-/obj/structure/sacrificealtar,
-/turf/open/floor/holofloor/carpet,
-/area/f13/building)
+/turf/closed/wall/f13/wood/house,
+/area/f13/city)
 "rVK" = (
 /obj/effect/landmark/poster_spawner/prewar,
 /turf/closed/wall/f13/store,
@@ -28253,19 +29002,24 @@
 "rWr" = (
 /obj/effect/landmark/latejoin,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalleftborderright0"
 	},
 /area/f13/tunnel)
-"rWL" = (
-/obj/machinery/light/small{
-	dir = 1
+"rWv" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "innermaincornerinner";
+	tag = "icon-innermaincornerinner (WEST)"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/area/f13/wasteland)
 "rWN" = (
 /obj/structure/closet/crate/bin,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"rWQ" = (
+/obj/structure/sign/poster/prewar/poster83,
+/turf/closed/wall/f13/supermart,
+/area/f13/building)
 "rXa" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13/wood{
@@ -28300,6 +29054,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"rXu" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
+	},
+/area/f13/building)
 "rXv" = (
 /obj/structure/simple_door/metal/fence{
 	door_type = "fence_wood";
@@ -28315,18 +29075,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"rYd" = (
-/obj/structure/closet/bus,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
-"rYF" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/obj/effect/spawner/lootdrop/clothing_high,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "rYS" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -28341,24 +29089,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/radiation)
-"rZx" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/f13/leatherarmor,
-/obj/item/clothing/gloves/botanic_leather,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/light/small,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
-"rZG" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/legion)
 "rZK" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt{
@@ -28369,21 +29099,26 @@
 	},
 /area/f13/ncr)
 "saf" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
+/obj/item/scalpel,
+/obj/item/cautery,
+/obj/item/razor,
+/obj/item/surgical_drapes,
+/obj/item/reagent_containers/medspray/sterilizine,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "sap" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/wood,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical";
+	tag = "icon-housewindowbrokenvertical"
 	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
 /area/f13/building)
+"saq" = (
+/turf/closed/indestructible/f13/matrix,
+/area/f13/legion)
 "say" = (
 /obj/structure/chair,
 /obj/effect/decal/remains{
@@ -28392,17 +29127,6 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
-"saz" = (
-/obj/structure/closet/crate/medical,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
 	},
 /area/f13/building)
 "saA" = (
@@ -28414,6 +29138,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"saB" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "saH" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -28423,31 +29153,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"saZ" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/knife,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
-"sbj" = (
-/obj/structure/wreck/trash/five_tires,
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outermaincornerinner";
-	tag = "icon-outermaincornerinner"
-	},
-/area/f13/wasteland)
-"sbk" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "sbD" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -28466,16 +29171,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"scr" = (
-/obj/structure/table,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/storage/pill_bottle/chem_tin/radx,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "scB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -28488,6 +29183,11 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/building)
+"scW" = (
+/obj/item/kitchen/knife,
+/obj/structure/dresser,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "scY" = (
 /obj/machinery/light/small,
@@ -28512,18 +29212,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"sdP" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/f13/wood/house/broken,
-/area/f13/building)
-"sea" = (
-/obj/structure/table,
-/obj/item/storage/belt/medical,
+"sdM" = (
+/obj/structure/rack,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
 	tag = "icon-bluerustychess2"
 	},
+/area/f13/building)
+"sdP" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood/house/broken,
 /area/f13/building)
 "sed" = (
 /obj/effect/decal/cleanable/dirt{
@@ -28533,9 +29232,23 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/ncr)
+"seg" = (
+/obj/effect/decal/riverbankcorner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "sew" = (
 /obj/machinery/light/small{
 	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"seB" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -28576,14 +29289,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"sft" = (
-/obj/structure/sink{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "sfA" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/button{
@@ -28595,12 +29300,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"sfD" = (
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+"sfB" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2";
+	tag = "icon-horizontaltopbordertop2"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "sfI" = (
 /obj/structure/rack,
 /obj/item/stock_parts/cell,
@@ -28627,6 +29332,12 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/wasteland)
+"sgd" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/f13/caves)
 "sgn" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -28638,10 +29349,13 @@
 	},
 /area/f13/brotherhood)
 "sgr" = (
-/obj/structure/chair/wood,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical";
+	tag = "icon-housewindowvertical"
 	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "sgw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28678,6 +29392,19 @@
 	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/caves)
+"shd" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
 "shf" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/metal{
@@ -28686,48 +29413,23 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"shg" = (
-/obj/structure/simple_door/fakeglass,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
-"shn" = (
-/mob/living/simple_animal/hostile/ghoul/glowing,
-/turf/open/floor/plating,
-/area/f13/radiation)
 "shp" = (
 /obj/machinery/light/broken,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"shu" = (
-/obj/structure/barricade/tentclothedge,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/building)
 "shF" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
-"shT" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
+"shU" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/area/f13/building)
-"shW" = (
-/obj/structure/table/wood,
-/obj/item/candle/infinite,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
-"sid" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "sif" = (
 /obj/structure/car/rubbish1,
@@ -28735,10 +29437,39 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"sik" = (
+/obj/item/reagent_containers/food/snacks/grown/broc,
+/obj/item/reagent_containers/food/snacks/grown/broc,
+/obj/item/reagent_containers/food/snacks/grown/broc,
+/obj/item/reagent_containers/food/snacks/grown/broc,
+/obj/item/reagent_containers/food/snacks/grown/xander,
+/obj/item/reagent_containers/food/snacks/grown/xander,
+/obj/item/reagent_containers/food/snacks/grown/xander,
+/obj/item/reagent_containers/food/snacks/grown/xander,
+/obj/structure/closet/fridge{
+	desc = "An old pre-war fridge. This one is proudly labeled as lead-lined"
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sim" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"sio" = (
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"siu" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
+	},
+/area/f13/building)
 "siE" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -28793,10 +29524,13 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"sjy" = (
-/obj/structure/chair,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+"sjA" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (NORTH)"
+	},
+/area/f13/wasteland)
 "sjX" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light/small{
@@ -28825,22 +29559,8 @@
 	},
 /area/f13/building)
 "sln" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"slq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/mob/living/simple_animal/hostile/gecko,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "slr" = (
 /obj/structure/chair/wood/modern,
@@ -28865,31 +29585,40 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"slQ" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "busladder"
+"slM" = (
+/obj/effect/decal/remains{
+	icon_state = "remains";
+	tag = "icon-remains"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
+/obj/structure/chair/wood/worn{
+	dir = 1
 	},
-/area/f13/wasteland)
-"slT" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
-"slU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/supermart,
+"slT" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical";
+	tag = "icon-housewindowvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "sme" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"smh" = (
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/obj/structure/closet/cabinet,
+/obj/item/gun/ballistic/automatic/pistol/m1911,
+/obj/item/ammo_box/magazine/m45,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "smi" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -28902,13 +29631,6 @@
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"smp" = (
-/obj/structure/simple_door/metal/fence{
-	door_type = "fence_wood";
-	icon_state = "fence_wood"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "smw" = (
 /obj/structure/chair/wood/fancy{
 	dir = 8
@@ -28936,13 +29658,8 @@
 	},
 /area/f13/ncr)
 "snA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6";
-	pixel_x = -28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/structure/bed/dogbed,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "snB" = (
 /turf/open/indestructible/ground/outside/road{
@@ -28979,6 +29696,13 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"snQ" = (
+/obj/structure/closet/cabinet,
+/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/syringe/medx,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "snR" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -29002,18 +29726,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plating/tunnel,
 /area/f13/village)
-"soE" = (
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"soK" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
-	},
-/area/f13/wasteland)
 "soY" = (
 /obj/structure/fence{
 	dir = 4
@@ -29024,29 +29736,6 @@
 /obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/building)
-"sph" = (
-/obj/structure/table/wood,
-/obj/item/clothing/mask/cigarette/pipe,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"spi" = (
-/obj/structure/fluff/broken_flooring,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/building)
-"spt" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbrokenvertical";
-	tag = "icon-housewindowbrokenvertical"
-	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "spx" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -29055,16 +29744,9 @@
 /turf/closed/wall/f13/wood,
 /area/f13/village)
 "spC" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbroken";
-	tag = "icon-housewindowbroken"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
+/obj/structure/chair/wood,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "spL" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -29109,31 +29791,42 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
-"srt" = (
-/obj/effect/decal/marking{
-	icon_state = "doublehorizontal"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/wasteland)
 "srw" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "srM" = (
-/obj/structure/window/fulltile/house,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood,
 /area/f13/building)
+"srS" = (
+/obj/item/clothing/under/f13/tribal,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ssm" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
 	icon_state = "outermaincornerouter"
 	},
 /area/f13/wasteland)
+"ssC" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical";
+	tag = "icon-housewindowvertical (NORTHEAST)"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"ste" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "stg" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/farm)
@@ -29159,15 +29852,18 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
-"stK" = (
-/turf/closed/wall/f13/wood/house,
-/area/f13/city)
 "suo" = (
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
+"suq" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housebase";
+	tag = "icon-housebase"
+	},
+/area/f13/building)
 "suw" = (
 /obj/item/paper_bin{
 	pixel_y = 6
@@ -29212,6 +29908,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"svJ" = (
+/obj/structure/flora/wasteplant/wild_broc,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "svP" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -29224,6 +29924,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"swe" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"swi" = (
+/obj/structure/flora/wasteplant/wild_feracactus,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "swx" = (
 /obj/item/mining_scanner,
 /turf/open/indestructible/ground/outside/dirt,
@@ -29252,42 +29960,30 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"swU" = (
+/turf/closed/wall/rust,
+/area/f13/building)
 "sxs" = (
-/obj/structure/simple_door/house{
-	icon_state = "interioropening";
-	tag = "icon-interioropening"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
-"sxy" = (
-/obj/structure/barricade/tentclothedge,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
-	},
-/area/f13/building)
+/obj/structure/flora/wasteplant/wild_fungus,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "sxP" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
-"sxT" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+"syq" = (
+/obj/structure/chair/office/dark{
+	dir = 4;
+	icon_state = "officechair_dark"
 	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "syr" = (
 /obj/effect/decal/riverbank{
 	dir = 9
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/caves)
 "syA" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/small/broken{
@@ -29308,6 +30004,10 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"szn" = (
+/obj/structure/table/wood/bar,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "szy" = (
 /obj/structure/fence{
 	dir = 4
@@ -29333,11 +30033,6 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"szQ" = (
-/obj/item/clothing/head/helmet/f13/rustedcowboyhat,
-/obj/item/clothing/suit/armor/f13/rustedcowboy,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "szS" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/mop,
@@ -29358,6 +30053,11 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"sAL" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sAM" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt,
@@ -29385,12 +30085,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sBQ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/item/ammo_casing/caseless,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "sBR" = (
 /obj/structure/chair/stool/bar,
@@ -29427,9 +30123,13 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "sCF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/decoration/clock{
+	pixel_y = 21
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/building)
 "sCK" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -29444,39 +30144,36 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
-"sDi" = (
-/turf/open/floor/wood/f13/oakbroken2,
-/area/f13/building)
 "sDj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/chair,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "sDp" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sDr" = (
-/obj/structure/window/fulltile/wood{
-	layer = 3
-	},
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood,
 /area/f13/building)
-"sDJ" = (
-/obj/machinery/light/small{
-	dir = 1
+"sDO" = (
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gibleg"
 	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
 	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"sEn" = (
+/mob/living/simple_animal/hostile/gecko,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "sEB" = (
 /obj/structure/sink{
 	dir = 1;
@@ -29491,6 +30188,14 @@
 "sED" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood/house,
+/area/f13/building)
+"sFy" = (
+/obj/structure/table/wood,
+/obj/item/trash/waffles,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
 /area/f13/building)
 "sGm" = (
 /obj/structure/fence{
@@ -29525,12 +30230,9 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"sHM" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outermaincornerinner";
-	tag = "icon-outermaincornerinner (EAST)"
-	},
+"sIa" = (
+/obj/item/clothing/gloves/botanic_leather,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "sIf" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -29595,25 +30297,17 @@
 /obj/structure/sign/poster/contraband/pinup_shower,
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
-"sKG" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
+"sKp" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "shadowleft";
+	tag = "icon-shadowleft"
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "sKH" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
-"sKX" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "sLi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hydroponics/constructable,
@@ -29655,6 +30349,14 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"sLK" = (
+/obj/structure/table/wood,
+/obj/item/trash/candle,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "sLV" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/decal/cleanable/blood/old,
@@ -29666,6 +30368,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"sMz" = (
+/obj/structure/flora/wasteplant/wild_xander,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "sMP" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/recharger,
@@ -29701,22 +30407,11 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"sNE" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
 "sNM" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "interiorgate2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/obj/structure/table/wood/bar,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sNT" = (
 /obj/structure/chair{
 	dir = 4
@@ -29726,18 +30421,10 @@
 	},
 /area/f13/village)
 "sOD" = (
-/obj/structure/fence/corner,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleftbottom"
-	},
-/area/f13/wasteland)
-"sOS" = (
-/obj/structure/flora/tree/tall,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sPu" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/road,
@@ -29766,11 +30453,12 @@
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
 "sPJ" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1";
-	tag = "icon-verticalinnermain1"
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical";
+	tag = "icon-housewindowvertical (NORTHEAST)"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sPK" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -29781,18 +30469,43 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"sPS" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plating,
-/area/f13/radiation)
-"sQo" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
+"sQj" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"sQl" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/obj/item/pen{
+	pixel_y = 9
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
+"sQo" = (
+/obj/structure/chair{
+	dir = 4;
+	tag = "icon-chair (EAST)"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/clothing/under/pants/f13/ghoul,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"sQs" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "sQv" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29800,15 +30513,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
 "sQC" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/obj/machinery/computer/terminal{
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sQX" = (
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
@@ -29824,10 +30537,6 @@
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"sRJ" = (
-/obj/machinery/workbench,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "sRV" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light,
@@ -29836,10 +30545,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"sSc" = (
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+"sSr" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
+	},
+/area/f13/building)
 "sSt" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/f13/wood,
@@ -29856,34 +30568,16 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/wasteland)
-"sTe" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 5
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/building)
 "sTk" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/clothing_low,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"sTm" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2";
-	tag = "icon-verticalleftborderleft2"
-	},
-/area/f13/wasteland)
 "sTv" = (
 /obj/structure/closet/bus,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"sTw" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
-	},
-/area/f13/tunnel)
 "sTC" = (
 /obj/effect/landmark/latejoin,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -29896,13 +30590,25 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "sUd" = (
-/obj/machinery/trading_machine,
-/turf/open/floor/f13/wood,
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
 /area/f13/building)
 "sUf" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"sUi" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "sUl" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -29912,6 +30618,13 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"sUo" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "sUq" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -29924,13 +30637,6 @@
 	tag = "icon-horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"sUu" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
 "sUv" = (
 /obj/structure/fence/corner{
 	dir = 4;
@@ -29948,15 +30654,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"sUT" = (
-/obj/structure/chair/wood/modern{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "sUX" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 9;
@@ -29981,11 +30678,6 @@
 "sVl" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
-"sVs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/ruins,
-/area/f13/building)
 "sVD" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
@@ -30016,10 +30708,6 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"sWy" = (
-/obj/structure/chair/stool/retro/tan,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "sWz" = (
 /obj/machinery/door/unpowered/wooddoor{
 	name = "Sergeant"
@@ -30043,6 +30731,12 @@
 "sWI" = (
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
+"sWK" = (
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "sWR" = (
 /obj/structure/chair{
 	dir = 8
@@ -30056,15 +30750,13 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"sXG" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/vomit,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+"sXy" = (
+/obj/item/ammo_casing/caseless{
+	dir = 10;
+	icon_state = "sS-casing";
+	tag = "icon-sS-casing (SOUTHWEST)"
 	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "sXJ" = (
 /obj/structure/fluff/rails{
@@ -30072,6 +30764,12 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"sXN" = (
+/obj/item/ammo_casing/caseless,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "sYe" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light{
@@ -30088,13 +30786,6 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"sYw" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "sYF" = (
 /obj/machinery/light{
 	dir = 1
@@ -30120,18 +30811,6 @@
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"sZD" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2";
-	tag = "icon-horizontaltopborderbottom2"
-	},
-/area/f13/wasteland)
-"sZF" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outermaincornerouter";
-	tag = "icon-outermaincornerouter"
-	},
-/area/f13/wasteland)
 "sZQ" = (
 /obj/structure/fence/wooden{
 	dir = 1;
@@ -30152,26 +30831,21 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"tag" = (
-/obj/structure/table/wood,
-/obj/item/grown/sunflower{
-	desc = "A solis ortu usque ad occasum";
-	name = "Helianthus"
-	},
-/turf/open/floor/carpet/airless,
-/area/f13/legion)
 "tak" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innershade"
 	},
 /area/f13/wasteland)
-"tav" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "shadowleft";
-	tag = "icon-shadowleft"
+"tar" = (
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/wasteland)
+/area/f13/city)
+"tat" = (
+/obj/structure/simple_door/tentflap_cloth,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "taF" = (
 /obj/structure/fence{
 	dir = 4
@@ -30180,15 +30854,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
-"taG" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/auto,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+"taL" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4"
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "taN" = (
 /obj/structure/chair/comfy{
 	dir = 4
@@ -30273,19 +30947,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"tdu" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"tdv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "tdC" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -30315,12 +30976,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"tfc" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+"tfn" = (
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "tfz" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/rank/medical/doctor/purple,
@@ -30386,26 +31048,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"thc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "barwindowshutters";
-	name = "bar window shutters button";
-	pixel_x = 6;
-	pixel_y = -32;
-	req_one_access_txt = "28"
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters button";
-	pixel_x = -6;
-	pixel_y = -32;
-	req_one_access_txt = "28"
-	},
-/obj/machinery/light/small,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
 "thG" = (
 /obj/structure/fence{
 	dir = 4
@@ -30426,13 +31068,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
-"thR" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner";
-	tag = "icon-dirtcorner (WEST)"
-	},
-/area/f13/wasteland)
 "thW" = (
 /obj/machinery/light{
 	dir = 4
@@ -30458,23 +31093,49 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"tit" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/assembly/igniter,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tiu" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tjd" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical";
-	tag = "icon-housewindowvertical (NORTHEAST)"
+"tja" = (
+/obj/structure/sink{
+	pixel_y = 15
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
+"tjy" = (
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontal"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "tjB" = (
 /obj/item/ammo_casing/a50MG,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland)
+"tjI" = (
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalright"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
 "tjQ" = (
@@ -30498,12 +31159,6 @@
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
-"tkF" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "tkO" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13{
@@ -30525,21 +31180,6 @@
 /obj/item/paper,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
-"tkZ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
-"tlg" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
 	},
 /area/f13/building)
 "tlj" = (
@@ -30601,18 +31241,27 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"tmm" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+"tma" = (
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/area/f13/clinic)
-"tmp" = (
-/mob/living/simple_animal/hostile/radroach,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
+"tmh" = (
+/obj/machinery/shower{
+	dir = 4;
+	tag = "icon-shower (EAST)"
+	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "tmH" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/indestructible/ground/inside/mountain,
@@ -30631,6 +31280,11 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"tor" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "toy" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/desert,
@@ -30703,30 +31357,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
-"tqi" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+"tpN" = (
+/obj/item/ammo_casing/caseless{
+	dir = 4;
+	icon_state = "sS-casing";
+	tag = "icon-sS-casing (EAST)"
 	},
-/area/f13/building)
-"tqs" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "tqu" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"tqG" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "tqN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -30763,13 +31405,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"trJ" = (
-/obj/structure/tires/five,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2bottom";
-	tag = "icon-verticalleftborderleft2bottom"
-	},
-/area/f13/wasteland)
 "trW" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3"
@@ -30792,27 +31427,28 @@
 /obj/machinery/vending/medical,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"tsF" = (
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tsH" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"tsS" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "tsT" = (
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
-"tsW" = (
-/obj/structure/rack,
-/obj/item/shovel/spade,
-/obj/item/shovel,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/cultivator,
-/obj/item/clothing/gloves/botanic_leather,
-/obj/item/clothing/gloves/botanic_leather,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "tte" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -30836,10 +31472,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"ttE" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating,
-/area/f13/radiation)
 "ttU" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/f13/wood,
@@ -30848,12 +31480,6 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"tuS" = (
-/obj/structure/chair/wood/modern{
-	icon_state = "wooden_chair_settler"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "tvl" = (
 /obj/effect/landmark/latejoin,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -30899,6 +31525,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"tvP" = (
+/mob/living/simple_animal/hostile/gecko,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"tvV" = (
+/obj/effect/decal/cleanable/blood/innards,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "twq" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -30921,15 +31555,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "twP" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters{
-	id = "prospectorshutters"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
 	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/building)
+/area/f13/tunnel)
 "twY" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -30941,6 +31570,14 @@
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/wasteland)
+"txp" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outermaincornerouter";
+	tag = "icon-outermaincornerouter (EAST)"
 	},
 /area/f13/wasteland)
 "txr" = (
@@ -30957,6 +31594,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"txE" = (
+/obj/structure/fence/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "txO" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/syringe/medx,
@@ -30992,6 +31636,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"tyL" = (
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/tunnel)
 "tyQ" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -31024,27 +31674,20 @@
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
-"tzY" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"tzZ" = (
-/obj/structure/spider/stickyweb,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "tAg" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"tAz" = (
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "tAC" = (
 /obj/structure/easel,
 /turf/open/floor/f13/wood,
@@ -31067,12 +31710,17 @@
 /turf/open/water,
 /area/f13/brotherhood)
 "tAS" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "0-2"
+/mob/living/simple_animal/hostile/gecko,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2"
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/building)
+/area/f13/wasteland)
+"tAU" = (
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "tBm" = (
 /obj/structure/table/wood/settler,
 /obj/item/clothing/head/helmet/f13/deathskull,
@@ -31101,13 +31749,16 @@
 	},
 /area/f13/ncr)
 "tCc" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/effect/mine/stun,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
 "tCh" = (
 /obj/structure/car/rubbish1,
@@ -31115,9 +31766,19 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
+"tCo" = (
+/obj/machinery/grill,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tCq" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"tCu" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2left"
+	},
 /area/f13/wasteland)
 "tCv" = (
 /turf/open/indestructible/ground/outside/road{
@@ -31131,23 +31792,30 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/ncr)
-"tDb" = (
-/obj/structure/chair/bench,
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
-	},
-/area/f13/wasteland)
 "tDg" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"tDk" = (
+/obj/item/candle/infinite,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/airless,
+/area/f13/legion)
 "tDq" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"tDv" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/wood/settler,
+/obj/item/kitchen/knife,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tDH" = (
 /obj/structure/debris/v4,
 /obj/effect/decal/cleanable/dirt,
@@ -31168,6 +31836,12 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/village)
+"tEp" = (
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2"
+	},
+/area/f13/wasteland)
 "tEr" = (
 /obj/structure/closet/crate{
 	anchored = 1;
@@ -31192,19 +31866,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"tFr" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+"tFM" = (
+/mob/living/simple_animal/hostile/gecko,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
 	},
-/area/f13/legion)
-"tFK" = (
-/obj/effect/landmark/start/f13/farmer,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/area/f13/wasteland)
 "tFR" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
@@ -31269,61 +31936,51 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/brotherhood)
-"tHf" = (
-/obj/structure/table,
-/obj/machinery/light/small,
-/obj/item/reagent_containers/food/drinks/flask,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/city)
 "tHw" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"tIE" = (
-/obj/structure/chair/wood/modern,
-/turf/open/floor/wood/f13/oak,
+"tIu" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "tIM" = (
 /obj/structure/safe,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tIO" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small/broken{
-	dir = 4
-	},
-/turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
-"tIY" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 4
+"tIP" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "tJe" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tJk" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/open/floor/plasteel/chapel{
-	dir = 6
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0";
+	tag = "icon-horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland)
 "tJm" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -31337,29 +31994,17 @@
 /turf/closed/wall/f13/wood,
 /area/f13/brotherhood)
 "tJx" = (
-/obj/machinery/light/small{
-	dir = 1
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder";
+	tag = "icon-outerborder (EAST)"
 	},
-/obj/item/stock_parts/cell,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "tJz" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"tJG" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "0-2";
-	tag = "icon-0-2"
-	},
-/turf/open/floor/plating,
-/area/f13/caves)
 "tKk" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -31415,6 +32060,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tMX" = (
+/obj/item/clothing/head/helmet/f13/rustedcowboyhat,
+/obj/item/clothing/suit/armor/f13/rustedcowboy,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "tNa" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/rag/towel,
@@ -31445,13 +32095,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "tNI" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/chapel{
-	dir = 10
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2";
+	tag = "icon-verticalleftborderright2"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "tNX" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/desert,
@@ -31465,13 +32113,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"tOf" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical";
-	tag = "icon-housewindowvertical (NORTHEAST)"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "tOg" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/decal/cleanable/blood/gibs/limb,
@@ -31493,12 +32134,11 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building)
 "tOP" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain3";
+	tag = "icon-verticalinnermain3"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "tOS" = (
 /obj/structure/fluff/rails{
 	dir = 4
@@ -31510,26 +32150,19 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "tPt" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/metal,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft2";
+	tag = "icon-verticalrightborderleft2"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "tPy" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain3"
 	},
 /area/f13/wasteland)
 "tPA" = (
-/obj/structure/chair/wood,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "tQk" = (
 /obj/structure/table/wood,
@@ -31562,37 +32195,33 @@
 /area/f13/bar)
 "tQV" = (
 /obj/structure/chair/wood{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/wood/f13/oakbroken2,
 /area/f13/legion)
-"tRa" = (
-/turf/open/floor/wood/f13/oakbroken4,
-/area/f13/building)
+"tQY" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerbordercorner";
+	tag = "icon-outerbordercorner (EAST)"
+	},
+/area/f13/wasteland)
 "tRc" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
-"tRx" = (
-/obj/structure/fence/corner{
-	dir = 6
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
+"tRJ" = (
+/obj/structure/table/wood/fancy,
+/obj/item/candle,
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "tRX" = (
-/obj/structure/chair/wood,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/chair/office{
+	dir = 4
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "tRY" = (
 /obj/structure/barricade/wooden,
@@ -31601,6 +32230,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tSc" = (
+/obj/structure/chair/bench,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tSd" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -31619,15 +32255,6 @@
 /obj/structure/sign/poster/prewar/poster73,
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
-"tSF" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "tSQ" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/f13/wood,
@@ -31639,19 +32266,8 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"tTT" = (
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "tTV" = (
 /obj/structure/flora/wasteplant/wild_agave,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"tTX" = (
-/obj/structure/fence/corner,
-/obj/structure/fence{
-	dir = 1;
-	icon_state = "straight"
-	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "tUb" = (
@@ -31716,23 +32332,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tUC" = (
-/obj/item/mop{
-	icon_state = "mopbucket";
-	tag = "icon-mopbucket"
-	},
-/obj/item/mop,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/table/wood,
+/obj/item/clothing/suit/armor/f13/raider/raidermetal,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "tUH" = (
-/obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/closet,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "tUM" = (
 /obj/structure/bed/roller,
@@ -31750,9 +32356,17 @@
 	},
 /area/f13/wasteland)
 "tUS" = (
-/obj/effect/landmark/start/f13/barkeep,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"tVd" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
 /area/f13/building)
 "tVi" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -31777,36 +32391,22 @@
 	},
 /area/f13/wasteland)
 "tWd" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife/cosmicdirty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
-"tWt" = (
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/structure/barricade/wooden,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
+"tWu" = (
+/obj/structure/fence{
+	dir = 8;
+	icon_state = "straight"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "tWv" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
-	},
-/area/f13/wasteland)
-"tXc" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "tXe" = (
@@ -31842,9 +32442,9 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "tYd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/bed/mattress/pregame,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "tYe" = (
 /obj/machinery/light/small{
@@ -31852,11 +32452,29 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"tYk" = (
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "tYJ" = (
 /obj/structure/chair/wood,
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tYL" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tYQ" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
@@ -31868,13 +32486,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"tYW" = (
-/obj/structure/barricade/tentclothedge,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/building)
 "tZh" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_l,
@@ -31902,15 +32513,26 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"uag" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "uar" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
 /area/f13/clinic)
-"uaJ" = (
-/obj/structure/wreck/trash/bus_door,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2left"
+"uaD" = (
+/obj/effect/decal/riverbank,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
+"ubc" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0";
+	tag = "icon-verticalleftborderright0"
 	},
 /area/f13/wasteland)
 "ubd" = (
@@ -31924,39 +32546,49 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
+"ubt" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
+"ubv" = (
+/obj/structure/simple_door/bunker,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
 "ubJ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
-"ubK" = (
-/obj/structure/table/wood/settler,
-/obj/item/paperplane,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "ubS" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbroken"
+/obj/item/ammo_casing/c9mm/ap,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
+/area/f13/wasteland)
+"uco" = (
+/obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
-"ucj" = (
-/obj/effect/decal/cleanable/blood/innards,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/area/f13/wasteland)
 "ucs" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "ucw" = (
-/obj/structure/flora/grass/wasteland{
-	pixel_x = -3
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2bottom";
+	tag = "icon-verticalinnermain2bottom"
 	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ucz" = (
 /obj/structure/car/rubbish2,
@@ -31977,12 +32609,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"ucN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+"ucL" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "ucQ" = (
 /obj/machinery/shower{
 	dir = 8
@@ -32002,6 +32638,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"udf" = (
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
+	},
+/area/f13/wasteland)
 "udt" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/f13/wood,
@@ -32033,16 +32679,6 @@
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"uet" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
-	},
-/area/f13/wasteland)
 "uey" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32"
@@ -32058,15 +32694,9 @@
 	},
 /area/f13/building)
 "ueL" = (
-/obj/machinery/trading_machine/weapon,
-/turf/open/floor/f13/wood,
+/obj/item/stack/f13Cash/random/med,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"ueN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/wasteland)
 "ueT" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = -3
@@ -32080,10 +32710,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"ufb" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "uff" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -32101,9 +32727,17 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"ufP" = (
-/obj/machinery/trading_machine/armor,
+"ufK" = (
+/obj/structure/table/wood,
+/obj/item/clothing/suit/armor/f13/raider/sadist,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"ufP" = (
+/mob/living/simple_animal/hostile/wolf{
+	faction = list("hostile","wolf","raider");
+	name = "raider dog"
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "ugm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32134,6 +32768,7 @@
 	},
 /area/f13/brotherhood)
 "uhi" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/plating,
 /area/f13/radiation)
 "uhk" = (
@@ -32142,11 +32777,6 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
-"uhp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "uhq" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -32189,6 +32819,14 @@
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland)
+"ujr" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
+	},
+/area/f13/caves)
 "ujC" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/muzzle,
@@ -32197,6 +32835,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"ujK" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outermaincornerouter";
+	tag = "icon-outermaincornerouter"
+	},
+/area/f13/wasteland)
 "uke" = (
 /obj/structure/closet/cabinet/anchored,
 /turf/open/indestructible/ground/outside/dirt,
@@ -32204,24 +32848,19 @@
 "ukl" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
+"ukL" = (
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench";
+	tag = "icon-bench (WEST)"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "ukQ" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/wasteland)
-"ulc" = (
-/obj/structure/fence/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"uld" = (
-/obj/effect/decal/marking{
-	icon_state = "doublehorizontal"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/tunnel)
 "ulf" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -32229,20 +32868,27 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"uls" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress4"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "ulu" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
+"ulC" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "ulE" = (
-/turf/open/floor/plasteel/stairs/old,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
 "ulH" = (
 /obj/structure/car,
@@ -32255,30 +32901,34 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ulU" = (
-/obj/structure/rack,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"ulY" = (
-/mob/living/simple_animal/hostile/raider/baseball,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"umi" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "4-8"
+"umd" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
+"umi" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "umD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"umM" = (
+/mob/living/simple_animal/hostile/stalkeryoung,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "umS" = (
 /obj/structure/table/wood/fancy/black,
@@ -32289,11 +32939,25 @@
 /obj/item/toy/eightball,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
+"umW" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "unp" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
 	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
+"unr" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0";
+	tag = "icon-horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
 "unF" = (
@@ -32330,13 +32994,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uok" = (
-/obj/structure/table/reinforced,
-/obj/item/taperecorder,
-/obj/item/pda/engineering,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/machinery/light{
+	dir = 8
 	},
-/area/f13/wasteland)
+/obj/machinery/button/door{
+	id = "followersdeskshutters";
+	name = "desk shutters";
+	pixel_x = 6
+	},
+/obj/machinery/button/door{
+	id = "followershutters";
+	name = "door shutters";
+	pixel_x = -6
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "uom" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32344,6 +33019,10 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/brotherhood)
+"uop" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/f13/radiation)
 "uoK" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
@@ -32358,6 +33037,14 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"upg" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "upj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -32381,6 +33068,17 @@
 /area/f13/wasteland)
 "uqa" = (
 /turf/closed/wall/f13/wood,
+/area/f13/building)
+"uqd" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (NORTH)"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
+	},
 /area/f13/building)
 "uqe" = (
 /obj/effect/spawner/structure/window,
@@ -32422,20 +33120,9 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
-"urm" = (
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32";
-	tag = "icon-wasteland32"
-	},
-/area/f13/wasteland)
 "urt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	desc = "A lighting fixture.";
-	dir = 8;
-	light_color = "#008000";
-	name = "light tube"
-	},
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "uru" = (
@@ -32451,16 +33138,22 @@
 	},
 /area/f13/ncr)
 "ury" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/wood/f13/oakbroken4,
 /area/f13/building)
 "urA" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"urB" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
+"urL" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "urN" = (
 /turf/open/floor/carpet/black,
@@ -32470,6 +33163,15 @@
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"urY" = (
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "use" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/road{
@@ -32491,6 +33193,11 @@
 	name = "concrete wall"
 	},
 /area/f13/building)
+"usO" = (
+/obj/structure/closet/cardboard,
+/obj/item/crowbar,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "usW" = (
 /obj/machinery/shower{
 	dir = 8
@@ -32498,6 +33205,11 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
+/area/f13/building)
+"utk" = (
+/obj/structure/table/wood,
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "utT" = (
 /obj/structure/barricade/wooden/strong,
@@ -32512,6 +33224,11 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
+"uul" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/f13/doctor,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uuB" = (
 /obj/structure/toilet{
 	dir = 4
@@ -32556,30 +33273,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"uwi" = (
-/obj/machinery/shower{
-	dir = 4;
-	tag = "icon-shower (EAST)"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "uwl" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
-	},
-/area/f13/building)
-"uwy" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
 	},
 /area/f13/building)
 "uwQ" = (
@@ -32589,12 +33288,6 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building)
-"uwZ" = (
-/obj/structure/closet/crate/trashcart{
-	name = "corpse cart"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "uxf" = (
 /obj/structure/closet/crate/large,
@@ -32609,6 +33302,11 @@
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"uxV" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "uyg" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -32634,27 +33332,33 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"uyD" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uyM" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
 	},
 /area/f13/wasteland)
+"uyP" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0";
+	tag = "icon-verticalinnermain0"
+	},
+/area/f13/wasteland)
 "uyV" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"uze" = (
-/obj/structure/fence/wooden{
-	dir = 4;
-	icon_state = "post_wood"
-	},
+"uzb" = (
+/obj/item/chair/wood,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/area/f13/wasteland)
 "uzn" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 1
-	},
+/obj/structure/chair/stool,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "uzs" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -32675,6 +33379,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"uzM" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderlefttop";
+	tag = "icon-verticalrightborderlefttop"
+	},
+/area/f13/wasteland)
 "uzU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -32696,26 +33406,26 @@
 /obj/structure/car,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"uAX" = (
-/obj/item/ammo_casing/shotgun/improvised,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2";
-	tag = "icon-horizontaloutermain2"
+"uBw" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "uBx" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_br,
 /area/f13/bar)
-"uBK" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 8
+"uBE" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "uCh" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -32725,36 +33435,28 @@
 	},
 /area/f13/wasteland)
 "uCn" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/obj/structure/campfire,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"uCt" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
+"uCB" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0";
+	tag = "icon-verticalrightborderleft0"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
+/area/f13/wasteland)
 "uCO" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "uCS" = (
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/obj/machinery/light/broken{
+	dir = 4
 	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "uCT" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	tag = "icon-wooden_chair_settler (EAST)"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "uCW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -32762,6 +33464,10 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"uDp" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "uDw" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
@@ -32803,16 +33509,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
-"uEJ" = (
-/obj/structure/rack,
-/obj/item/crafting/wonderglue,
-/obj/item/crafting/wonderglue,
-/obj/item/crafting/wonderglue,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "uEK" = (
 /obj/structure/table/wood,
 /obj/item/pda,
@@ -32844,12 +33540,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "uFp" = (
-/obj/structure/billboard/ritas,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2";
-	tag = "icon-horizontaloutermain2"
-	},
-/area/f13/wasteland)
+/obj/structure/bed/mattress/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uFt" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1
@@ -32871,12 +33564,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "uFK" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
 	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "uGc" = (
 /obj/effect/decal/cleanable/oil,
@@ -32917,6 +33608,27 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"uHl" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/item/clothing/under/f13/shiny,
+/obj/item/clothing/under/f13/shiny,
+/obj/item/clothing/under/f13/settler,
+/obj/item/clothing/under/f13/settler,
+/obj/item/clothing/under/f13/relaxedwear,
+/obj/item/clothing/under/f13/relaxedwear,
+/obj/item/clothing/under/f13/spring,
+/obj/item/clothing/under/f13/spring,
+/obj/structure/closet/cabinet,
+/obj/item/holybeacon,
+/obj/item/clothing/accessory/pocketprotector/cosmetology,
+/obj/item/clothing/under/rank/chaplain,
+/obj/item/clothing/shoes/sneakers/black,
+/obj/item/clothing/head/nun_hood,
+/obj/item/storage/backpack/cultpack,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uHo" = (
 /obj/machinery/computer/shuttle/bunkerelevator{
 	dir = 4
@@ -32963,24 +33675,26 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"uIJ" = (
-/obj/structure/table/wood/settler,
-/obj/item/paper,
-/obj/item/pen,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+"uIz" = (
+/obj/structure/table/wood,
+/obj/item/trash/sosjerky{
+	icon_state = "plate";
+	tag = "icon-plate"
 	},
+/obj/item/kitchen/fork{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "uIK" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "uIT" = (
@@ -32988,10 +33702,6 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"uIV" = (
-/obj/structure/barricade/tentclothedge,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
 "uJd" = (
 /obj/structure/decoration/clock/old{
 	pixel_x = -32
@@ -33013,12 +33723,17 @@
 	},
 /area/f13/building)
 "uJP" = (
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+	dir = 4;
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner (EAST)"
+	},
+/area/f13/wasteland)
+"uKb" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outermaincornerouter";
+	tag = "icon-outermaincornerouter (WEST)"
 	},
 /area/f13/wasteland)
 "uKq" = (
@@ -33030,11 +33745,17 @@
 /obj/effect/landmark/start/f13/druid,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"uKw" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "uKA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/rack,
+/obj/item/watertank,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "uKB" = (
 /obj/structure/rack,
 /obj/item/radio,
@@ -33048,29 +33769,9 @@
 	},
 /area/f13/building)
 "uKG" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "uKJ" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -33086,13 +33787,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"uKT" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "uKY" = (
 /obj/structure/chair{
 	dir = 1
@@ -33101,19 +33795,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"uLh" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 10;
-	tag = "icon-sink (EAST)"
-	},
-/obj/structure/mirror{
-	pixel_x = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/city)
 "uLK" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/f13{
@@ -33142,19 +33823,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"uMU" = (
-/obj/machinery/light/small{
-	dir = 4
+"uMR" = (
+/obj/structure/fence{
+	dir = 8
 	},
-/obj/structure/closet/crate/trashcart{
-	name = "corpse cart"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
-"uMZ" = (
-/obj/machinery/light,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/area/f13/wasteland)
 "uNC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small{
@@ -33162,15 +33839,6 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
-	},
-/area/f13/building)
-"uND" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Clinic"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "uNK" = (
@@ -33201,11 +33869,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uOr" = (
-/obj/structure/chair/booth{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
 /area/f13/building)
 "uOu" = (
 /obj/machinery/light/small/broken{
@@ -33239,6 +33908,12 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"uPl" = (
+/obj/structure/decoration/clock/old/active{
+	pixel_y = 32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uPr" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -33279,25 +33954,44 @@
 	},
 /area/f13/bunker)
 "uQx" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = 25;
+	pixel_y = 18
 	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "uQz" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"uQN" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2left";
+	tag = "icon-horizontaltopborderbottom2left"
+	},
+/area/f13/wasteland)
 "uRa" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"uRw" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+"uRi" = (
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermainleft";
+	tag = "icon-horizontaloutermainleft"
+	},
+/area/f13/wasteland)
+"uRs" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderlefttop";
+	tag = "icon-verticalleftborderlefttop"
+	},
+/area/f13/wasteland)
 "uRJ" = (
 /turf/open/floor/f13/wood,
 /area/f13/village)
@@ -33307,13 +34001,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uRN" = (
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2";
+	tag = "icon-horizontalinnermain2"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outermaincornerinner";
-	tag = "icon-outermaincornerinner (EAST)"
+/area/f13/wasteland)
+"uRU" = (
+/obj/structure/wreck/trash/engine,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "uSj" = (
@@ -33328,6 +34024,10 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"uSp" = (
+/obj/item/toy/cattoy,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "uSq" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/helmet/f13/motorcycle,
@@ -33336,8 +34036,15 @@
 	},
 /area/f13/village)
 "uSz" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken4,
+/obj/structure/chair/stool/retro/black,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"uSA" = (
+/obj/structure/curtain,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
 /area/f13/building)
 "uSC" = (
 /obj/structure/table/wood,
@@ -33380,24 +34087,19 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "uTA" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/machinery/microwave/stove,
+/obj/effect/decal/cleanable/salt,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+	icon_state = "bluerustychess2"
 	},
-/area/f13/city)
+/area/f13/building)
 "uTG" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
-"uTH" = (
-/obj/structure/chair/stool/retro,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "uTQ" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -33415,10 +34117,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"uUd" = (
-/obj/effect/landmark/start/f13/preacher,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "uUo" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -33432,13 +34130,25 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
-"uUK" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "gatehouseladder"
+"uUJ" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/knife,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"uUL" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/processor/chopping_block,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
 /area/f13/building)
 "uUS" = (
 /obj/machinery/vending/cola/random,
@@ -33447,31 +34157,22 @@
 	},
 /area/f13/wasteland)
 "uUZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
+/obj/structure/closet/fridge,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/crafting/wonderglue,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"uVn" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright2top";
-	tag = "icon-verticalleftborderright2top"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "uVo" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop3"
 	},
-/area/f13/wasteland)
-"uVs" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6
-	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "uVw" = (
 /obj/effect/decal/cleanable/dirt{
@@ -33493,13 +34194,12 @@
 	},
 /area/f13/building)
 "uVF" = (
-/obj/structure/simple_door/house,
-/obj/machinery/door/poddoor/shutters{
-	id = "storeshutters";
-	name = "store shutters"
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "uVM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -33507,12 +34207,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"uWb" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright2bottom";
-	tag = "icon-verticalleftborderright2bottom"
-	},
-/area/f13/wasteland)
 "uWs" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -33529,6 +34223,15 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
+"uWE" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "uWH" = (
 /obj/structure/chair{
 	dir = 1
@@ -33536,12 +34239,6 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/building)
-"uWJ" = (
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
-/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "uWQ" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -33567,45 +34264,37 @@
 	},
 /area/f13/village)
 "uXa" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright";
-	layer = 2
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "storeshutters";
-	name = "store shutters"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"uXd" = (
-/obj/machinery/button/door{
-	id = "interiorgate";
-	name = "Interior door button";
-	pixel_x = 6;
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "frontgateshut";
-	name = "gate shutters";
-	pixel_x = -5;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/area/f13/wasteland)
 "uXj" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "uXU" = (
-/turf/open/floor/plasteel/chapel{
+/obj/structure/rack,
+/obj/item/kitchen/fork{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/machinery/light/small{
 	dir = 8
 	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "uXV" = (
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleplate"
+	},
+/area/f13/wasteland)
+"uXX" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "uYf" = (
@@ -33646,29 +34335,34 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"uZf" = (
-/obj/structure/simple_door/metal/fence,
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"uZg" = (
-/obj/structure/table/wood,
-/obj/item/trash/waffles,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+"uYO" = (
+/obj/structure/fence/wooden{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/building)
+"uZg" = (
+/obj/item/trash/sosjerky{
+	pixel_x = -6
+	},
+/obj/item/trash/sosjerky{
+	pixel_x = 1;
+	pixel_y = 10
+	},
+/obj/item/trash/sosjerky{
+	icon_state = "dr_gibb";
+	pixel_x = 4;
+	pixel_y = -3;
+	tag = "icon-dr_gibb"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uZj" = (
-/obj/structure/destructible/tribal_torch{
-	layer = 3.1;
-	pixel_y = 20
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uZl" = (
 /obj/item/radio/intercom{
 	frequency = 1891;
@@ -33682,19 +34376,9 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
-"uZv" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "uZy" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"uZR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vaf" = (
 /obj/item/chair/wood,
@@ -33706,12 +34390,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"vat" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2bottom";
-	tag = "icon-verticalinnermain2bottom"
-	},
-/area/f13/wasteland)
 "vaw" = (
 /obj/structure/table,
 /obj/item/storage/backpack,
@@ -33731,6 +34409,16 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"vaZ" = (
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (NORTH)"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/building)
 "vbi" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -33738,11 +34426,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"vcb" = (
-/obj/structure/table/wood,
-/obj/item/instrument/guitar,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "vcg" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -33753,6 +34436,12 @@
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
+"vcu" = (
+/obj/structure/fence/wooden{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "vcF" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -33778,10 +34467,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"vcV" = (
-/obj/structure/reagent_dispensers/barrel/two,
-/turf/open/water,
-/area/f13/wasteland)
 "vcY" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -33795,9 +34480,9 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"vdB" = (
-/obj/structure/decoration/rag,
-/turf/closed/wall/f13/store,
+"vdE" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "vdO" = (
 /obj/structure/fence{
@@ -33805,13 +34490,9 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"vei" = (
-/obj/structure/sink{
-	pixel_y = 18
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+"ven" = (
+/obj/item/trash/f13/cram_large,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "ves" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33889,27 +34570,29 @@
 	tag = "icon-horizontaloutermain0"
 	},
 /area/f13/wasteland)
-"vfR" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#c40e0e"
+"vfC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
-"vfS" = (
-/obj/structure/wreck/trash/two_tire,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "followerladder"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
+"vfJ" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
 "vfU" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"vgc" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
 "vgy" = (
 /obj/structure/table/wood,
 /obj/item/paper,
@@ -33929,14 +34612,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"vhd" = (
-/obj/structure/table/wood,
-/obj/item/trash/candle,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
 /area/f13/building)
 "vhm" = (
 /obj/effect/decal/marking{
@@ -33960,10 +34635,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"vhu" = (
-/obj/structure/bed,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "vhw" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -33986,6 +34657,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"vib" = (
+/obj/structure/chair/wood/modern,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "vim" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -34004,11 +34679,8 @@
 	},
 /area/f13/brotherhood)
 "viv" = (
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/wood/f13/oakbroken3,
 /area/f13/building)
 "viD" = (
 /obj/structure/closet/crate/medical,
@@ -34025,16 +34697,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
-"viM" = (
-/obj/structure/cargocrate,
-/obj/structure/cargocrate{
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "vjd" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -34053,10 +34715,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/village)
-"vjl" = (
-/obj/item/trash/f13/fancylads,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "vjO" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -34074,12 +34732,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"vkb" = (
-/obj/item/mop,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "vkB" = (
 /obj/structure/chair/wood/modern,
 /obj/effect/decal/remains/human,
@@ -34103,14 +34755,9 @@
 	},
 /area/f13/village)
 "vlg" = (
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/f13/wood,
 /area/f13/building)
-"vlx" = (
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "vly" = (
 /obj/structure/debris/v3,
 /turf/open/floor/plating/dirt/dark,
@@ -34125,10 +34772,6 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"vmg" = (
-/obj/structure/noticeboard,
-/turf/closed/wall/f13/wood,
-/area/f13/building)
 "vmX" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -34159,15 +34802,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"voE" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "voF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -34177,10 +34811,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
-"voQ" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "voV" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -34189,28 +34819,10 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/farm)
-"voY" = (
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "vpa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence/end{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"vpl" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "vpx" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -34218,17 +34830,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vpH" = (
-/obj/structure/cargocrate,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"vpJ" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0";
-	tag = "icon-verticalrightborderleft0"
-	},
-/area/f13/wasteland)
 "vpM" = (
 /obj/structure/flora/rock/jungle,
 /turf/closed/indestructible/rock,
@@ -34260,6 +34861,16 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"vrc" = (
+/obj/structure/chair/wood/modern{
+	icon_state = "wooden_chair_settler"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"vrw" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "vrz" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -34279,17 +34890,6 @@
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"vrJ" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
-"vsb" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/assembly/igniter,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "vsm" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/fence/wooden{
@@ -34303,12 +34903,6 @@
 /obj/machinery/light/broken,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"vta" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
 "vtb" = (
 /obj/structure/fence{
 	dir = 4
@@ -34326,32 +34920,18 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "vtj" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbroken"
-	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"vtv" = (
-/obj/structure/fireplace{
-	layer = 2.1;
-	level = 1;
-	pixel_y = -10
-	},
-/obj/effect/decal/cleanable/ash{
-	pixel_x = -11;
-	pixel_y = -7
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"vtD" = (
-/obj/structure/barricade/tentclothcorner,
+/obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
+	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/building)
+/area/f13/wasteland)
+"vtv" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/decal/remains/human,
+/obj/item/clothing/suit/armor/f13/tribal,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vtH" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/dirt,
@@ -34361,19 +34941,27 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "vuH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence{
-	dir = 4
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "vuZ" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"vvc" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/syringe/medx,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/building)
 "vvi" = (
@@ -34393,27 +34981,40 @@
 /turf/closed/wall/f13/wood,
 /area/f13/bar)
 "vwn" = (
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/machinery/door/airlock/public/glass{
+	name = "Followers Clinic"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "vwt" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"vwx" = (
+/obj/structure/fence/corner{
+	dir = 5
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "vwM" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
-"vxb" = (
-/obj/structure/bed/dogbed{
-	pixel_x = -1;
-	pixel_y = 7
+"vwS" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontaltopborderbottom2left";
+	tag = "icon-horizontaltopborderbottom2left (WEST)"
 	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/area/f13/wasteland)
 "vxc" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -34422,6 +35023,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"vxd" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontaltopborderbottom2right";
+	tag = "icon-horizontaltopborderbottom2right (WEST)"
+	},
+/area/f13/wasteland)
 "vxv" = (
 /obj/machinery/chem_dispenser{
 	pixel_y = 10
@@ -34436,10 +35044,25 @@
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"vyb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "vye" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"vyY" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "vzb" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/trash,
@@ -34489,6 +35112,18 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"vAm" = (
+/obj/structure/table,
+/obj/item/roller,
+/obj/item/roller,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 30;
+	pixel_y = -3
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "vAt" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib1-old"
@@ -34500,16 +35135,6 @@
 /obj/item/storage/backpack/satchel/leather,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"vAy" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/building)
 "vAM" = (
 /obj/machinery/vending/dinnerware,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -34518,15 +35143,6 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
-"vBp" = (
-/obj/structure/closet/crate/bin,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "vBr" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/f13/wood,
@@ -34537,6 +35153,16 @@
 	},
 /turf/open/floor/wood/f13,
 /area/f13/building)
+"vBD" = (
+/obj/structure/rack,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/cotton,
+/obj/item/seeds/wheat,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "vBH" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -34545,6 +35171,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"vBO" = (
+/obj/item/chair/stool/retro/black,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "vCi" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
@@ -34568,14 +35198,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/brotherhood)
-"vCY" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/building)
 "vDb" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/cleanable/oil{
@@ -34585,6 +35207,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"vDd" = (
+/obj/item/stack/sheet/mineral/wood/five,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vDe" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt{
@@ -34606,26 +35232,29 @@
 	},
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
+"vDu" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
+	},
+/area/f13/wasteland)
 "vDP" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
+"vDQ" = (
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/legion)
 "vEw" = (
 /obj/item/chair/stool/retro,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"vFc" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/costumes,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
-"vFh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
 "vFn" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood{
@@ -34643,13 +35272,6 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"vFD" = (
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "vFL" = (
 /obj/effect/landmark/start/f13/ncroffduty,
 /turf/open/floor/f13{
@@ -34661,13 +35283,6 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
 	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"vGl" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt";
-	tag = "icon-dirt (NORTHEAST)"
 	},
 /area/f13/wasteland)
 "vGA" = (
@@ -34703,12 +35318,6 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"vHg" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/building)
 "vHh" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/f13{
@@ -34736,12 +35345,9 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"vHI" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/oak,
+"vHK" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "vHQ" = (
 /obj/structure/chair{
@@ -34760,27 +35366,12 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"vHV" = (
-/obj/structure/chair,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "vIb" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"vIe" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/building)
 "vIl" = (
 /obj/item/radio/intercom{
 	frequency = 1891;
@@ -34791,6 +35382,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"vIo" = (
+/obj/structure/rack,
+/obj/item/crafting/wonderglue,
+/obj/item/crafting/wonderglue,
+/obj/item/crafting/wonderglue,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "vIr" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermainbottom";
@@ -34824,10 +35425,11 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"vIN" = (
+"vIJ" = (
+/obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2left";
-	tag = "icon-horizontaltopborderbottom2left"
+	icon_state = "verticalinnermain1";
+	tag = "icon-verticalinnermain1"
 	},
 /area/f13/wasteland)
 "vJb" = (
@@ -34835,31 +35437,26 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vJq" = (
-/obj/structure/bed/dogbed{
-	pixel_x = -10;
-	pixel_y = 13
-	},
 /obj/machinery/light/small{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
-"vJr" = (
-/obj/structure/fence/corner{
-	dir = 1
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerpavementcorner"
+/area/f13/building)
+"vJB" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "vJP" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"vKd" = (
-/obj/structure/car/rubbish2,
-/turf/closed/wall/mineral/wood,
-/area/f13/building)
 "vKl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -34877,10 +35474,30 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"vLj" = (
+/obj/item/trash/can,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"vLr" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "vMh" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood,
+/area/f13/building)
+"vMo" = (
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "vMu" = (
 /obj/machinery/light{
@@ -34931,12 +35548,10 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vNW" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0";
-	tag = "icon-verticalleftborderleft0"
-	},
+"vOq" = (
+/obj/structure/table/wood/settler,
+/obj/item/flashlight/lantern,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "vOx" = (
 /obj/structure/barricade/sandbags,
@@ -34953,14 +35568,6 @@
 	icon_state = "verticaloutermainbottom"
 	},
 /area/f13/wasteland)
-"vPh" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "vPz" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/floor/plasteel/barber{
@@ -34977,6 +35584,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"vPQ" = (
+/obj/structure/chair/wood/modern{
+	dir = 4;
+	icon_state = "wooden_chair_settler"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vPU" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -34987,6 +35601,10 @@
 "vPY" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"vQz" = (
+/mob/living/simple_animal/hostile/stalker,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "vQE" = (
 /obj/effect/landmark/start/f13/ncrrearechelon,
 /obj/effect/decal/cleanable/dirt{
@@ -35012,13 +35630,23 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "vQU" = (
-/obj/item/toy/cattoy,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/obj/item/ammo_casing/shotgun/improvised,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "vRo" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"vRK" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left";
+	tag = "icon-horizontalinnermain2left (WEST)"
+	},
+/area/f13/wasteland)
 "vRR" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
@@ -35052,6 +35680,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
+"vSV" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1";
+	tag = "icon-horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "vTr" = (
 /obj/structure/table/wood/settler,
 /obj/item/lipstick,
@@ -35061,6 +35695,12 @@
 /obj/structure/closet/cabinet,
 /obj/item/flashlight/lantern,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"vTZ" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
 /area/f13/building)
 "vUa" = (
 /obj/machinery/mineral/wasteland_vendor/attachments{
@@ -35077,16 +35717,13 @@
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"vVb" = (
-/obj/machinery/light/small{
-	dir = 1
+"vVt" = (
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0";
+	tag = "icon-horizontaltopbordertop0"
 	},
-/obj/structure/rack,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "vVF" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -35107,18 +35744,7 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"vVK" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2top";
-	tag = "icon-verticalleftborderleft2top"
-	},
-/area/f13/wasteland)
 "vVR" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "vVU" = (
@@ -35129,6 +35755,11 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"vWq" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "vWC" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -35183,35 +35814,19 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
+"vXw" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "vXF" = (
 /obj/structure/fence/corner{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"vXM" = (
-/obj/structure/table,
-/obj/machinery/light/fo13colored/Red{
-	bulb_colour = "#008000";
-	desc = "A lighting fixture.";
-	dir = 4;
-	light_color = "#008000";
-	name = "light tube"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Secret"
-	},
-/obj/machinery/light/fo13colored/Red{
-	bulb_colour = "#008000";
-	desc = "A lighting fixture.";
-	dir = 4;
-	light_color = "#008000";
-	name = "light tube"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vYe" = (
 /obj/structure/barricade/sandbags,
@@ -35232,14 +35847,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"vYZ" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+"vYP" = (
+/obj/structure/cable{
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
-/area/f13/building)
+/obj/item/storage/trash_stack,
+/turf/open/floor/plating,
+/area/f13/caves)
 "vZl" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor1-old"
@@ -35250,26 +35865,34 @@
 	},
 /area/f13/building)
 "vZs" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/table/wood,
+/obj/machinery/light/small,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"wad" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/caves)
 "wbd" = (
 /obj/structure/table/wood,
 /obj/machinery/processor/chopping_block,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"wbP" = (
-/obj/machinery/light/small{
+"wbi" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2bottom";
+	tag = "icon-verticalleftborderleft2bottom"
+	},
+/area/f13/wasteland)
+"wch" = (
+/obj/structure/barricade/tentclothedge{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/handy/protectron,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "wcu" = (
 /obj/structure/barricade/bars,
@@ -35296,21 +35919,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"wcW" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "wdl" = (
 /obj/structure/fence{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"wdA" = (
-/obj/structure/table,
-/obj/item/kitchen/fork,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
 /area/f13/building)
 "wdJ" = (
 /obj/effect/decal/remains/human,
@@ -35328,21 +35947,25 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
+"wec" = (
+/obj/machinery/light/small,
+/obj/structure/rack,
+/obj/item/stack/medical/gauze/improvised,
+/obj/item/stack/medical/gauze/improvised,
+/obj/item/stack/medical/gauze/improvised,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wef" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
-"weI" = (
-/obj/structure/chair/stool{
-	dir = 4;
-	icon_state = "bench";
-	tag = "icon-bench (EAST)"
+"weD" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8;
+	tag = "icon-comfychair (WEST)"
 	},
-/obj/effect/decal/remains/human,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "weJ" = (
 /obj/structure/decoration/clock{
 	pixel_y = 32
@@ -35357,19 +35980,17 @@
 	icon_state = "horizontaloutermainright"
 	},
 /area/f13/wasteland)
-"wfC" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"wgf" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+"wfP" = (
+/obj/structure/closet/bus,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/area/f13/wasteland)
+"wgf" = (
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "wgr" = (
 /obj/machinery/mineral/wasteland_vendor/mining,
 /turf/open/indestructible/ground/inside/mountain,
@@ -35379,22 +36000,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/syringe/medx,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"whh" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "clinicfrontdoor";
-	name = "door shutters";
-	pixel_x = -6
-	},
-/obj/machinery/button/door{
-	id = "clinicdesk";
-	name = "desk shutters";
-	pixel_x = 6
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
 /area/f13/building)
 "whm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -35416,20 +36021,10 @@
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
-"whU" = (
-/obj/structure/chair/stool{
-	dir = 8;
-	icon_state = "bench";
-	tag = "icon-bench (WEST)"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/remains/human,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
+"whS" = (
+/mob/living/simple_animal/hostile/raider/biker,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "wim" = (
 /obj/structure/table/booth,
 /turf/open/floor/wood/wood_tiled,
@@ -35444,18 +36039,16 @@
 /obj/structure/grille/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"wiZ" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderrighttop";
+	tag = "icon-verticalrightborderrighttop"
+	},
+/area/f13/wasteland)
 "wjl" = (
 /obj/structure/sign/poster/ncr/keep_to_myself,
 /turf/closed/wall/f13/store,
 /area/f13/ncr)
-"wjr" = (
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
 "wjt" = (
 /mob/living/simple_animal/hostile/retaliate/goat/bighorn,
 /turf/open/indestructible/ground/outside/desert,
@@ -35466,6 +36059,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"wjx" = (
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "124"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "wjB" = (
 /obj/structure/toilet{
 	dir = 8
@@ -35475,20 +36077,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
-"wjF" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Bar";
-	req_one_access_txt = "28"
-	},
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_y = 32
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "barshutters"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "wjI" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /turf/open/floor/plating/dirt/dark,
@@ -35534,37 +36122,16 @@
 /obj/item/clothing/under/f13/shiny,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wld" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermaintop";
-	tag = "icon-verticalinnermaintop"
-	},
-/area/f13/wasteland)
-"wlX" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "wmI" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "wmJ" = (
-/obj/item/pet_carrier{
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wmL" = (
 /obj/item/clothing/suit/armor/bulletproof,
 /turf/open/indestructible/ground/inside/mountain,
@@ -35589,18 +36156,28 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"wnU" = (
+"wom" = (
+/obj/structure/flora/grass/wasteland{
+	layer = 4.2;
+	pixel_x = -3
+	},
 /turf/open/indestructible/ground/outside/road{
-	dir = 1;
-	icon_state = "innermaincornerouter";
-	tag = "icon-innermaincornerouter (NORTH)"
+	icon_state = "hole";
+	tag = "icon-hole"
 	},
 /area/f13/wasteland)
 "woy" = (
-/obj/structure/decoration/rag,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/obj/machinery/vending/medical{
+	req_access = null
+	},
+/turf/closed/wall/f13/supermart,
+/area/f13/building)
+"woF" = (
+/obj/structure/bed/roller,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "woL" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/fence/wooden{
@@ -35653,25 +36230,53 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wpo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/mine/stun,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "wpx" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wpQ" = (
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "wqe" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 10;
+	tag = "icon-sink (EAST)"
+	},
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
+"wqi" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"wqs" = (
+/obj/structure/wreck/trash/five_tires,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"wqL" = (
+/obj/item/clothing/suit/armor/f13/rustedcowboy,
+/obj/item/clothing/head/helmet/f13/rustedcowboyhat,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "wqO" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -35697,17 +36302,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "wrG" = (
-/obj/structure/table/wood,
-/obj/item/melee/curator_whip{
-	desc = "It stings like hell to be hit by.";
-	name = "Slave whip"
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/item/melee/curator_whip{
-	desc = "It stings like hell to be hit by.";
-	name = "Slave whip"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/area/f13/city)
 "wrP" = (
 /obj/structure/table/optable,
 /turf/open/floor/f13/wood,
@@ -35716,10 +36317,22 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"wrS" = (
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wsq" = (
 /obj/effect/landmark/start/f13/villager,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"wsy" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical";
+	tag = "icon-housewindowvertical (NORTHEAST)"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/city)
 "wsA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -35742,9 +36355,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
-"wsN" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/clinic)
 "wtj" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalcorroded"
@@ -35758,20 +36368,10 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wtJ" = (
-/obj/effect/landmark/observer_start,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
-"wtY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
+"wtR" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/f13/caves)
 "wuk" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verylittleshadowleft"
@@ -35791,9 +36391,18 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/tunnel)
+"wuZ" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "wvf" = (
 /obj/structure/closet,
 /obj/item/stack/sheet/metal/twenty,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"wvm" = (
+/obj/structure/table/wood/settler,
+/obj/item/paperplane,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wvq" = (
@@ -35805,13 +36414,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"wvH" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft3";
-	tag = "icon-verticalleftborderleft3"
-	},
-/area/f13/wasteland)
 "wvV" = (
 /obj/effect/landmark/start/f13/ncrlieutenant,
 /obj/effect/decal/cleanable/dirt{
@@ -35819,13 +36421,10 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"wwE" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+"wwb" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/building)
 "wwF" = (
@@ -35873,6 +36472,16 @@
 /obj/item/instrument/trumpet,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"wxX" = (
+/obj/structure/fence/wooden{
+	dir = 4;
+	icon_state = "post_wood"
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "wya" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
@@ -35906,18 +36515,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"wyX" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+"wzd" = (
+/obj/structure/fence{
+	dir = 4;
+	tag = "icon-metal_fence3"
 	},
-/area/f13/building)
-"wzg" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright2";
-	tag = "icon-verticalleftborderright2"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
 	},
 /area/f13/wasteland)
 "wzh" = (
@@ -35927,19 +36533,21 @@
 	},
 /area/f13/village)
 "wzm" = (
-/obj/structure/simple_door/metal/fence{
-	dir = 8
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowbottom"
 	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "wzn" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/obj/item/trash/chips,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"wzr" = (
+/obj/structure/closet/crate/coffin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "wzw" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -35975,17 +36583,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wAp" = (
-/obj/item/clothing/under/f13/female/tribal,
-/turf/open/indestructible/ground/outside/desert,
+"wAm" = (
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/obj/item/hatchet,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"wAQ" = (
-/obj/item/trash/f13/sugarbombs,
+"wAq" = (
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "wAU" = (
 /obj/structure/rack,
 /obj/item/taperecorder,
@@ -36002,13 +36611,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"wAZ" = (
-/obj/structure/reagent_dispensers/barrel/two,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2";
-	tag = "icon-horizontaloutermain2"
-	},
-/area/f13/wasteland)
 "wBb" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -36019,6 +36621,20 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"wBk" = (
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench";
+	tag = "icon-bench (WEST)"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "wBo" = (
 /obj/machinery/light/broken,
 /turf/open/floor/f13/wood,
@@ -36029,10 +36645,12 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/village)
-"wBA" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+"wBx" = (
+/obj/structure/chair/bench{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "wBC" = (
 /obj/structure/rack,
 /obj/item/clothing/head/crown,
@@ -36051,7 +36669,21 @@
 	},
 /area/f13/village)
 "wCA" = (
-/turf/open/floor/wood,
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
+"wCZ" = (
+/obj/structure/table,
+/obj/item/kitchen/fork,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
 /area/f13/building)
 "wDc" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -36109,10 +36741,6 @@
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"wEJ" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "wEO" = (
 /obj/machinery/shower{
 	dir = 4
@@ -36122,37 +36750,26 @@
 	},
 /area/f13/building)
 "wER" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/item/trash/pistachios,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"wFf" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
 	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/building)
+/area/f13/wasteland)
 "wFo" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "wFp" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0";
-	tag = "icon-horizontaltopbordertop0"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	tag = "icon-housewindow"
 	},
-/area/f13/wasteland)
-"wFz" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "clinicoutsideladder"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "wFG" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -36160,6 +36777,11 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
+"wFL" = (
+/obj/structure/simple_door/room,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "wGc" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_north_middle"
@@ -36174,6 +36796,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
+"wGt" = (
+/turf/closed/mineral/random/low_chance,
+/area/f13/city)
+"wGx" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/legion)
+"wGz" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2top";
+	tag = "icon-verticalleftborderleft2top"
+	},
+/area/f13/wasteland)
 "wGJ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
@@ -36188,22 +36826,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"wGY" = (
-/obj/structure/chair/wood/modern{
-	dir = 8;
-	icon_state = "wooden_chair_old";
-	tag = "icon-wooden_chair_old (WEST)"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"wHo" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/item/flag/followers,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+"wHu" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2";
+	tag = "icon-verticalinnermain2"
 	},
 /area/f13/wasteland)
 "wHJ" = (
@@ -36221,14 +36847,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"wIk" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
-/area/f13/building)
 "wIm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -36238,14 +36856,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"wIG" = (
-/obj/structure/chair/wood/modern{
-	dir = 1;
-	tag = "icon-wooden_chair_new (NORTH)"
-	},
-/obj/effect/decal/remains/human,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "wIK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderlefttop"
@@ -36281,13 +36891,16 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
-"wKP" = (
-/turf/open/indestructible/ground/outside/sidewalk{
+"wKv" = (
+/obj/structure/barricade/tentclothedge{
 	dir = 1;
-	icon_state = "horizontaloutermain1";
-	tag = "icon-horizontaloutermain1 (NORTH)"
+	pixel_y = -3
 	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "wKU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -36321,14 +36934,11 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "wLB" = (
-/obj/machinery/power/solar_control{
-	dir = 8
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft1";
+	tag = "icon-verticalrightborderleft1"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/building)
+/area/f13/wasteland)
 "wLO" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/dirt,
@@ -36366,6 +36976,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
+"wMy" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "wNK" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -36400,8 +37016,9 @@
 	},
 /area/f13/building)
 "wOj" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/legion)
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wOo" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/barber{
@@ -36418,6 +37035,18 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
 	icon_state = "rubble"
+	},
+/area/f13/wasteland)
+"wOx" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "wOA" = (
@@ -36454,6 +37083,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"wOT" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 1;
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter (NORTH)"
+	},
+/area/f13/wasteland)
 "wPl" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/f13/wood,
@@ -36477,6 +37113,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"wPG" = (
+/obj/structure/closet/fridge/cannibal,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wPS" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
@@ -36501,32 +37143,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wQY" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "wQZ" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -10
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
 	},
-/obj/structure/mirror{
-	pixel_x = -32
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "wRb" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small/broken,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "wRG" = (
 /obj/structure/table/wood,
@@ -36547,9 +37173,16 @@
 	},
 /area/f13/wasteland)
 "wSj" = (
-/obj/structure/flora/tree/joshua,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/spider/stickyweb,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "wSk" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/outside/desert,
@@ -36581,27 +37214,38 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"wSJ" = (
-/obj/structure/decoration/clock/old/active{
-	pixel_y = 32
+"wSC" = (
+/obj/structure/spider/stickyweb,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
+"wSJ" = (
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
 /area/f13/building)
 "wSP" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
-"wSS" = (
-/obj/structure/fence/corner{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "wSX" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13{
@@ -36616,20 +37260,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"wTf" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom2right";
-	tag = "icon-horizontalbottomborderbottom2right"
+"wTU" = (
+/obj/structure/decoration/hatch,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop3";
+	tag = "icon-horizontalbottombordertop3"
 	},
 /area/f13/wasteland)
-"wTE" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/microwave,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
 "wUc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -36651,18 +37288,18 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"wUv" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+"wUo" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
 	},
 /area/f13/building)
+"wUv" = (
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "wUL" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/desert,
@@ -36674,9 +37311,10 @@
 	},
 /area/f13/wasteland)
 "wVk" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
+/obj/structure/easel,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "wVn" = (
@@ -36705,6 +37343,13 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
+"wWb" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
+	},
+/area/f13/wasteland)
 "wWh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/pusher,
@@ -36749,12 +37394,13 @@
 	},
 /area/f13/wasteland)
 "wXq" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/item/radio/off,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/building)
 "wXv" = (
@@ -36769,17 +37415,22 @@
 	},
 /area/f13/ncr)
 "wXK" = (
-/obj/effect/landmark/start/f13/sheriff,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/clothing/head/hardhat,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
 /area/f13/building)
 "wXR" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/auto,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/building)
 "wXT" = (
@@ -36812,28 +37463,21 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"wYh" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "wYn" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"wYo" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
-"wYs" = (
-/obj/machinery/computer/arcade,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
 "wYv" = (
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
@@ -36847,35 +37491,24 @@
 	},
 /area/f13/building)
 "wZd" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/area/f13/legion)
-"wZn" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderlefttop";
-	tag = "icon-verticalrightborderlefttop"
-	},
-/area/f13/wasteland)
-"wZG" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/building)
 "wZT" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "xac" = (
-/obj/structure/table,
-/obj/item/kitchen/knife,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom2left";
+	tag = "icon-horizontalbottomborderbottom2left"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "xaj" = (
 /obj/structure/debris/v4,
 /turf/closed/wall/r_wall/rust,
@@ -36920,15 +37553,16 @@
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"xby" = (
-/obj/structure/simple_door/house{
-	icon_state = "interioropening";
-	tag = "icon-interioropening"
+"xbA" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/city)
+/area/f13/building)
 "xbK" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -36955,13 +37589,23 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
-"xcg" = (
-/obj/structure/table,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+"xcb" = (
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/f13/legion)
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
+"xcg" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerborder";
+	tag = "icon-outerborder (NORTH)"
+	},
+/area/f13/wasteland)
 "xcm" = (
 /obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plasteel/barber{
@@ -36979,16 +37623,6 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/village)
-"xcA" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
-"xcL" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/landmark/start/f13/auxilia,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "xcQ" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/combat{
@@ -37023,32 +37657,29 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "xdD" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"xdG" = (
-/obj/structure/chair/stool/retro/black,
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"xdJ" = (
-/obj/machinery/smartfridge/chemistry,
-/turf/closed/wall/f13/supermart,
-/area/f13/building)
-"xdL" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderrighttop";
-	tag = "icon-verticalrightborderrighttop"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"xdG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "xed" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
-"xem" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/floor/wood/f13/oak,
+"xee" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
 "xeo" = (
 /obj/structure/table/optable,
@@ -37070,9 +37701,18 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/wasteland)
 "xeG" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/f13/wood,
+/obj/structure/bed/roller,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
+"xeH" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertopright";
+	tag = "icon-horizontaltopbordertopright"
+	},
+/area/f13/wasteland)
 "xeK" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -37105,6 +37745,18 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"xfk" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright1";
+	tag = "icon-verticalrightborderright1"
+	},
+/area/f13/wasteland)
+"xfl" = (
+/obj/structure/fence/corner/wooden{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "xfo" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -37112,10 +37764,6 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland)
-"xfw" = (
-/obj/item/trash/f13/cram_large,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "xfy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -37128,35 +37776,19 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/caves)
-"xfG" = (
-/obj/structure/disposalpipe/broken{
+"xfI" = (
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "xfP" = (
 /obj/structure/bed/mattress/pregame,
 /obj/item/storage/backpack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"xfR" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbroken";
-	tag = "icon-housewindowbroken"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
-"xfW" = (
-/obj/structure/cable{
-	icon_state = "1-10";
-	tag = "icon-1-10"
-	},
-/turf/open/floor/plating,
-/area/f13/caves)
 "xgn" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/white/box,
@@ -37179,17 +37811,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "xgC" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/f13/caravaneer,
-/obj/item/clothing/under/f13/caravaneer,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/structure/fence{
+	dir = 4
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "xgI" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -37209,14 +37838,20 @@
 "xgX" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/caves)
+"xhd" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "xhh" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
-"xhB" = (
-/obj/structure/reagent_dispensers/barrel/old,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+"xhF" = (
+/obj/structure/table/wood,
+/obj/item/candle/infinite,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "xhJ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "topshadowright"
@@ -37234,6 +37869,15 @@
 	icon_state = "verticalinnermain2"
 	},
 /area/f13/wasteland)
+"xiy" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "xiB" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13{
@@ -37261,13 +37905,11 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"xjS" = (
-/obj/structure/rack,
-/obj/item/storage/pill_bottle/chem_tin/radx,
-/obj/item/storage/pill_bottle/chem_tin/radx,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+"xjP" = (
+/obj/structure/simple_door/house,
+/obj/structure/barricade/wooden/planks,
 /turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
 "xjZ" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -37314,13 +37956,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "xll" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/food/drinks/flask,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/obj/structure/simple_door/room,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "xlA" = (
 /obj/structure/chair/wood{
@@ -37359,29 +37996,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"xmW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/building)
-"xne" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/city)
-"xnh" = (
-/obj/effect/decal/riverbank{
-	dir = 6
-	},
-/turf/open/water,
-/area/f13/wasteland)
 "xnl" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -37395,6 +38009,10 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
+"xnr" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "xnt" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -37412,6 +38030,26 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"xnJ" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
+"xnM" = (
+/obj/structure/simple_door/house{
+	icon_state = "interior";
+	tag = "icon-interior"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "xnR" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin/towel,
@@ -37434,10 +38072,14 @@
 	},
 /area/f13/village)
 "xor" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/ketchup,
+/turf/open/floor/wood/f13/oakbroken2,
+/area/f13/building)
+"xos" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/area/f13/building)
 "xow" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -37450,10 +38092,11 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"xoZ" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2right";
-	tag = "icon-horizontaltopbordertop2right"
+"xoF" = (
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "xpi" = (
@@ -37468,23 +38111,15 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xpN" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
+"xpr" = (
+/obj/structure/car/rubbish2,
+/turf/closed/wall/mineral/wood,
+/area/f13/building)
+"xqe" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright3";
+	tag = "icon-verticalleftborderright3"
 	},
-/area/f13/wasteland)
-"xpW" = (
-/obj/structure/fence{
-	dir = 1;
-	icon_state = "straight"
-	},
-/obj/structure/fence/corner{
-	dir = 8;
-	icon_state = "corner"
-	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "xqk" = (
 /obj/structure/barricade/wooden,
@@ -37504,6 +38139,10 @@
 	dir = 5;
 	icon_state = "rubble"
 	},
+/area/f13/wasteland)
+"xqr" = (
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "xqw" = (
 /turf/open/indestructible/ground/outside/road{
@@ -37538,6 +38177,12 @@
 /obj/structure/sign/poster/contraband/pinup_pink,
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
+"xrm" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft3";
+	tag = "icon-verticalleftborderleft3"
+	},
+/area/f13/wasteland)
 "xrA" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/indestructible/ground/inside/mountain,
@@ -37588,6 +38233,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"xsD" = (
+/obj/machinery/hydroponics/soil,
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "xsF" = (
 /obj/structure/chair/stool/retro,
 /turf/open/floor/wood/f13/carpet,
@@ -37604,10 +38254,6 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
 	},
-/area/f13/wasteland)
-"xtm" = (
-/obj/structure/railing,
-/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "xtG" = (
 /obj/structure/simple_door/metal/barred,
@@ -37642,12 +38288,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"xuJ" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "xuL" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
@@ -37655,9 +38295,9 @@
 	},
 /area/f13/wasteland)
 "xuM" = (
-/obj/structure/chair/comfy/black,
-/turf/open/floor/wood,
-/area/f13/building)
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "xvg" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
@@ -37672,6 +38312,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"xvI" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
+	},
+/area/f13/caves)
 "xvN" = (
 /obj/structure/table/wood/settler,
 /obj/item/lipstick/black,
@@ -37730,17 +38377,12 @@
 /obj/structure/table/booth,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
-"xwR" = (
-/turf/open/floor/wood/f13/oakbroken2,
-/area/f13/legion)
 "xwW" = (
-/obj/structure/chair/stool/retro,
-/turf/open/floor/holofloor/carpet,
-/area/f13/building)
-"xwZ" = (
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/building)
 "xxf" = (
@@ -37754,14 +38396,11 @@
 /obj/structure/chair/wood/worn,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"xxq" = (
-/obj/machinery/light/small{
-	dir = 8
+"xxs" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 4
 	},
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "xxL" = (
 /obj/machinery/light/small/broken{
@@ -37771,14 +38410,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"xxV" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "xya" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/holofloor/carpet,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2right";
+	tag = "icon-horizontaltopbordertop2right"
+	},
+/area/f13/wasteland)
 "xys" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -37796,8 +38433,14 @@
 /obj/structure/stone_tile/center,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"xzK" = (
-/turf/open/floor/plasteel/dark,
+"xzH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/building)
 "xzM" = (
 /turf/open/indestructible/ground/outside/road{
@@ -37805,12 +38448,15 @@
 	},
 /area/f13/wasteland)
 "xzU" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderrightbottom";
+	tag = "icon-verticalrightborderrightbottom"
 	},
-/turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"xAq" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xAB" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb,
@@ -37841,13 +38487,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"xBl" = (
-/obj/structure/chair/bench,
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "xBC" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -37855,20 +38494,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"xBH" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "xBK" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/meatsalted,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "xBM" = (
 /obj/machinery/door/window{
 	dir = 4
@@ -37879,13 +38513,15 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"xBX" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
+"xCi" = (
+/obj/structure/simple_door/bunker,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "xCo" = (
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/dirt{
@@ -37948,16 +38584,8 @@
 	},
 /area/f13/village)
 "xFv" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/ruins,
+/area/f13/city)
 "xFL" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/f13{
@@ -37993,12 +38621,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
-"xGz" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderlefttop";
-	tag = "icon-verticalleftborderlefttop"
-	},
-/area/f13/wasteland)
 "xGD" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -38016,6 +38638,13 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"xGR" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "xHc" = (
 /obj/structure/fence{
 	dir = 4
@@ -38030,21 +38659,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
-"xHC" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/building)
-"xHY" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+"xHy" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plating,
+/area/f13/caves)
 "xIh" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -38088,6 +38706,11 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"xIG" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/breadhard,
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "xIJ" = (
 /obj/structure/rack,
 /obj/item/clothing/under/pants/youngfolksjeans{
@@ -38106,33 +38729,27 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/wasteland)
-"xJc" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt";
-	tag = "icon-dirt (NORTHEAST)"
-	},
-/area/f13/wasteland)
 "xJd" = (
 /obj/structure/chair/stool,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "xJA" = (
-/obj/structure/fence{
-	dir = 4;
-	tag = "icon-metal_fence3"
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"xKa" = (
-/obj/structure/barricade/tentclothcorner{
+/area/f13/caves)
+"xJY" = (
+/obj/structure/fence{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "xKb" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -38150,6 +38767,13 @@
 "xKx" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
+	},
+/area/f13/wasteland)
+"xKE" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner (WEST)"
 	},
 /area/f13/wasteland)
 "xKH" = (
@@ -38178,11 +38802,19 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"xLz" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
+"xLh" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2bottom";
+	tag = "icon-verticalleftborderleft2bottom"
+	},
+/area/f13/wasteland)
+"xLl" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1";
+	tag = "icon-horizontalinnermain1"
 	},
 /area/f13/wasteland)
 "xLK" = (
@@ -38237,28 +38869,24 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"xMz" = (
+/mob/living/simple_animal/hostile/wolf,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0";
+	tag = "icon-verticalrightborderleft0"
+	},
+/area/f13/wasteland)
 "xMN" = (
 /obj/structure/barricade/tentclothcorner,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "xMP" = (
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_x = -32
-	},
-/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
-	anchored = 1;
-	pixel_x = -28
-	},
-/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
-	anchored = 1;
-	pixel_x = -36
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/item/trash/can,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "xNm" = (
-/obj/structure/simple_door/tentflap_cloth,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "xNE" = (
 /obj/structure/fence{
@@ -38287,13 +38915,23 @@
 /obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"xOZ" = (
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
+"xOA" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -10;
+	tag = "icon-sink (WEST)"
 	},
-/area/f13/wasteland)
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
+"xOZ" = (
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "xPd" = (
 /obj/structure/chair{
 	dir = 8
@@ -38304,9 +38942,12 @@
 	},
 /area/f13/building)
 "xPh" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/closet/crate/bin,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "xPn" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -38376,10 +39017,19 @@
 	icon_state = "housebase"
 	},
 /area/f13/building)
+"xRS" = (
+/obj/structure/flora/tree/tall,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "xSa" = (
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "xSC" = (
 /obj/structure/closet/cardboard,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -38415,10 +39065,24 @@
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
-"xTF" = (
-/obj/structure/bonfire,
+"xTB" = (
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench";
+	tag = "icon-bench (EAST)"
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright1"
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
+	},
+/area/f13/wasteland)
+"xTF" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
 	},
 /area/f13/wasteland)
 "xTK" = (
@@ -38427,13 +39091,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"xTM" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/storage/pill_bottle/chem_tin/radx,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "xTZ" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/road{
@@ -38441,43 +39098,33 @@
 	},
 /area/f13/wasteland)
 "xUc" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0";
+	tag = "icon-horizontaloutermain0"
 	},
 /area/f13/wasteland)
-"xUt" = (
-/obj/machinery/light/small,
-/obj/structure/rack,
-/obj/item/stack/medical/gauze/improvised,
-/obj/item/stack/medical/gauze/improvised,
-/obj/item/stack/medical/gauze/improvised,
+"xUO" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xUL" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
-"xUO" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
-	},
-/area/f13/wasteland)
 "xUS" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xUW" = (
-/obj/structure/wreck/trash/machinepiletwo{
-	layer = 3
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -6
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "xVc" = (
 /obj/structure/decoration/rag{
 	layer = 2.5;
@@ -38488,14 +39135,6 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
-"xVh" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -6
-	},
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "xVu" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/farm)
@@ -38528,19 +39167,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xWu" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"xWC" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "xWF" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
@@ -38548,6 +39176,20 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"xWG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken3,
+/area/f13/legion)
+"xWT" = (
+/mob/living/simple_animal/hostile/raider,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"xXh" = (
+/obj/effect/decal/riverbank{
+	dir = 6
+	},
+/turf/open/water,
+/area/f13/wasteland)
 "xXl" = (
 /obj/item/clothing/under/f13/police,
 /obj/item/clothing/head/f13/police,
@@ -38601,6 +39243,13 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"xXZ" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "xYN" = (
 /obj/structure/chair{
 	dir = 4
@@ -38646,6 +39295,16 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/farm)
+"xZR" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"yao" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "yau" = (
 /obj/structure/rack,
 /obj/item/seeds/cabbage,
@@ -38669,10 +39328,11 @@
 	},
 /area/f13/wasteland)
 "yaw" = (
-/obj/structure/wreck/trash/machinepile{
-	layer = 3
+/obj/structure/wreck/trash/machinepile,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "yaz" = (
 /obj/effect/decal/remains/human,
@@ -38700,6 +39360,13 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"yaT" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "ybg" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -38707,13 +39374,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"ybi" = (
-/obj/machinery/vending/nukacolavend,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0";
-	tag = "icon-horizontaloutermain0"
-	},
-/area/f13/wasteland)
 "ybq" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -38767,6 +39427,12 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/village)
+"ycD" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom2";
+	tag = "icon-horizontalbottomborderbottom2"
+	},
+/area/f13/wasteland)
 "ydQ" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowdestroyed"
@@ -38791,29 +39457,11 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/legion)
-"yea" = (
-/obj/structure/decoration/vent,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
-"yej" = (
-/obj/structure/chair/wood/modern{
-	dir = 1;
-	icon_state = "wooden_chair_settler";
-	tag = "icon-wooden_chair_settler (NORTH)"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	tag = "icon-housewood4-broken"
-	},
-/area/f13/building)
 "yel" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "yev" = (
@@ -38827,6 +39475,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"yeC" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "yeJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainleft"
@@ -38848,6 +39503,23 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
+"yfo" = (
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench";
+	tag = "icon-bench (WEST)"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
+	},
+/area/f13/wasteland)
+"yfI" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "yga" = (
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -38887,10 +39559,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ygP" = (
+"ygL" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright3";
-	tag = "icon-verticalleftborderright3"
+	icon_state = "verticalleftborderrightbottom";
+	tag = "icon-verticalleftborderrightbottom"
 	},
 /area/f13/wasteland)
 "ygY" = (
@@ -38911,17 +39583,6 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"yht" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "yhv" = (
 /obj/structure/simple_door/brokenglass,
 /turf/open/floor/f13/wood,
@@ -38930,6 +39591,15 @@
 /obj/structure/campfire,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"yhE" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "followerlabladder"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "yiq" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -38945,39 +39615,10 @@
 /obj/effect/spawner/lootdrop/three_course_meal,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
-"yiv" = (
-/obj/structure/reagent_dispensers/barrel/explosive,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/building)
 "yiF" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"yiJ" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
-"yiM" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Sheriff Office";
-	req_one_access_txt = "62"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"yiU" = (
-/obj/item/storage/trash_stack,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
 "yjt" = (
@@ -38989,6 +39630,12 @@
 /obj/structure/chair/stool,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"yjB" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2top";
+	tag = "icon-verticalleftborderright2top"
+	},
+/area/f13/wasteland)
 "yjG" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
@@ -39009,14 +39656,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"ykw" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outermaincornerouter";
-	tag = "icon-outermaincornerouter (EAST)"
-	},
-/area/f13/wasteland)
 "ykx" = (
 /obj/item/clothing/head/ushanka,
 /obj/structure/displaycase,
@@ -39032,11 +39671,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "ykD" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
+	icon_state = "horizontaloutermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "ykH" = (
 /obj/structure/table/wood/settler,
 /obj/item/lipstick/purple,
@@ -39046,25 +39684,6 @@
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2"
-	},
-/area/f13/wasteland)
-"yla" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/kitchenspike,
-/obj/structure/decoration/hatch{
-	dir = 1;
-	layer = 2.5
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
-"ylA" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt";
-	tag = "icon-dirt (EAST)"
 	},
 /area/f13/wasteland)
 "ylC" = (
@@ -39095,10 +39714,9 @@
 /turf/open/floor/wood/f13/oakbroken3,
 /area/f13/legion)
 "ymd" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom2right";
+	tag = "icon-horizontalbottomborderbottom2right"
 	},
 /area/f13/wasteland)
 "ymi" = (
@@ -39477,7 +40095,7 @@ gcK
 gcK
 gcK
 ims
-fPl
+uXj
 uXj
 ims
 gcK
@@ -39564,6 +40182,8 @@ mGC
 gcK
 gcK
 gcK
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -39578,10 +40198,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -39734,7 +40352,7 @@ gcK
 gcK
 gcK
 xZu
-fPl
+uXj
 uXj
 xZu
 gcK
@@ -39820,6 +40438,15 @@ gjC
 mGC
 gcK
 gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -39827,18 +40454,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -39991,7 +40609,7 @@ gcK
 gcK
 gcK
 xZu
-fPl
+uXj
 uXj
 xZu
 gcK
@@ -40078,26 +40696,26 @@ mGC
 mGC
 gcK
 gcK
+ktB
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
+ktB
+ktB
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -40248,7 +40866,7 @@ gbL
 gbL
 gbL
 xZu
-fPl
+uXj
 uXj
 xZu
 gcK
@@ -40332,10 +40950,18 @@ gmX
 gmX
 sBk
 gcK
+ktB
+ktB
+ktB
+ktB
+ggK
+hBr
 gcK
 gcK
 gcK
 gcK
+gcK
+ktB
 gcK
 gcK
 gcK
@@ -40345,16 +40971,8 @@ gcK
 gbL
 gbL
 gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gbL
 gbL
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -40505,7 +41123,7 @@ gbL
 gbL
 gbL
 xZu
-fPl
+uXj
 uXj
 xZu
 gbL
@@ -40589,19 +41207,18 @@ gmX
 snB
 wwM
 gcK
+ktB
+ktB
+hBr
+ggK
+ggK
+ggK
+gcK
+gcK
 gcK
 gcK
 gcK
 ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -40612,8 +41229,9 @@ gbL
 gbL
 gcK
 gcK
-gcK
 gbL
+gbL
+gcK
 gcK
 gcK
 gcK
@@ -40762,7 +41380,7 @@ gbL
 gbL
 gbL
 xZu
-fPl
+uXj
 uXj
 xZu
 gbL
@@ -40846,19 +41464,18 @@ gmX
 gmX
 koD
 gcK
+ktB
+ktB
+ggK
+ggK
+oDm
+ggK
+vtv
+gcK
 gcK
 gcK
 gcK
 ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -40869,7 +41486,8 @@ gbL
 gbL
 gcK
 gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -40951,8 +41569,8 @@ kzs
 sNC
 kzs
 xGv
-fGl
-fIk
+dAX
+lJx
 sHu
 xEc
 xEc
@@ -41019,7 +41637,7 @@ gbL
 gbL
 gbL
 xZu
-fPl
+uXj
 uXj
 xZu
 gcK
@@ -41104,17 +41722,17 @@ gmX
 koD
 gcK
 ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
+hBr
+ggK
+ggK
+nHC
+ggK
+ggK
+hBr
 gcK
+gcK
+gcK
+ktB
 gcK
 gcK
 gcK
@@ -41123,10 +41741,10 @@ gcK
 gcK
 gbL
 gbL
+gcK
+gcK
 gbL
-gcK
-gcK
-gcK
+gbL
 gcK
 gcK
 gcK
@@ -41276,7 +41894,7 @@ gbL
 gbL
 gbL
 xZu
-fPl
+uXj
 uXj
 xZu
 gcK
@@ -41361,6 +41979,29 @@ snB
 koD
 gcK
 ktB
+ggK
+jlH
+ggK
+ggK
+ggK
+ggK
+ggK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gbL
+gbL
+gcK
+gcK
+gbL
+gbL
 ktB
 gcK
 gcK
@@ -41370,28 +42011,6 @@ gcK
 gcK
 gcK
 gcK
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -41405,10 +42024,9 @@ gbL
 gbL
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -41533,7 +42151,7 @@ gcK
 gcK
 gcK
 xZu
-fPl
+uXj
 uXj
 xZu
 gcK
@@ -41618,11 +42236,14 @@ snB
 koD
 gcK
 ktB
-gcK
-gcK
-gcK
 ggK
-hBr
+ggK
+ggK
+oDR
+ggK
+ggK
+xKr
+ggK
 gcK
 gcK
 gcK
@@ -41630,6 +42251,26 @@ gcK
 gcK
 ktB
 gcK
+ktB
+gcK
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -41643,29 +42284,6 @@ gbL
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
 gbL
 gbL
 gcK
@@ -41790,7 +42408,7 @@ gcK
 gcK
 gcK
 xZu
-fPl
+uXj
 uXj
 xZu
 gcK
@@ -41875,18 +42493,41 @@ snB
 koD
 gcK
 ktB
-gcK
+dMk
+ggK
+nHC
+ggK
+ggK
+wnA
+wnA
+wnA
 hBr
-ggK
-ggK
-ggK
-gcK
 gcK
 gcK
 gcK
 gcK
 ktB
 gcK
+ktB
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -41897,32 +42538,9 @@ gbL
 gbL
 gbL
 gbL
-gbL
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
 gbL
 gbL
 gcK
@@ -42047,7 +42665,7 @@ gcK
 gcK
 gcK
 xZu
-fPl
+uXj
 uXj
 xZu
 gcK
@@ -42132,29 +42750,30 @@ apk
 koD
 gcK
 ktB
-gcK
 ggK
 ggK
-qTN
 ggK
-kHQ
-gcK
+ggK
+ggK
+wnA
+ggK
+ggK
+ggK
+ggK
 gcK
 gcK
 gcK
 ktB
 gcK
-gcK
-gcK
-gcK
-gcK
+ktB
 gcK
 gbL
 gbL
 gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -42172,14 +42791,13 @@ gcK
 gcK
 gcK
 gbL
+gcK
+gcK
+gcK
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -42304,7 +42922,7 @@ gcK
 gcK
 gcK
 xZu
-fPl
+uXj
 uXj
 xZu
 gcK
@@ -42389,26 +43007,23 @@ cdc
 koD
 gcK
 ktB
+ggK
+ggK
+ggK
+ggK
+ggK
 hBr
 ggK
 ggK
-nHC
-ggK
-ggK
+wnA
+wnA
+wnA
 hBr
-gcK
-gcK
 gcK
 ktB
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
 gbL
 gbL
 gbL
@@ -42428,15 +43043,18 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
 gbL
+gcK
+gcK
+gcK
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -42561,7 +43179,7 @@ gcK
 gcK
 gcK
 xZu
-fPl
+uXj
 uXj
 xZu
 gcK
@@ -42646,33 +43264,34 @@ cdc
 koD
 gcK
 ktB
-ggK
-lFe
-ggK
+hBr
 ggK
 ggK
-ggK
+oTc
 ggK
 gcK
 gcK
 gcK
-ktB
-ktB
-ktB
-ktB
+hBr
+ggK
+ggK
+hBr
 gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
 ktB
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -42687,13 +43306,12 @@ gcK
 gcK
 gbL
 gbL
+gcK
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -42818,7 +43436,7 @@ gcK
 gcK
 gcK
 xZu
-fPl
+uXj
 uXj
 xZu
 eoI
@@ -42903,30 +43521,30 @@ cdc
 koD
 gcK
 ktB
-ggK
-ggK
-ggK
-rOT
-ggK
-ggK
-xKr
-ggK
+gcK
+gcK
+gcK
+hBr
 gcK
 gcK
 gcK
 gcK
+hBr
+xAq
+ggK
+hBr
 gcK
 ktB
-gcK
 ktB
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
 ktB
+ktB
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -42942,15 +43560,15 @@ gcK
 gcK
 gcK
 gcK
+gcK
 gbL
 gbL
+gcK
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -43075,7 +43693,7 @@ gcK
 gbL
 gbL
 xZu
-fPl
+uXj
 uXj
 uXj
 eoI
@@ -43160,32 +43778,32 @@ gmX
 koD
 gcK
 ktB
-iPY
-ggK
-nHC
-ggK
-ggK
-wnA
-wnA
-wnA
-hBr
-gcK
-gcK
-gcK
-gcK
 ktB
-gcK
 ktB
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+ktB
 ktB
 gcK
 gcK
+dCV
+dCV
+dCV
+xBK
+aIJ
+dCV
+dCV
+dCV
+gcK
+gcK
+ktB
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -43199,15 +43817,15 @@ gcK
 gcK
 gcK
 gcK
+gcK
 gbL
 gbL
+gcK
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -43333,7 +43951,7 @@ gcK
 gbL
 xZu
 mwO
-fPl
+uXj
 uXj
 eoI
 cos
@@ -43416,33 +44034,33 @@ erY
 ajy
 koD
 gcK
-ktB
-ggK
-ggK
-ggK
-ggK
-ggK
-wnA
-ggK
-ggK
-ggK
-ggK
 gcK
 gcK
-gcK
-ktB
-gcK
-ktB
-gcK
-gbL
-gbL
-gbL
-ktB
 ktB
 ktB
 ktB
 gcK
 gcK
+dCV
+wSj
+tYk
+tYk
+vJB
+tYk
+fTl
+dCV
+gcK
+gcK
+ktB
+ktB
+ktB
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -43456,15 +44074,15 @@ gcK
 gcK
 gcK
 gcK
+gcK
 gbL
 gbL
+gcK
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -43590,7 +44208,7 @@ gcK
 gcK
 gbL
 mwO
-fPl
+uXj
 uXj
 eoI
 cos
@@ -43673,32 +44291,32 @@ erY
 gmX
 koD
 gcK
+gcK
+gcK
 ktB
-ggK
-ggK
-ggK
-ggK
-ggK
-hBr
-ggK
-ggK
-xcA
-xcA
-xcA
 dCV
-gcK
+dCV
+dCV
+dCV
+dCV
+tYk
+mXL
+tYk
+vJB
+fCe
+vJB
+dCV
+dCV
+dCV
+dCV
+dCV
 ktB
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-ktB
-ktB
-ktB
-gbL
-gbL
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -43713,15 +44331,15 @@ gcK
 gcK
 gcK
 gcK
+gcK
 gbL
 gbL
+gcK
+gcK
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -43847,7 +44465,7 @@ qFk
 qFk
 qFk
 mwO
-fPl
+uXj
 uXj
 eoI
 cos
@@ -43930,32 +44548,29 @@ erY
 gmX
 koD
 gcK
+gcK
+gcK
 ktB
-hBr
-ggK
-ggK
-rTM
-ggK
-gcK
-gcK
-gcK
 dCV
-pMh
-pMh
+wSJ
+tYk
+vuH
 dCV
-gcK
+vJB
+wXq
+cDf
+xwW
+wXK
+vJB
+dCV
+jMT
+tYk
+pmM
+dCV
 ktB
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-ktB
-ktB
-ktB
-gbL
-gbL
 gcK
 gcK
 gcK
@@ -43968,17 +44583,20 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
+gcK
+gcK
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -44187,30 +44805,30 @@ erY
 gmX
 koD
 gcK
+gcK
+gcK
 ktB
-gcK
-gcK
-gcK
-hBr
-gcK
-gcK
-gcK
-gcK
 dCV
-yiJ
-pMh
+pcv
+vJB
+vJB
+aIJ
+hdT
+tYk
+vJB
+tYk
+vJB
+tYk
+aIJ
+tYk
+tYk
+qXJ
 dCV
-gcK
 ktB
-ktB
-ktB
-ktB
-gbL
-gbL
-gbL
-ktB
-ktB
-ktB
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -44225,13 +44843,13 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
@@ -44447,27 +45065,27 @@ gcK
 ktB
 ktB
 ktB
+dCV
+pgV
+tsS
+vvc
+dCV
+wSP
+wXK
+pmM
+kcT
+mEl
+fTl
+dCV
+sUi
+qvM
+emQ
+dCV
+ktB
+ktB
 ktB
 ktB
 gcK
-gcK
-dCV
-dCV
-dCV
-pQF
-wyX
-dCV
-dCV
-dCV
-gcK
-gcK
-ktB
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
 gbL
 gbL
 gcK
@@ -44482,13 +45100,13 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
@@ -44619,7 +45237,7 @@ otr
 qLC
 lwj
 lwj
-fPl
+uXj
 uXj
 uXj
 rjE
@@ -44701,32 +45319,32 @@ cdc
 vnc
 koD
 gcK
-gcK
-gcK
 ktB
-ktB
-ktB
-gcK
-gcK
 dCV
-qQp
-lLu
-lLu
-oOZ
-lLu
-qXr
 dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+shU
+shU
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+dCV
+ktB
 gcK
 gcK
 ktB
 ktB
-ktB
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
@@ -44739,13 +45357,13 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
@@ -44877,7 +45495,7 @@ sLr
 xGH
 aBH
 cFe
-fPl
+uXj
 uXj
 uXj
 uXj
@@ -44887,8 +45505,8 @@ uXj
 uXj
 lwj
 lwj
-syr
-hZs
+uXj
+mvv
 gcK
 gcK
 gcK
@@ -44958,35 +45576,36 @@ cdc
 snB
 koD
 gcK
+ktB
+dCV
+tYk
+vJB
+pVl
+tAz
+dCV
+vJB
+wSC
+tYk
+tYk
+vJB
+vJB
+pUx
+vJB
+dCV
+rmy
+vJB
+umd
+umd
+dCV
+ktB
 gcK
 gcK
 ktB
-dCV
-dCV
-dCV
-dCV
-dCV
-lLu
-ltD
-lLu
-oOZ
-ngF
-oOZ
-dCV
-dCV
-dCV
-dCV
-dCV
 ktB
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -45001,8 +45620,7 @@ gcK
 gbL
 gbL
 gbL
-gbL
-gbL
+gcK
 gbL
 gbL
 gbL
@@ -45135,7 +45753,7 @@ tBN
 bpD
 ekW
 gaV
-fPl
+uXj
 uXj
 uXj
 uXj
@@ -45144,7 +45762,7 @@ uXj
 uXj
 lwj
 lwj
-fPl
+uXj
 uXj
 gcK
 gcK
@@ -45215,36 +45833,36 @@ cdc
 snB
 koD
 gcK
+ktB
+dCV
+jmC
+dCV
+wSP
+tYk
+dCV
+vJB
+vJB
+lBX
+tYk
+vJB
+vJB
+vJB
+ldI
+dCV
+sdM
+vJB
+wCZ
+lbo
+dCV
+ktB
 gcK
 gcK
 ktB
-dCV
-saz
-lLu
-vYZ
-dCV
-oOZ
-bpB
-eGu
-wtY
-oOk
-oOZ
-dCV
-sXG
-lLu
-kGI
-dCV
 ktB
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -45262,8 +45880,8 @@ gbL
 gbL
 gbL
 gbL
-gbL
-gbL
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -45401,7 +46019,7 @@ mfD
 xGH
 lwj
 lwj
-fPl
+uXj
 uXj
 gcK
 gcK
@@ -45472,32 +46090,32 @@ bJB
 gmX
 koD
 gcK
+ktB
+dCV
+jFb
+lPU
+vJB
+vJB
+shU
+xwW
+baS
+tYk
+tYk
+tYk
+xwW
+oPR
+wZd
+shU
+kcT
+xwW
+umd
+qGr
+dCV
+ktB
 gcK
 gcK
 ktB
-dCV
-scr
-oOZ
-oOZ
-wyX
-aYu
-lLu
-oOZ
-lLu
-oOZ
-lLu
-wyX
-lLu
-lLu
-bLa
-dCV
 ktB
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
 gcK
 gcK
 gcK
@@ -45658,7 +46276,7 @@ fyf
 tBN
 lwj
 lwj
-fPl
+uXj
 uXj
 gcK
 gcK
@@ -45730,35 +46348,38 @@ snB
 koD
 gcK
 ktB
-ktB
-ktB
 dCV
-sea
-wbP
-pme
+jMW
+lRQ
+tYk
+vJB
+shU
+tYk
+wZd
+tYk
+vJB
+hdT
+vJB
+hCv
+vJB
+shU
+hdT
+xwW
+vJB
+vJB
 dCV
-sDJ
-oOk
-kGI
-neD
-mBA
-qXr
-dCV
-nIJ
-jdK
-jAK
-dCV
 ktB
-ktB
+gcK
+gcK
 ktB
 ktB
 gcK
-gbL
-gbL
 gcK
 gcK
 gcK
 gcK
+gbL
+gcK
 gcK
 gbL
 gbL
@@ -45776,10 +46397,7 @@ gbL
 gbL
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
+gcK
 gcK
 gcK
 gbL
@@ -45915,7 +46533,7 @@ fyf
 jnN
 lwj
 lwj
-fPl
+uXj
 uXj
 uXj
 gcK
@@ -45988,24 +46606,24 @@ koD
 gcK
 ktB
 dCV
+jFb
+lPU
+qfp
+tCc
 dCV
+vJB
+vJB
+vJB
+tYk
+tYk
+vJB
+vuH
+fEi
 dCV
-dCV
-dCV
-dCV
-dCV
-dCV
-dCV
-jcn
-jcn
-dCV
-dCV
-dCV
-dCV
-dCV
-dCV
-dCV
-dCV
+vJB
+lBX
+vJB
+jOw
 dCV
 ktB
 gcK
@@ -46018,6 +46636,8 @@ gcK
 gcK
 gcK
 gbL
+gcK
+gcK
 gbL
 gbL
 gbL
@@ -46034,9 +46654,7 @@ gbL
 gbL
 gbL
 gbL
-gbL
-gbL
-gbL
+gcK
 gcK
 gcK
 gbL
@@ -46172,7 +46790,7 @@ wUL
 tBN
 lwj
 lwj
-fPl
+uXj
 kCH
 uXj
 gcK
@@ -46245,24 +46863,24 @@ koD
 gcK
 ktB
 dCV
-lLu
-oOZ
-sxT
-wjr
+jYg
+lUg
+wXR
+xwW
 dCV
-oOZ
-tzZ
-lLu
-lLu
-oOZ
-oOZ
-xmW
-oOZ
+vJB
+cDf
+xcb
+vJB
+vJB
+qvM
+vJB
+tYk
 dCV
-vBp
-oOZ
-xWC
-xWC
+xwW
+bmj
+qbq
+icm
 dCV
 ktB
 gcK
@@ -46275,6 +46893,8 @@ gcK
 gcK
 gcK
 gbL
+gcK
+gcK
 gbL
 gbL
 gbL
@@ -46291,9 +46911,7 @@ gbL
 gbL
 gbL
 gbL
-gbL
-gbL
-gbL
+gcK
 gcK
 gcK
 gbL
@@ -46335,11 +46953,11 @@ tXe
 nPy
 nPZ
 sGG
-vUA
-vUA
-vUA
-vUA
-vUA
+rhr
+rhr
+rhr
+rhr
+rhr
 cpK
 cpK
 bTf
@@ -46429,7 +47047,7 @@ qFk
 tBN
 lwj
 lwj
-fPl
+uXj
 uXj
 uXj
 uXj
@@ -46488,7 +47106,7 @@ fmQ
 fyf
 fyf
 fyf
-fyf
+hwC
 gcK
 gts
 fyf
@@ -46502,24 +47120,24 @@ koD
 gcK
 ktB
 dCV
-lVR
 dCV
-sDJ
-lLu
 dCV
-oOZ
-oOZ
-raq
-lLu
-oOZ
-oOZ
-oOZ
-emZ
 dCV
-cwW
-oOZ
-eLd
-wdA
+aIJ
+dCV
+dCV
+dLO
+dLO
+xCi
+xCi
+dLO
+dLO
+dCV
+dCV
+aIJ
+dCV
+dCV
+dCV
 dCV
 ktB
 gcK
@@ -46532,12 +47150,12 @@ gcK
 gcK
 gcK
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
@@ -46592,11 +47210,11 @@ tNa
 cpK
 lvS
 eJe
-vUA
-uok
-atX
-bzf
-vUA
+rhr
+cNF
+jiR
+wjR
+rhr
 cpK
 cpK
 elT
@@ -46686,7 +47304,7 @@ cny
 sLr
 lwj
 lwj
-fPl
+lqV
 uXj
 uXj
 uXj
@@ -46745,7 +47363,7 @@ fmQ
 fyf
 fyf
 fyf
-fyf
+hwC
 fyf
 thG
 fyf
@@ -46758,27 +47376,27 @@ snB
 koD
 gcK
 ktB
+ktB
+ktB
 dCV
-mxq
-oUO
-oOZ
-oOZ
-jcn
-wtY
-cKp
-lLu
-lLu
-lLu
-wtY
-kJP
-jTQ
-jcn
-neD
-wtY
-xWC
-mMn
+eOc
+vJB
+eOc
+dCV
+dLO
+xvI
+xvI
+xvI
+xvI
+dLO
+dCV
+sdM
+vJB
+mOp
 dCV
 ktB
+ktB
+ktB
 gcK
 gcK
 ktB
@@ -46789,13 +47407,13 @@ gcK
 gcK
 gcK
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -46849,11 +47467,11 @@ tXe
 cpK
 jSN
 eJe
-vUA
-aRc
-bzV
-bzf
-eDx
+rhr
+iuE
+szG
+wjR
+raV
 cpK
 cpK
 rRi
@@ -46943,7 +47561,7 @@ peu
 gun
 lwj
 lwj
-fPl
+uXj
 uXj
 uXj
 uXj
@@ -47002,7 +47620,7 @@ eRJ
 fyf
 fyf
 fyf
-fyf
+hwC
 fyf
 thG
 fyf
@@ -47014,45 +47632,45 @@ wGJ
 snB
 koD
 gcK
+gcK
+gcK
 ktB
 dCV
-mRt
-ppN
-lLu
-oOZ
-jcn
-lLu
-jTQ
-lLu
-oOZ
-aYu
-oOZ
-bHF
-oOZ
-jcn
-aYu
-wtY
-oOZ
-oOZ
+qiJ
+vJB
+dCV
+dCV
+dLO
+xvI
+xvI
+xvI
+xvI
+dLO
+dCV
+dCV
+vJB
+rSe
 dCV
 ktB
-gcK
-gcK
 ktB
 ktB
 gcK
 gcK
+ktB
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -47106,11 +47724,11 @@ cpK
 cpK
 cpK
 eJe
-vUA
-bzf
-bCm
-bzf
-vUA
+rhr
+wjR
+juV
+wjR
+rhr
 cpK
 cpK
 cpK
@@ -47200,7 +47818,7 @@ peu
 oWC
 lwj
 lwj
-fPl
+uXj
 uXj
 kCH
 uXj
@@ -47259,7 +47877,7 @@ fmQ
 fyf
 fyf
 fyf
-fyf
+hwC
 fyf
 thG
 fyf
@@ -47271,45 +47889,45 @@ cdc
 snB
 koD
 gcK
+gcK
+gcK
 ktB
 dCV
-mxq
-oUO
-sTe
-wpo
+xbA
 dCV
-oOZ
-oOZ
-oOZ
-lLu
-lLu
-oOZ
-vYZ
-gnj
 dCV
-oOZ
-raq
-oOZ
-phF
+dLO
+dLO
+xvI
+xvI
+xvI
+xvI
+dLO
+dLO
+dCV
+dCV
+mOp
 dCV
 ktB
 gcK
 gcK
-ktB
-ktB
 gcK
 gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -47363,11 +47981,11 @@ sCz
 sCz
 sCz
 qLO
-vUA
-bzf
-bPH
-hUW
-vUA
+rhr
+wjR
+nLX
+uug
+rhr
 cpK
 cpK
 cpK
@@ -47457,7 +48075,7 @@ peu
 gun
 lwj
 lwj
-fPl
+uXj
 uXj
 uXj
 uXj
@@ -47528,45 +48146,45 @@ dFQ
 gmX
 koD
 gcK
-ktB
+gcK
+gcK
+gcK
 dCV
-mWG
-pHi
-taG
-wtY
 dCV
-oOZ
-eGu
-okn
-oOZ
-oOZ
-jdK
-oOZ
-lLu
 dCV
-wtY
-wYo
-bSE
-pYb
+gcK
+gcK
+xvI
+xvI
+xJA
+xvI
+xvI
+gcK
+gcK
+gcK
+dCV
+dCV
 dCV
 ktB
 gcK
 gcK
-ktB
-ktB
 gcK
 gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gcK
+gcK
+gcK
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -47714,9 +48332,9 @@ cny
 sLr
 lwj
 lwj
-fPl
 uXj
-lqV
+uXj
+uXj
 uXj
 uXj
 uXj
@@ -47784,46 +48402,46 @@ hbW
 cdc
 vnc
 bfu
-gcK
-ktB
-dCV
-dCV
-dCV
-dCV
-wyX
-dCV
-dCV
-dLO
-dLO
-cly
-cly
-dLO
-dLO
-dCV
-dCV
-wyX
-dCV
-dCV
-dCV
-dCV
-ktB
+vfu
 gcK
 gcK
-ktB
-ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+xvI
+xvI
+xvI
+xvI
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
 gcK
 gcK
 gbL
+gcK
+gcK
+gcK
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -47872,7 +48490,7 @@ sgz
 sgz
 koD
 ezX
-aaS
+jNs
 mfN
 qQf
 qQf
@@ -47971,7 +48589,7 @@ qFk
 vAe
 lwj
 lwj
-fPl
+uXj
 uXj
 uXj
 uXj
@@ -48040,34 +48658,34 @@ onk
 hbW
 cdc
 snB
-wwM
+fLc
+pJt
+cwg
+pJt
+pJt
+pJt
+pJt
+pJt
+pJt
+qiU
+qiU
+wbi
+xLh
+pJt
+pJt
+pJt
+pJt
+pJt
+pJt
+pJt
+tQY
+htp
+exp
+ujr
+exp
+pAm
 gcK
-ktB
-ktB
-ktB
-dCV
-tkZ
-oOZ
-tkZ
-dCV
-dLO
-muh
-muh
-muh
-muh
-dLO
-dCV
-cwW
-oOZ
-nvV
-dCV
-ktB
-ktB
-ktB
 gcK
-gcK
-ktB
-ktB
 gcK
 gcK
 gcK
@@ -48075,12 +48693,12 @@ gcK
 gcK
 gbL
 gbL
+gcK
+gcK
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -48228,8 +48846,8 @@ cWG
 cWG
 daU
 bpD
-fPl
 uXj
+lqV
 uXj
 uXj
 uXj
@@ -48296,35 +48914,35 @@ aJb
 hBN
 erY
 lZP
-snB
-koD
+hOl
+pGa
+pGa
+pGa
+pGa
+pGa
+pGa
+pGa
+pGa
+pGa
+pGa
+pGa
+qPS
+tNI
+pGa
+csm
+pGa
+pGa
+pGa
+tNI
+sKp
+tBB
+exp
+bnG
+exp
+exp
+htp
 gcK
 gcK
-gcK
-ktB
-dCV
-tJx
-oOZ
-dCV
-dCV
-dLO
-muh
-muh
-muh
-muh
-dLO
-dCV
-dCV
-oOZ
-nUs
-dCV
-ktB
-ktB
-ktB
-gcK
-gcK
-ktB
-ktB
 gcK
 gcK
 gcK
@@ -48332,12 +48950,12 @@ gcK
 gcK
 gbL
 gbL
+gcK
+gcK
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -48486,7 +49104,7 @@ mfD
 xGH
 bpD
 fyf
-fPl
+uXj
 uXj
 uXj
 uXj
@@ -48553,33 +49171,33 @@ hOl
 sgz
 cdc
 bJB
-gmX
-koD
-gcK
-gcK
-gcK
-ktB
-dCV
-tPt
-dCV
-dCV
-dLO
-dLO
-muh
-muh
-muh
-muh
-dLO
-dLO
-dCV
-dCV
-nvV
-dCV
-ktB
-gcK
-gcK
-gcK
-gcK
+hOl
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+uRN
+uRN
+uRN
+xLl
+vSV
+vSV
+vSV
+uRN
+uRN
+vRK
+pbu
+ycD
+htp
+exp
+exp
+exp
+htp
 gcK
 gcK
 gcK
@@ -48589,12 +49207,12 @@ gcK
 gcK
 gbL
 gbL
+gcK
+gcK
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -48692,7 +49310,7 @@ ubg
 koD
 dMW
 fyf
-fyf
+lWZ
 fyf
 fyf
 fyf
@@ -48810,48 +49428,48 @@ imk
 qoS
 erY
 cdc
-snB
-koD
+hOl
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+oBQ
+ehN
+vSV
+vSV
+vRK
+xMz
+eeC
+tPt
+nXd
+oBQ
+oBQ
+oBQ
+pei
+ymd
+htp
+exp
+exp
+hkz
+htp
 gcK
 gcK
 gcK
-gcK
-dCV
-dCV
-dCV
-gcK
-gcK
-wKP
-wKP
-bvq
-wKP
-wKP
-gcK
-gcK
-gcK
-dCV
-dCV
-dCV
-ktB
 gcK
 gcK
 gcK
 gcK
 gbL
 gbL
-gbL
-gcK
-gcK
 gcK
 gcK
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -48911,7 +49529,7 @@ ohV
 pfb
 uVw
 xdt
-fyI
+nQu
 ezX
 cpK
 cpK
@@ -48993,7 +49611,7 @@ rss
 tBN
 bpD
 vJP
-gPQ
+kCH
 xKi
 gwi
 vAe
@@ -49068,26 +49686,33 @@ muk
 hbW
 uVo
 snB
-koD
-vfu
+geM
+ees
+cEo
+ees
+ees
+mhL
+ees
+muk
+bDb
+vRK
+vRK
+xcg
+eUp
+udf
+xfk
+eUp
+eUp
+afG
+afG
+xFv
+xFv
+xFv
+xFv
+goG
+xFv
+rVr
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-wKP
-wKP
-wKP
-wKP
-gcK
-gcK
-gcK
-vfu
-vfu
 gcK
 gcK
 gcK
@@ -49095,20 +49720,13 @@ gcK
 gcK
 gcK
 gbL
-gbL
-gbL
 gcK
 gcK
 gcK
 gcK
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -49207,7 +49825,7 @@ koD
 dMW
 fyf
 fyf
-lWZ
+fyf
 fyf
 fyf
 tBN
@@ -49249,7 +49867,7 @@ uRJ
 unW
 tBN
 bpD
-fPl
+uXj
 uXj
 uXj
 uXj
@@ -49325,47 +49943,47 @@ ofX
 iZa
 apk
 apk
-fLc
-fQc
-hqQ
-fQc
-fQc
-fQc
-fQc
-fQc
-fQc
-pWw
-pWw
-cSF
-geR
-fQc
-fQc
-fQc
-fQc
-fQc
-fQc
-fQc
-eGo
-fNz
-fyf
-gxK
-fyf
-stK
-gbL
-gbL
-gbL
+koD
+vfu
+umi
+vfu
+vfu
+vfu
+sUr
+sfB
+bDb
+vSV
+erY
+ycD
+vfu
+wWb
+vfu
+wWb
+xFv
+xFv
+xFv
+xFv
+tAU
+qOd
+pgR
+tar
+xFv
+wGt
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -49425,7 +50043,7 @@ onx
 pfb
 uVw
 xdt
-fyI
+nQu
 rhr
 cpK
 cpK
@@ -49506,7 +50124,7 @@ uRJ
 nrV
 tBN
 bpD
-fPl
+uXj
 uXj
 ush
 uXj
@@ -49582,47 +50200,47 @@ unI
 hbW
 erY
 ubg
-pIN
-pIN
-pIN
-pIN
-pIN
-pIN
-pIN
-pIN
-pIN
-pIN
-pIN
-qXn
-wzg
-pIN
-eFL
-pIN
-pIN
-pIN
-wzg
-tav
-tBB
-dMW
-bBm
-fyf
-fyf
-xJA
-gbL
-gbL
-gbL
+koD
+sUX
+cGJ
+vfu
+sUr
+vfu
+wWb
+xya
+bDb
+bqC
+vRK
+ycD
+vfu
+vfu
+wWb
+vyY
+xFv
+pgR
+xOA
+lRe
+tar
+jCh
+tar
+tar
+xFv
+wGt
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -49839,32 +50457,40 @@ unI
 hbW
 wGJ
 snB
-ehN
-ehN
-ehN
-ehN
-ehN
-ehN
-ehN
-ehN
-ehN
-fAN
-fAN
-fAN
-jTR
-aac
-aac
-aac
-fAN
-fAN
-lCO
-aGO
-pNY
-fNz
-fyf
-fyf
-fyf
-xJA
+koD
+dMW
+cGJ
+wWb
+sUr
+sUr
+qvu
+mzC
+bDb
+uRN
+pbu
+ycD
+wWb
+wWb
+wWb
+vfu
+xFv
+pgR
+tar
+tar
+lnm
+ffT
+xFv
+kCD
+xFv
+xFv
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gbL
 gbL
 gbL
@@ -49872,14 +50498,6 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
 gbL
 gbL
 gcK
@@ -50021,7 +50639,7 @@ uRJ
 mvv
 bpD
 vAe
-fPl
+uXj
 kCH
 qNM
 uXj
@@ -50096,32 +50714,40 @@ unI
 qvQ
 apk
 abN
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-ehN
-aac
-aac
-lCO
-beE
-lcq
-kaj
-gkv
-oBQ
-oBQ
-oBQ
-mdI
-wTf
-fNz
-fyf
-fyf
-pzQ
-xJA
+koD
+dMW
+cGW
+uJP
+sUr
+wWb
+vfu
+unr
+bDb
+uRN
+wTU
+ycD
+kWx
+xFv
+xFv
+xFv
+xFv
+dvG
+tar
+jAn
+egJ
+tar
+xFv
+wgf
+wgf
+xFv
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gbL
 gbL
 gbL
@@ -50129,14 +50755,6 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
 gbL
 gbL
 gcK
@@ -50353,47 +50971,47 @@ unI
 hbW
 erY
 gmX
-geM
-ees
-hDr
-ees
-ees
-pKP
-ees
-muk
-nZd
-lCO
-lCO
-rLn
-dqk
-gqj
-rUC
-dqk
-dqk
-jPE
-jPE
-rlo
-rlo
-rlo
-rlo
-sfD
-rlo
-stK
+koD
+dMW
+lyk
+uKb
+uJP
+sUr
+sUr
+mzC
+bDb
+ndx
+ndx
+ycD
+xPh
+xFv
+dsA
+wgf
+xFv
+xFv
+jDE
+xFv
+xFv
+xnM
+xFv
+fXA
+ste
+xFv
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
 gbL
 gbL
 gbL
 gcK
 gcK
 gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
 gbL
 gbL
 gcK
@@ -50493,7 +51111,7 @@ fyf
 fyf
 fyf
 fyf
-qTY
+fyf
 fyf
 jJb
 fyf
@@ -50611,34 +51229,34 @@ hbW
 erY
 gmX
 koD
-vfu
-hFz
-vfu
-vfu
-vfu
-sUr
-exn
-nZd
-aac
+dMW
+lyk
+fyf
+uKb
+uJP
+wWb
+mzC
+bDb
+wfP
 erY
-pNY
+ymd
 vfu
-wKP
-vfu
-wKP
-rlo
-rlo
-rlo
-rlo
-nCj
-cXP
-nXl
-acI
-rlo
-bjo
-gbL
-gbL
-gbL
+xFv
+oJe
+wgf
+oja
+wgf
+dRu
+oja
+apM
+wgf
+xFv
+dOi
+vIo
+xFv
+gcK
+ktB
+gcK
 gcK
 gcK
 gcK
@@ -50854,12 +51472,12 @@ uqa
 dCU
 rpu
 rpu
-buo
+sik
 uqa
-cfd
+svJ
 fyf
-dCx
-eid
+sMz
+tfn
 fyf
 fyf
 kGc
@@ -50868,34 +51486,34 @@ hbW
 erY
 gmX
 koD
-sUX
-stK
-vfu
-sUr
-vfu
-wKP
-xoZ
-nZd
-iIc
-lCO
-pNY
-vfu
-vfu
-wKP
-oSX
-rlo
-nXl
-gYL
-nWv
-acI
-xne
-acI
-acI
-rlo
-bjo
-gbL
-gbL
-gbL
+dMW
+lyk
+fyf
+fyf
+uKb
+uJP
+mzC
+vwS
+erY
+erY
+ymd
+xTB
+ism
+wgf
+qlX
+yeC
+wgf
+gOs
+wgf
+wgf
+wgf
+xFv
+cFO
+ibB
+xFv
+gcK
+ktB
+gcK
 gcK
 gcK
 gcK
@@ -51113,11 +51731,11 @@ rpu
 rpu
 rpu
 yjG
-cgy
+swe
 fyf
 fyf
-eid
-bBm
+tfn
+gNB
 fyf
 kGc
 unI
@@ -51126,33 +51744,33 @@ erY
 ubg
 koD
 dMW
-stK
-wKP
-sUr
-sUr
-uFp
-mkV
-nZd
-fAN
-aGO
-pNY
-wKP
-wKP
-wKP
-vfu
-rlo
-nXl
-acI
-acI
-lQK
-tmp
-rlo
-xby
-rlo
-rlo
-gbL
-gbL
-gbL
+lyk
+rVr
+rVr
+mDf
+rVr
+mzC
+vxd
+erY
+erY
+tBB
+yfo
+fxe
+wgf
+qlX
+tAU
+tAU
+wrG
+imq
+yeC
+wgf
+xFv
+xFv
+xFv
+xFv
+gcK
+ktB
+gcK
 gcK
 gcK
 gcK
@@ -51365,15 +51983,15 @@ fyf
 fyf
 fyf
 uqa
-anc
+rzn
 rpu
-nSQ
+oqA
 plt
 uqa
-chK
-dkE
-cfd
-eid
+swi
+sIa
+svJ
+tfn
 fyf
 fyf
 kGc
@@ -51383,54 +52001,54 @@ erY
 uVo
 koD
 dMW
-hLs
-sHM
-sUr
-wKP
-vfu
-wFp
-nZd
-fAN
-hIY
-pNY
-ybi
-rlo
-rlo
-rlo
-rlo
-iEQ
-acI
-evz
-iVc
-acI
-rlo
-vrJ
-vrJ
-rlo
-gbL
-gbL
-gbL
+rVr
+rVr
+kmX
+kmX
+rVr
+rVr
+bDb
+vSV
+erY
+xac
+wWb
+arr
+gOs
+wgf
+qlX
+qlX
+qlX
+qlX
+qlX
+wgf
+kBs
+tar
+pth
+xFv
 gcK
-gcK
-gcK
-gbL
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
 gcK
 gcK
 gcK
 gcK
 gbL
 gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -51626,11 +52244,11 @@ rpu
 rpu
 qfV
 rpu
-aLF
+rQG
 fyf
-dCx
-cgy
-eid
+sMz
+swe
+tfn
 fyf
 fyf
 kGc
@@ -51640,54 +52258,54 @@ erY
 gmX
 koD
 dMW
-xJA
-dGR
-sHM
-sUr
-sUr
-mkV
-nZd
-rcL
-rcL
-pNY
-reU
-rlo
-wYs
-vrJ
-rlo
-rlo
-vpl
-rlo
-rlo
-bAJ
-rlo
-sKX
-fPP
-rlo
-gbL
-gbL
-gbL
+rVr
+enp
+kuh
+mEe
+qzJ
+rVr
+bDb
+vSV
+nBC
+ycD
+vfu
+dzz
+wgf
+dRu
+wgf
+wgf
+wgf
+wgf
+dRu
+gOs
+xFv
+adS
+wqe
+xFv
 gcK
-gcK
-gcK
-gbL
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
 gcK
 gcK
 gcK
 gcK
 gbL
 gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -51879,14 +52497,14 @@ fyf
 fyf
 fyf
 uqa
-avO
+rAf
 rpu
 rpu
-bwF
+sio
 uqa
-cjG
-cgy
-chK
+sxs
+swe
+swi
 uqa
 fyf
 fyf
@@ -51897,44 +52515,31 @@ erY
 gmX
 koD
 dMW
-xJA
-fyf
-dGR
-sHM
-wKP
-mkV
-nZd
-rYd
-erY
-wTf
+rVr
+etC
+kmX
+mHv
+qAi
+rVr
+vwS
+vSV
+uRN
+ycD
 vfu
-rlo
-eOY
-vrJ
-uBK
-vrJ
-nms
-uBK
-bQU
-vrJ
-rlo
-vkb
-uEJ
-rlo
+fxe
+oXK
+tAU
+dhB
+wgf
+wgf
+dhB
+tAU
+oXK
+xFv
+xFv
+xFv
+xFv
 gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
@@ -51942,9 +52547,22 @@ gcK
 gcK
 gbL
 gbL
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -52137,12 +52755,12 @@ fyf
 fyf
 uqa
 uqa
-aLF
+rQG
 yjG
 uqa
 uqa
 uqa
-aLF
+rQG
 uqa
 uqa
 fyf
@@ -52154,44 +52772,31 @@ erY
 gmX
 koD
 dMW
-xJA
-fyf
-fyf
-dGR
-sHM
-mkV
-fTj
-erY
-erY
-wTf
-hrs
-qXi
-vrJ
-tkF
-drK
-vrJ
-fLR
-vrJ
-vrJ
-vrJ
-rlo
-bvV
-aPr
-rlo
-gcK
-ktB
+rVr
+rVr
+kvZ
+mSw
+rVr
+rVr
+hEq
+uRN
+uRN
+ycD
+vfu
+xFv
+ukL
+tAU
+qRz
+wgf
+wgf
+wBk
+tAU
+ukL
+xFv
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
@@ -52199,9 +52804,22 @@ gcK
 gcK
 gbL
 gbL
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -52397,9 +53015,9 @@ rpu
 rpu
 rpu
 uqa
-bZU
+smh
 rpu
-kyu
+rXu
 qfV
 uqa
 fyf
@@ -52411,32 +53029,27 @@ erY
 gmX
 koD
 dMW
-xJA
-stK
-stK
-pYF
-stK
-mkV
-hGx
-erY
-erY
-tBB
-jKq
-xfR
-vrJ
-tkF
-nCj
-nCj
-anK
-iMl
-drK
-vrJ
-rlo
-rlo
-rlo
-rlo
-gcK
-ktB
+fyf
+rVr
+wsy
+wsy
+rVr
+rVr
+hEq
+wom
+uRN
+ymd
+vfu
+xFv
+xFv
+xFv
+xFv
+xFv
+xFv
+xFv
+xFv
+xFv
+xFv
 gcK
 gcK
 gcK
@@ -52446,9 +53059,6 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
@@ -52457,8 +53067,16 @@ gcK
 gbL
 gbL
 gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -52650,13 +53268,13 @@ fyf
 fyf
 fyf
 uqa
-aFw
+rDd
 qfV
 rpu
 vde
 rpu
-cpJ
-dHX
+syq
+sNM
 rpu
 uqa
 fyf
@@ -52668,32 +53286,17 @@ erY
 ubg
 koD
 dMW
-stK
-stK
-qFI
-qFI
-stK
-stK
-nZd
-aac
-erY
-qoJ
-wKP
-mFs
-fLR
-vrJ
-tkF
-tkF
-tkF
-tkF
-tkF
-vrJ
-clO
-acI
-jkY
-rlo
-gcK
-ktB
+fyf
+fyf
+fyf
+fyf
+fyf
+hzb
+wKo
+gWo
+eMD
+hzb
+jMC
 gcK
 gcK
 gcK
@@ -52703,19 +53306,34 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -52912,8 +53530,8 @@ rpu
 rpu
 uqa
 uqa
-cIm
-cIm
+szn
+szn
 rpu
 uqa
 fyf
@@ -52925,32 +53543,16 @@ erY
 snB
 koD
 dMW
-stK
-iZE
-ncU
-qcq
-uTA
-stK
-nZd
-aac
-nBC
-pNY
-vfu
-eKz
-vrJ
-nms
-vrJ
-vrJ
-vrJ
-vrJ
-nms
-fLR
-rlo
-cek
-uLh
-rlo
-gcK
-ktB
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+hCs
+pfl
+fyf
+fyf
 gcK
 gcK
 gcK
@@ -52960,19 +53562,35 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -53166,12 +53784,12 @@ fyf
 uqa
 uqa
 rpu
-kyu
+rXu
 uqa
 vUF
 rpu
 rpu
-dKt
+sSr
 uqa
 fyf
 fyf
@@ -53180,32 +53798,25 @@ unI
 uOF
 ubg
 uVo
-koD
+crA
 dMW
-stK
-jpd
-qFI
-rrB
-tHf
-stK
-fTj
-aac
-fAN
-pNY
-vfu
-xfR
-weI
-nCj
-ocX
-vrJ
-vrJ
-ocX
-nCj
-weI
-rlo
-rlo
-rlo
-rlo
+lsC
+qsL
+vwn
+wzm
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
 gcK
 gcK
 gcK
@@ -53217,19 +53828,26 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -53426,7 +54044,7 @@ rpu
 olW
 uqa
 vUF
-nSQ
+oqA
 qfV
 rpu
 uqa
@@ -53439,27 +54057,23 @@ dmL
 snB
 koD
 dMW
-stK
-stK
-fGC
-qhs
-stK
-stK
-sZD
-fAN
-fAN
-pNY
-vfu
-rlo
-eFs
-nCj
-pfc
-vrJ
-vrJ
-whU
-nCj
-eFs
-rlo
+jqp
+ewY
+vYv
+vYv
+qPa
+uok
+pim
+pim
+pim
+pim
+pim
+dit
+mhI
+mhI
+lpH
+iAr
+dit
 gcK
 gcK
 gcK
@@ -53474,19 +54088,23 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -53679,8 +54297,8 @@ fyf
 fyf
 fyf
 uqa
-aQN
-blH
+rRo
+saf
 uqa
 vUF
 rpu
@@ -53696,27 +54314,29 @@ xEs
 apk
 koD
 dMW
-fyf
-stK
-nNI
-nNI
-stK
-stK
-snB
-ioQ
-fAN
-wTf
-vfu
-rlo
-rlo
-rlo
-rlo
-rlo
-rlo
-rlo
-rlo
-rlo
-rlo
+cPB
+tkh
+vYv
+vYv
+rdW
+upg
+pim
+pim
+pim
+pim
+yhE
+lbZ
+ccj
+mhI
+mhI
+ccj
+dit
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -53727,23 +54347,21 @@ gcK
 gcK
 gcK
 gbL
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
 gbL
 gcK
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -53939,9 +54557,9 @@ uqa
 uqa
 uqa
 uqa
-aLF
+rQG
 itJ
-aLF
+rQG
 uqa
 uqa
 fyf
@@ -53953,37 +54571,26 @@ erY
 gmX
 koD
 dMW
-fyf
+dit
+eHZ
+vYv
+vYv
+rry
+pim
+pim
+pim
+pim
+pim
+yiF
+jUR
+eLu
+mhI
+mhI
+lJE
+dit
 gcK
 gcK
 gcK
-gcK
-gcK
-snB
-gWo
-eMD
-hzb
-jMC
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
 gcK
 gcK
 gcK
@@ -53997,6 +54604,17 @@ gcK
 gcK
 gcK
 gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
@@ -54210,37 +54828,26 @@ erY
 gmX
 koD
 dMW
-fyf
+dcW
+vYv
+vYv
+vYv
+dit
+dit
+wjx
+woy
+wjx
+mMI
+dit
+dit
+rJg
+mhI
+mhI
+ezE
+dit
 gcK
 gcK
 gcK
-gcK
-gcK
-aac
-pfl
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
 gcK
 gcK
 gcK
@@ -54254,6 +54861,17 @@ gcK
 gcK
 gcK
 gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
@@ -54467,28 +55085,23 @@ erY
 gmX
 koD
 dMW
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-aac
-pfl
-fyf
-uey
-fyf
-uVs
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+vYv
+vYv
+vYv
+vYv
+rAi
+kgD
+vYv
+vYv
+vYv
+vYv
+vYv
+dit
+uSA
+uSA
+uSA
+uSA
+dit
 gcK
 gcK
 gcK
@@ -54497,7 +55110,6 @@ gcK
 gcK
 gcK
 gcK
-gbL
 gcK
 gcK
 gcK
@@ -54507,10 +55119,16 @@ gcK
 gcK
 gbL
 gbL
-gbL
 gcK
 gcK
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
@@ -54724,25 +55342,23 @@ erY
 gmX
 koD
 dMW
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-aac
-pWN
-aRW
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+dit
+eNs
+vYv
+vYv
+rQL
+kgD
+vYv
+vYv
+vYv
+vYv
+vYv
+enR
+mhI
+mhI
+mhI
+mhI
+dit
 gcK
 gcK
 gcK
@@ -54751,10 +55367,6 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-ktB
-gbL
 gcK
 gcK
 gcK
@@ -54764,7 +55376,13 @@ gcK
 gcK
 gbL
 gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -54966,7 +55584,7 @@ dMW
 sqA
 fyf
 fyf
-bBm
+gNB
 fyf
 fyf
 fyf
@@ -54981,36 +55599,26 @@ dFQ
 gmX
 koD
 dMW
-bBm
-fyf
+jqp
+tkh
+vYv
+vYv
+rRl
+urY
+vyb
+vyb
+vyb
+xdG
+vYv
+dit
+qxu
+qxu
+qxu
+qxu
+dit
 gcK
 gcK
 gcK
-gcK
-aac
-aac
-pWN
-oCi
-ssm
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
 gcK
 gcK
 gcK
@@ -55022,6 +55630,16 @@ gcK
 gbL
 gbL
 gbL
+gcK
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -55238,36 +55856,23 @@ cdc
 vnc
 koD
 dMW
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-aac
-aac
-snB
-koD
-nPX
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
+cPB
+eQw
+vYv
+vYv
+rWQ
+uBw
+qZI
+qZI
+qZI
+xee
+vYv
+dit
+vLr
+vLr
+vLr
+vLr
+dit
 gcK
 gcK
 gcK
@@ -55278,7 +55883,20 @@ gcK
 gcK
 gbL
 gbL
+gcK
 gbL
+gbL
+gbL
+gcK
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -55495,36 +56113,23 @@ cdc
 snB
 koD
 dMW
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-snB
-gWo
-eMD
-hzb
-jMC
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
+dit
+dit
+kxq
+mWa
+dit
+uIK
+vAm
+woF
+vAm
+xeG
+vYv
+qfa
+pim
+pim
+pim
+pim
+dit
 gcK
 gcK
 gcK
@@ -55535,7 +56140,20 @@ gcK
 gcK
 gbL
 gbL
+gcK
 gbL
+gbL
+gbL
+gcK
+gbL
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -55737,7 +56355,7 @@ dMW
 fyf
 fyf
 uqa
-drN
+jLV
 uqa
 itJ
 uqa
@@ -55752,26 +56370,23 @@ uTG
 snB
 koD
 dMW
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-uVo
-pfl
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+dit
+fiN
+pim
+pim
+dit
+dit
+dit
+dit
+dit
+dit
+vYv
+dit
+xzH
+yiF
+yiF
+yiF
+dit
 gcK
 gcK
 gcK
@@ -55780,16 +56395,19 @@ gcK
 gcK
 gcK
 gcK
+gbL
+gbL
 gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
 gcK
 gcK
+gcK
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -55994,13 +56612,13 @@ dMW
 fyf
 fyf
 uqa
-bOH
-pVI
+siu
+snA
 rpu
 rpu
 rkZ
 rpu
-drN
+jLV
 fyf
 kGc
 unI
@@ -56009,44 +56627,44 @@ bJB
 gmX
 koD
 dMW
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-lvy
-uit
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+dit
+fuy
+pim
+pim
+wjx
+vYv
+vYv
+wpo
+vYv
+vYv
+vYv
+dit
+dit
+dit
+dit
+dit
+dit
 gcK
 gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -56266,20 +56884,21 @@ cdc
 snB
 koD
 dMW
+dit
+fUu
+pim
+mXF
+dit
+vYv
+vYv
+vYv
+vYv
+xfI
+vYv
+vfC
+dit
 fyf
 fyf
-bBm
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-doo
-fyf
-fyf
 fyf
 fyf
 gcK
@@ -56287,23 +56906,22 @@ gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -56521,38 +57139,38 @@ ajD
 lSD
 uVo
 apk
-koD
+crA
 dMW
+dit
+dit
+kzj
+dit
+dit
+qsL
+qsL
+qsL
+wzm
+dit
+vYv
+vfC
+dit
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-bBm
 fyf
 fyf
 gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-ktB
 gcK
 gcK
 gcK
@@ -56766,10 +57384,10 @@ fyf
 fyf
 uqa
 rpu
-ijl
+snQ
 uqa
 rpu
-nSQ
+oqA
 rpu
 uqa
 fyf
@@ -56780,31 +57398,31 @@ apk
 ehN
 koD
 dMW
+dkK
+gzj
+mvv
+ngg
+wAm
+uKA
+vBD
+cNc
+ttW
+dit
+dit
+dit
+dit
 fyf
 fyf
 fyf
 fyf
-uVs
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sND
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -57020,15 +57638,15 @@ koD
 cpK
 dMW
 fyf
-aYY
+rSc
 uqa
-bOH
-nZs
+siu
+srM
 uqa
 rpu
 tJe
 rpu
-drN
+jLV
 fyf
 kGc
 ofX
@@ -57037,37 +57655,37 @@ ehN
 ubg
 koD
 dMW
-fyf
-pis
-fyf
-fyf
-fyf
-fyf
-fyf
+dkK
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+dqc
+dit
+bXG
 fyf
 fyf
 fyf
 fyf
 wjt
-uVs
-fyf
-fyf
-fyf
 fyf
 fyf
 gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-ktB
 gcK
 gcK
 gcK
@@ -57279,7 +57897,7 @@ dMW
 fyf
 fyf
 uqa
-drN
+jLV
 uqa
 uqa
 uqa
@@ -57294,37 +57912,37 @@ wGJ
 snB
 koD
 dMW
-fyf
-qOV
-cWG
-cWG
-cWG
-cWG
-cWG
-lfu
-cWG
-cWG
-ghx
-fyf
+dkK
+mvv
+rjH
+rjH
+rjH
+rjH
+rjH
+rjH
+rjH
+xgC
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
 gcK
 gcK
 gcK
@@ -57340,8 +57958,8 @@ gcK
 gcK
 gcK
 gbL
-gbL
-gbL
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -57481,7 +58099,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+uey
 fyf
 fyf
 fyf
@@ -57551,37 +58169,37 @@ wGJ
 uVo
 koD
 dMW
-fyf
-tBN
-mvv
-oCW
+dkK
+gTC
 mvv
 mvv
 mvv
+uKG
 mvv
 mvv
 mvv
-bpD
-vfS
-fyf
+xgC
+sND
 fyf
 fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
 gcK
 gcK
 gcK
@@ -57597,8 +58215,8 @@ gcK
 gcK
 gcK
 gbL
-gbL
-gbL
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -57746,9 +58364,9 @@ fyf
 fyf
 fyf
 fyf
-tBN
-mvv
-bpD
+fbH
+mfD
+hCg
 fyf
 fyf
 fyf
@@ -57808,42 +58426,31 @@ apk
 snB
 koD
 dMW
-fyf
-jsX
-nji
+dkK
 mvv
-mvv
-mvv
-mvv
-pKm
-mvv
-mvv
-bpD
+rjH
+rjH
+rjH
+rjH
+rjH
+rjH
+rjH
+xgC
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
+sND
 fyf
-fyf
-fyf
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
 gcK
 gbL
 gbL
@@ -57853,9 +58460,20 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
-gbL
-gbL
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -58000,12 +58618,12 @@ fyf
 fyf
 fyf
 fyf
-hAC
 fyf
 fyf
-tBN
-mvv
-bpD
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -58058,25 +58676,23 @@ ybI
 ybI
 dkP
 sTa
-aLo
+ahK
 onk
 hbW
 ehN
 gmX
 koD
 dMW
-fyf
-jyl
-sYX
-sYX
-abi
-abi
-abi
-sYX
-sYX
-qyU
-sYX
-sYX
+dDF
+xJY
+xJY
+xJY
+xJY
+xJY
+xJY
+xJY
+xJY
+vwx
 fyf
 fyf
 fyf
@@ -58089,17 +58705,12 @@ gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 gbL
@@ -58111,8 +58722,15 @@ gcK
 gcK
 gcK
 gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
-gbL
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -58248,7 +58866,7 @@ wDc
 fyf
 fyf
 fyf
-sND
+fyf
 fyf
 fyf
 fyf
@@ -58315,52 +58933,52 @@ idu
 idu
 hBN
 aJb
-gbS
+ajX
 tUb
 ehN
 ehN
-ehN
+gmX
 koD
 dMW
 fyf
-tBN
-sYX
-qie
-rpu
-eZr
-rpu
-rpu
-xjA
-rpu
-rpu
-sYX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 pis
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+gqO
+fyf
+fyf
+fyf
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gbL
+gbL
+gcK
+gcK
+gbL
+gbL
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
 gcK
 gcK
 gcK
@@ -58572,52 +59190,52 @@ ehN
 hOl
 sgz
 sgz
-gVV
+alM
 ehN
 ehN
 ehN
-ehN
+gmX
 koD
 dMW
-sYX
-sYX
-sYX
-uCO
-uWJ
-wIk
-hUm
-rpu
-jpr
-ebK
-rpu
-sYX
-sYX
-sYX
-sYX
-sYX
+fyf
+qOV
+cWG
+cWG
+cWG
+cWG
+cWG
+wqi
+cWG
+cWG
+bKs
 fyf
 fyf
 fyf
 fyf
+wjt
+fyf
+fyf
+gcK
+gcK
+gcK
+gcK
+gbL
+gbL
+gbL
+gcK
+gbL
+gbL
+gcK
+gcK
+gbL
+gbL
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
 gcK
 gcK
 gcK
@@ -58829,38 +59447,38 @@ kaM
 kaM
 qoS
 dmL
-hAX
+amy
 qoS
 ehN
 ehN
-ehN
+gmX
 koD
 dMW
-sYX
-jzC
-njC
-qsS
-uCO
-wSJ
-rpu
-fLJ
-gvW
-kVO
-rpu
-uCO
-dqD
-cNJ
-gon
-sYX
+fyf
+uQx
+mvv
+oCW
+mvv
+mvv
+mvv
+mvv
+tlj
+mvv
+bpD
+uco
 fyf
 fyf
 fyf
 fyf
+fyf
+fyf
 gcK
 gcK
 gcK
 gcK
-gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -59086,31 +59704,28 @@ jZE
 ees
 dNT
 gQv
-hXv
+arb
 muk
 qnS
 erY
 ubg
 koD
 dMW
-sYX
-jQq
-njK
-mZD
-uZg
-xdG
-tuS
-gvW
-gvW
-rpu
-klA
-sDp
-xzK
-xzK
-oPJ
-sYX
 fyf
-wjt
+uRU
+vBO
+mvv
+mvv
+mvv
+mvv
+wqs
+mvv
+mvv
+bpD
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -59132,7 +59747,10 @@ gcK
 gcK
 gcK
 gcK
-gbL
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -59277,15 +59895,15 @@ mvv
 doX
 cWG
 cWG
+cWG
+cWG
 wDc
-fyf
-fyf
 thG
-adD
+arx
 cWG
 cWG
 cWG
-cWB
+aLg
 cWG
 cWG
 daU
@@ -59350,34 +59968,34 @@ cdc
 snB
 koD
 dMW
-abi
-saZ
-nnz
-mZD
-vhd
-xeG
-ogf
-ubK
-gvW
-oeq
-plt
-uCO
-uCO
-uCO
-uCO
+fyf
+fvi
+sYX
+sYX
+fGS
+fGS
+fGS
+sYX
+sYX
+xjP
+sYX
 sYX
 fyf
 fyf
 fyf
 fyf
 fyf
+fyf
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-ktB
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -59534,15 +60152,15 @@ xGH
 mvv
 mvv
 mvv
+mvv
+mvv
 bpD
-fyf
-fyf
 thG
 tBN
 mvv
 mvv
 mvv
-daM
+aPg
 mvv
 mvv
 mvv
@@ -59578,9 +60196,9 @@ fyf
 fyf
 uxC
 sYX
-maS
-abi
-maS
+xUO
+fGS
+xUO
 sYX
 fyf
 fyf
@@ -59591,9 +60209,9 @@ fyf
 fyf
 fyf
 sYX
-spt
-spt
-tjd
+sap
+sap
+ssC
 sYX
 uxC
 uxC
@@ -59602,40 +60220,29 @@ uxC
 wEo
 kGc
 unI
-bbR
+tAS
 cdc
 snB
 koD
 dMW
+fyf
+tBN
 sYX
-kcZ
-mZD
-mZD
-viv
-xeG
+ofa
 rpu
-gvW
-gvW
+xMP
 rpu
 rpu
-uCO
-rQU
-oYd
-bzU
+xjA
+rpu
+rpu
 sYX
 fyf
 fyf
 fyf
 fyf
 fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
+fyf
 gcK
 gcK
 gcK
@@ -59644,6 +60251,17 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 gcK
@@ -59791,15 +60409,15 @@ nlO
 mfD
 mfD
 mfD
+mfD
+mfD
 hCg
-fyf
-fyf
 thG
-aep
+atX
 mvv
 aBH
 mfD
-dbh
+aPr
 mfD
 mfD
 xGH
@@ -59837,8 +60455,8 @@ fyf
 kGD
 bgk
 rkZ
-nPP
-vtj
+pCi
+gmR
 fyf
 fyf
 fyf
@@ -59848,15 +60466,15 @@ fyf
 fyf
 fyf
 kGD
-oJj
+scW
 rkZ
-nPP
-cPI
+pCi
+rSf
 fyf
 fyf
 fyf
 fyf
-xJA
+lyk
 kGc
 unI
 dXy
@@ -59865,32 +60483,24 @@ snB
 koD
 dMW
 sYX
-hbG
-crd
-fBO
-mZD
+sYX
+sYX
+uCO
+saB
+uOr
+dpH
 rpu
-sid
-rub
+qer
+ebK
 rpu
-jpr
-rpu
-sDp
-rpu
-rpu
-gvW
-abi
+sYX
+sYX
+sYX
+sYX
+sYX
 fyf
 fyf
 fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -59909,10 +60519,18 @@ gcK
 gcK
 gcK
 gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
-gbL
+gcK
+gcK
 gbL
 gcK
 gcK
@@ -60050,14 +60668,14 @@ fyf
 fyf
 fyf
 fyf
-uHT
+fyf
 thG
 tBN
 mvv
-bKs
+aDX
 sYX
 sYX
-abi
+fGS
 sYX
 sYX
 wpx
@@ -60092,9 +60710,9 @@ fyf
 fyf
 fyf
 sYX
-dqo
+yao
 rpu
-jmY
+onh
 sYX
 fyf
 fyf
@@ -60104,16 +60722,16 @@ fyf
 fyf
 fyf
 fyf
-cPI
+rSf
 rpu
 rpu
-wfC
+hpj
 kGD
 fyf
 fyf
 fyf
 fyf
-xJA
+lyk
 kGc
 unI
 lSD
@@ -60122,26 +60740,24 @@ snB
 koD
 dMW
 sYX
-fKJ
-aHE
-hDe
-mZD
-rpu
-sew
-rpu
-rpu
-rpu
-jhp
+uTA
+vJq
+hPL
 uCO
-rhp
-qfV
+uPl
+rpu
+wrS
 gvW
+vPQ
+rpu
+uCO
+euL
+pUE
+ghH
 sYX
 fyf
 fyf
 fyf
-fyf
-fyf
 gcK
 gcK
 gcK
@@ -60155,8 +60771,10 @@ gcK
 gcK
 gcK
 gcK
-ktB
-ktB
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -60168,8 +60786,8 @@ gcK
 gbL
 gbL
 gbL
-gbL
-gbL
+gcK
+gcK
 gbL
 gcK
 gcK
@@ -60313,8 +60931,8 @@ nlO
 mfD
 hCg
 sYX
-def
-dzf
+aQa
+aVC
 csO
 uCO
 rpu
@@ -60333,10 +60951,10 @@ fyf
 fyf
 fyf
 uqa
-jZk
-jZk
-nYY
-jZk
+cQU
+cQU
+ePQ
+cQU
 uqa
 fyf
 fyf
@@ -60351,18 +60969,18 @@ fyf
 yjG
 rpu
 klA
-nSQ
+oqA
 sYX
 fyf
 fyf
-oFM
+pzN
 fyf
 fyf
 fyf
 fyf
 fyf
 sYX
-haN
+seB
 rpu
 rpu
 sYX
@@ -60370,7 +60988,7 @@ fyf
 fyf
 fyf
 fyf
-xJA
+lyk
 kGc
 unI
 hbW
@@ -60379,42 +60997,24 @@ apk
 koD
 dMW
 sYX
-uCO
-uCO
-uCO
-uCO
-uCO
-uCO
-uCO
-jpr
-uCO
-uCO
-uCO
-uCO
-uCO
-uCO
+hhe
+kCx
+mZD
+sFy
+uSz
+vrc
+gvW
+gvW
+rpu
+klA
+sDp
+wpQ
+wpQ
+uxV
 sYX
 fyf
 fyf
 fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-ktB
-ktB
-gbL
 gcK
 gcK
 gcK
@@ -60422,11 +61022,29 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
-gbL
-gbL
+gcK
+gcK
 gbL
 gcK
 gcK
@@ -60589,11 +61207,11 @@ fyf
 fyf
 fyf
 fyf
-kcQ
-jZk
-mdM
-obr
-pCf
+cRH
+cQU
+edO
+eTZ
+fJj
 uqa
 fyf
 fyf
@@ -60627,7 +61245,7 @@ fyf
 fyf
 fyf
 fyf
-xJA
+lyk
 kGc
 unI
 hbW
@@ -60635,43 +61253,30 @@ erY
 ubg
 koD
 dMW
-sYX
-kgd
-rpu
-pvP
-rpu
-jhp
-rpu
+fGS
+uUJ
+kWT
+mZD
+sLK
+xOZ
+vDd
+wvm
+gvW
+lzP
+plt
 uCO
-rpu
-rpu
-fcA
 uCO
-mpI
-oYd
-iAz
+uCO
+uCO
 sYX
 fyf
 fyf
-doo
-uVs
 fyf
 gcK
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-ktB
-ktB
-gbL
 gcK
 gcK
 gcK
@@ -60679,11 +61284,24 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gbL
 gbL
-gbL
-gbL
+gcK
+gcK
 gbL
 gcK
 gcK
@@ -60825,13 +61443,13 @@ fyf
 sYX
 rpu
 rpu
-cht
+aFu
 uCO
-deQ
+aTE
 rpu
-dJY
+aYp
 uCO
-ehP
+bcx
 rpu
 uCO
 uZy
@@ -60846,8 +61464,8 @@ fyf
 fyf
 fyf
 fyf
-kcQ
-lvL
+cRH
+dgt
 uCO
 uCO
 uCO
@@ -60858,10 +61476,10 @@ fyf
 fyf
 fyf
 sYX
-okz
+eVb
 wEO
 uCO
-etg
+bgz
 wtp
 vXh
 rpu
@@ -60877,14 +61495,14 @@ fyf
 fyf
 sYX
 aYG
-cLk
+sln
 rpu
 yjG
 fyf
 fyf
 fyf
 fyf
-xJA
+lyk
 kGc
 unI
 hbW
@@ -60893,23 +61511,21 @@ snB
 koD
 dMW
 sYX
-kzr
-jpr
+uUL
+mZD
+mZD
+sUo
+xOZ
 rpu
+gvW
+gvW
 rpu
-xfw
 rpu
 uCO
-klA
-rpu
-sRJ
-uCO
-rYF
-rpu
-rpu
-abi
-fyf
-fyf
+xhd
+bqw
+ikj
+sYX
 fyf
 fyf
 fyf
@@ -60918,17 +61534,19 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-ktB
-ktB
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -61080,11 +61698,11 @@ fyf
 fyf
 fyf
 sYX
-agX
+avx
 sKH
 nfp
 uCO
-dfx
+aTI
 rpu
 ccF
 uCO
@@ -61092,7 +61710,7 @@ rpu
 vXh
 uCO
 rpu
-eHB
+bmu
 vXh
 sYX
 fyf
@@ -61104,10 +61722,10 @@ fyf
 fyf
 fyf
 uqa
-jZk
-lwd
-jZk
-pHm
+cQU
+dgG
+cQU
+fKt
 uqa
 fyf
 fyf
@@ -61115,13 +61733,13 @@ fyf
 fyf
 fyf
 sYX
-hQS
-vZs
+lgI
+lzW
 uCO
-aim
+mvF
 wtp
 rpu
-fGA
+nJM
 rMz
 fqa
 fyf
@@ -61150,42 +61768,42 @@ uVo
 koD
 dMW
 sYX
-uCO
-uCO
-uCO
-vsb
+hoe
+ltZ
+oll
+mZD
 rpu
+vHK
+wzn
 rpu
-uCO
+qer
 rpu
-rpu
-plt
-uCO
-uCO
 sDp
-uCO
-sYX
+rpu
+rpu
+gvW
+fGS
 fyf
-wjt
 fyf
 fyf
-fyf
 gcK
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-ktB
-ktB
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -61335,11 +61953,11 @@ fyf
 fyf
 fyf
 fyf
-fyf
-abi
+uey
+fGS
 rpu
 rpu
-cBb
+aGv
 uCO
 uCO
 sDp
@@ -61361,10 +61979,10 @@ fyf
 fyf
 fyf
 uqa
-jZk
+cQU
 uCO
-obV
-jZk
+eUQ
+cQU
 uqa
 fyf
 fyf
@@ -61373,7 +61991,7 @@ fyf
 fyf
 sYX
 uCO
-shg
+lCi
 uCO
 uCO
 uCO
@@ -61387,17 +62005,17 @@ qOV
 daU
 mvv
 haP
-ffw
+wUv
 bpD
-cPI
-jVg
-jlB
+rSf
+hXv
+qTr
 rpu
 wtp
 guh
 sYX
-lIq
-uwi
+tja
+tmh
 sYX
 kGc
 unI
@@ -61407,26 +62025,26 @@ snB
 koD
 dMW
 sYX
-kCS
-oeq
+uUZ
+vLj
+omd
+mZD
+rpu
+sew
+rpu
+rpu
+rpu
+jhp
 uCO
-vtv
-rpu
-rpu
-jpr
-rpu
-vjl
-rpu
-sDp
-rpu
-rpu
-rpu
+cYH
+qfV
+gvW
 sYX
 fyf
 fyf
 fyf
-fyf
-fyf
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -61594,9 +62212,9 @@ fyf
 fyf
 fyf
 sYX
-arb
+azj
 rpu
-cKC
+aGX
 uCO
 rpu
 rpu
@@ -61607,7 +62225,7 @@ rpu
 sDp
 rpu
 vXh
-eHB
+bmu
 sYX
 fyf
 fyf
@@ -61618,10 +62236,10 @@ fyf
 fyf
 fyf
 uqa
-lwd
+dgG
 uqa
 uCO
-pMf
+fMj
 uqa
 fyf
 fyf
@@ -61629,9 +62247,9 @@ fyf
 fyf
 fyf
 tKZ
-dFM
+lhN
 rpu
-oYh
+mbD
 csO
 uCO
 rpu
@@ -61647,14 +62265,14 @@ aBH
 mfD
 hCg
 kGD
-jVg
-nkA
+hXv
+slM
 rpu
 wtp
 bjy
 sYX
 dhC
-omd
+eVh
 sYX
 kGc
 unI
@@ -61664,26 +62282,26 @@ apk
 koD
 dMW
 sYX
-kIq
-rpu
-sDp
-rpu
-qfV
-kVO
 uCO
-rpu
-sKH
-jpr
 uCO
-bxl
-qfV
-klA
-abi
+uCO
+uCO
+uCO
+uCO
+uCO
+qer
+uCO
+uCO
+uCO
+uCO
+uCO
+uCO
+sYX
 fyf
 fyf
 fyf
-fyf
-fyf
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -61851,15 +62469,15 @@ fyf
 fyf
 fyf
 sYX
-aun
+azk
 aug
 rpu
 sDp
 qfV
 vXh
 gvW
-egb
-dzf
+baY
+aVC
 rpu
 uCO
 bxl
@@ -61877,7 +62495,7 @@ fyf
 fyf
 fyf
 uqa
-okz
+eVb
 dhC
 uqa
 fyf
@@ -61898,7 +62516,7 @@ sYX
 fyf
 fyf
 tBN
-jde
+mcz
 mvv
 bpD
 fyf
@@ -61921,26 +62539,26 @@ gmX
 koD
 dMW
 sYX
-lkz
+rJU
+rpu
+orB
+rpu
+jhp
 rpu
 uCO
 rpu
-tuS
-oAA
+rpu
+pJJ
 uCO
-rpu
-rpu
-rpu
-uCO
-msy
-rpu
-bkj
+ifs
+bqw
+iAz
 sYX
 fyf
 fyf
 fyf
-fyf
-fyf
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -62108,13 +62726,13 @@ fyf
 fyf
 fyf
 sYX
-azk
+aAk
 rpu
 ntB
 uCO
-dgG
+aUb
 vUF
-dKR
+aYY
 gvW
 vXh
 sLm
@@ -62131,10 +62749,10 @@ fyf
 fyf
 fyf
 fyf
-xJA
+lyk
 fyf
 uqa
-omd
+eVh
 jbw
 uqa
 fyf
@@ -62146,7 +62764,7 @@ sYX
 cIh
 ccF
 msy
-lxk
+mvV
 uCO
 rpu
 aug
@@ -62165,10 +62783,10 @@ rpu
 rpu
 jcl
 sYX
-biJ
+sOD
 sKH
 rpu
-qhD
+tor
 sYX
 kGc
 unI
@@ -62178,25 +62796,25 @@ gmX
 koD
 dMW
 sYX
-sYX
-sYX
-sYX
-sYX
-kom
-sYX
-sYX
-kom
-wpx
-kom
-sYX
-sYX
-kVm
-sYX
-sYX
+huU
+qer
+rpu
+rpu
+ven
+rpu
+uCO
+klA
+rpu
+rzu
+uCO
+bIO
+rpu
+rpu
+fGS
 fyf
 fyf
 fyf
-fyf
+gcK
 gcK
 gcK
 gcK
@@ -62362,8 +62980,8 @@ uey
 qOV
 cWG
 hpm
+cWG
 wDc
-fyf
 sYX
 uCO
 uCO
@@ -62373,7 +62991,7 @@ rpu
 vUF
 gvW
 gvW
-dzf
+aVC
 rpu
 uCO
 uCO
@@ -62388,7 +63006,7 @@ fyf
 fyf
 fyf
 fyf
-kiW
+cSO
 uxC
 uqa
 uqa
@@ -62401,12 +63019,12 @@ fyf
 fyf
 sYX
 sYX
-abi
-maS
+fGS
+xUO
 sYX
 sYX
-abi
-maS
+fGS
+xUO
 sYX
 sYX
 fyf
@@ -62431,29 +63049,29 @@ kGc
 unI
 hbW
 erY
-soK
+tFM
 koD
 dMW
-ifs
-tBN
-pIn
-mvv
-mvv
-mvv
-mvv
-mvv
-ljA
-mvv
-mvv
-mvv
-mvv
-wAQ
-ifs
+sYX
+uCO
+uCO
+uCO
+tit
+rpu
+rpu
+uCO
+rpu
+rpu
+plt
+uCO
+uCO
+sDp
+uCO
+sYX
 fyf
 fyf
 fyf
-fyf
-fyf
+gcK
 gcK
 gcK
 gcK
@@ -62619,10 +63237,10 @@ qOV
 daU
 mvv
 haP
+wUv
 bpD
-fyf
 sYX
-aAk
+aAR
 qfV
 rpu
 sDp
@@ -62631,11 +63249,11 @@ rpu
 rpu
 rpu
 rpu
-ehV
+bcF
 uCO
-etg
+bgz
 rpu
-eLe
+bnm
 sYX
 fyf
 fyf
@@ -62659,12 +63277,12 @@ fyf
 fyf
 tBN
 mvv
-jde
+mcz
 mvv
 mvv
-oHO
+nrB
 mvv
-vGl
+onz
 wDc
 sND
 fyf
@@ -62680,38 +63298,38 @@ rkZ
 rpu
 sYX
 rkZ
-fGj
+sUd
 aug
 rpu
 sYX
 kGc
 unI
-hzq
+tCu
 dFQ
 gmX
 koD
-xOZ
-ifs
-tBN
-mvv
-mvv
-vwn
-hxO
-ymi
-aNZ
-mvv
-sSc
-rjH
-mvv
-rjH
-bpD
-ifs
+gKG
+sYX
+hGX
+lzP
+uCO
+rco
+rpu
+rpu
+qer
+rpu
+lhz
+rpu
+sDp
+rpu
+rpu
+rpu
+sYX
 fyf
 fyf
 fyf
 fyf
 fyf
-gcK
 gcK
 gcK
 gcK
@@ -62825,7 +63443,7 @@ hbW
 sRp
 uVo
 qgZ
-aLo
+xMm
 ybI
 ybI
 ybI
@@ -62876,12 +63494,12 @@ tBN
 mvv
 mvv
 aBH
+mfD
 hCg
-fyf
 sYX
-aAO
+aBx
 aug
-cNE
+aHz
 uCO
 uCO
 uCO
@@ -62890,9 +63508,9 @@ uCO
 sDp
 uCO
 uCO
-eyg
+bhl
 aug
-eEK
+bmr
 sYX
 fyf
 fyf
@@ -62915,7 +63533,7 @@ fyf
 fyf
 fyf
 nlO
-fGS
+lCo
 mvv
 mvv
 mvv
@@ -62932,13 +63550,13 @@ fyf
 fyf
 fyf
 sYX
-iYP
-qov
-spt
+sgr
+slT
+sap
 sYX
 sYX
-spt
-spt
+sap
+sap
 sYX
 sYX
 kGc
@@ -62948,27 +63566,27 @@ cdc
 vnc
 koD
 dMW
-ifs
-nlO
-mfD
-mfD
-mfD
-xpN
-nXE
-aNZ
-mvv
-mvv
-mvv
-iAm
-mvv
-bpD
-ifs
+sYX
+iHX
+rpu
+sDp
+rpu
+qfV
+vPQ
+uCO
+rpu
+sKH
+qer
+uCO
+bxl
+qfV
+klA
+fGS
 fyf
-uVs
 fyf
-bBm
 fyf
-gcK
+fyf
+fyf
 gcK
 gcK
 gcK
@@ -63082,7 +63700,7 @@ erY
 apk
 cdc
 kCt
-gbS
+mLr
 hBN
 erY
 apk
@@ -63136,20 +63754,20 @@ bpD
 fyf
 fyf
 sYX
-aAR
+aCn
 rpu
-cPg
+aHZ
 uCO
 rpu
 vUF
-dZT
-dzf
+aZn
+aVC
 rpu
 sLm
 uCO
-eyI
+blX
 rpu
-eTJ
+boj
 sYX
 fyf
 fyf
@@ -63179,7 +63797,7 @@ mvv
 mvv
 mvv
 mvv
-xJc
+oRz
 wDc
 fyf
 fyf
@@ -63205,27 +63823,27 @@ cdc
 snB
 koD
 dMW
-ifs
 sYX
+iQK
+rpu
+uCO
+rpu
+vrc
+vMo
+uCO
+rpu
+rpu
+rpu
+uCO
+msy
+rpu
+nuV
 sYX
-sYX
-fyf
-xuJ
-ymi
-aNZ
-mvv
-vtH
-xBl
-vlx
-gaZ
-bpD
-ifs
 fyf
 fyf
+sND
 fyf
 fyf
-fyf
-gcK
 gcK
 gcK
 gcK
@@ -63339,7 +63957,7 @@ erY
 erY
 apk
 cdc
-gVV
+gRk
 sgz
 erY
 rbe
@@ -63406,7 +64024,7 @@ rpu
 sDp
 rpu
 qfV
-etg
+bgz
 sYX
 fyf
 fyf
@@ -63432,12 +64050,12 @@ dCV
 dCV
 dCV
 gts
-lSG
-xnh
-fCW
+mPa
+xXh
+nNZ
 mvv
 mvv
-vGl
+onz
 wDc
 fyf
 fyf
@@ -63462,22 +64080,22 @@ cdc
 snB
 koD
 dMW
-ifs
 sYX
-ojS
-rpu
-fyf
-tBN
-mvv
-mvv
-mvv
-rjH
-mvv
-mzn
-mvv
-bpD
-ifs
-fyf
+sYX
+sYX
+sYX
+sYX
+ejD
+sYX
+sYX
+ejD
+wpx
+ejD
+sYX
+sYX
+gPG
+sYX
+sYX
 fyf
 fyf
 fyf
@@ -63506,15 +64124,15 @@ gcK
 gcK
 gcK
 qal
-uhi
-uhi
-uhi
+gYu
+gYu
+gYu
 vIt
-reo
+sgd
 vIt
-rdd
-uhi
-hFi
+wtR
+gYu
+oDp
 pdx
 gcK
 gcK
@@ -63596,7 +64214,7 @@ erY
 erY
 mmK
 kaM
-hAX
+kaM
 qoS
 eaO
 erY
@@ -63650,20 +64268,20 @@ fyf
 fyf
 fyf
 sYX
-aFF
+aDk
 rpu
 vXh
 uCO
-dhB
+aUc
 rpu
 sKH
 aug
 rpu
-ejD
+bet
 uCO
-eEC
+bmg
 rpu
-etg
+bgz
 sYX
 fyf
 fyf
@@ -63683,19 +64301,19 @@ uCO
 uCO
 uCO
 dCV
-itU
-yea
-nby
-hkL
+jml
+kiP
+lil
+xiy
 dCV
 gts
 fQr
 gKP
-xnh
-oHO
+xXh
+nrB
 mvv
 mvv
-vGl
+onz
 cWG
 cWG
 wDc
@@ -63719,21 +64337,21 @@ cdc
 snB
 koD
 dMW
-ifs
-sYX
-ose
-rpu
-fyf
-xHY
+tWu
+tBN
+pIn
 mvv
-qWg
 mvv
-qDi
 mvv
-rjH
 mvv
-bpD
-ifs
+mvv
+tCo
+mvv
+mvv
+mvv
+mvv
+gYi
+tWu
 fyf
 fyf
 fyf
@@ -63763,15 +64381,15 @@ gcK
 gcK
 gcK
 vaA
-afp
+oVV
 fck
 pdx
-sPS
-uhi
-ltb
-rdd
-rRQ
-uhi
+bmG
+gYu
+caj
+wtR
+xHy
+gYu
 pdx
 gcK
 gcK
@@ -63853,7 +64471,7 @@ hbW
 erY
 gmX
 uoS
-hXv
+ees
 ees
 jBH
 jBH
@@ -63907,20 +64525,20 @@ qOV
 gjB
 fyf
 sYX
-aUb
+aDl
 rpu
-cRH
+aJZ
 uCO
-dlb
+aVq
 rpu
 rpu
 qfV
 rpu
-esj
+beG
 uCO
-eEK
+bmr
 rpu
-eEK
+bmr
 sYX
 fyf
 fyf
@@ -63933,29 +64551,29 @@ fyf
 gts
 dCV
 uCO
-oKy
-rpa
-tWd
-uKG
-mpN
-slq
+fgI
+fOe
+gqE
+gRs
+hxU
+hWq
 dCV
-yla
-aRz
-vta
-vta
+jmz
+kiW
+jsP
+jsP
 dCV
 gts
 fqi
 tvr
 gKP
-xnh
+xXh
 mvv
 ofL
 mvv
 mvv
 mvv
-vGl
+onz
 wDc
 fyf
 fyf
@@ -63968,29 +64586,29 @@ fyf
 fyf
 rsE
 fyf
-qeh
+tvP
 kGc
 unI
-dCk
+tEp
 lZP
 snB
 koD
 dMW
-ifs
-sYX
-sYX
-sYX
-fyf
-nlO
-mfD
-mfD
-anu
-mfD
-mfD
-mfD
-mfD
-hCg
-ifs
+tWu
+tBN
+mvv
+mvv
+tsF
+hxO
+ymi
+wBx
+mvv
+xqr
+rjH
+mvv
+rjH
+bpD
+tWu
 fyf
 fyf
 fyf
@@ -64020,15 +64638,15 @@ gcK
 gcK
 gcK
 vaA
-lSp
+rfE
 pdx
 pdx
-kjX
+fFd
 vIt
-iAX
-rdd
+jTT
+wtR
 vIt
-ltb
+caj
 pdx
 gcK
 gcK
@@ -64169,14 +64787,14 @@ sYX
 sYX
 sYX
 sYX
-dHq
-dHq
+aWF
+aWF
 sYX
 wpx
 sYX
 sYX
 sYX
-dHq
+aWF
 sYX
 sYX
 fyf
@@ -64189,31 +64807,31 @@ fyf
 fyf
 gts
 dCV
-mrS
-pOo
-pOo
-pOo
-pOo
-pOo
-pOo
-eqL
-vta
-vta
-vta
-aRz
+egb
+flP
+flP
+flP
+flP
+flP
+flP
+iLc
+jsP
+jsP
+jsP
+kiW
 dCV
 gts
 fQr
 tvr
-cHH
+nUj
 gKP
-eiJ
-xnh
+oRQ
+xXh
 mvv
 mvv
-rQE
+pKP
 mvv
-vGl
+onz
 wDc
 upX
 fyf
@@ -64233,37 +64851,37 @@ bJB
 gmX
 koD
 dMW
-inI
-lrY
-lrY
-lrY
-lrY
-lrY
-lrY
-lrY
-lrY
-lrY
-lrY
-lrY
-xpW
-lrY
-tTX
-lrY
-lrY
-lrY
-lrY
-lrY
-lrY
-lrY
-lrY
+tWu
+nlO
+mfD
+mfD
+mfD
+vtj
+vOq
+wBx
+mvv
+mvv
+mvv
+iaQ
+mvv
+bpD
+nTa
+cuz
+cuz
+cuz
+cuz
+cuz
+cuz
+cuz
+cuz
 gcK
 gcK
 gcK
 gcK
 gcK
-pyj
-tXc
-ylA
+gSI
+rni
+dea
 gcK
 gcK
 gcK
@@ -64277,15 +64895,15 @@ gcK
 gcK
 fyf
 vaA
-tJG
-gld
+iyJ
+uop
 vIt
-bPU
-xfW
+vYP
+jjd
 vIt
-ttE
+mDO
 mTd
-qLX
+oRr
 pdx
 gcK
 gcK
@@ -64446,18 +65064,18 @@ fyf
 fyf
 gts
 dCV
-mMN
-pOo
-pOo
-qZO
-onz
-tUS
-dvL
+ehP
+flP
+flP
+grj
+fmO
+fQt
+hYe
 dCV
-mge
-vta
-aRz
-eGt
+jtu
+jsP
+kiW
+lDd
 dCV
 gts
 fQr
@@ -64466,8 +65084,8 @@ tvr
 tvr
 tvr
 gKP
-eiJ
-xnh
+oRQ
+xXh
 mvv
 mvv
 mvv
@@ -64490,6 +65108,21 @@ erY
 gmX
 koD
 dMW
+tWu
+sYX
+sYX
+sYX
+fyf
+xSa
+ymi
+wBx
+mvv
+mvv
+tSc
+mMq
+wcW
+bpD
+tWu
 fyf
 fyf
 fyf
@@ -64501,25 +65134,10 @@ fyf
 fyf
 fyf
 fyf
-fyf
-xJA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-xJA
-cOW
-hqC
-cgA
+lyk
+ezR
+cht
+fkd
 mvv
 mvv
 gcK
@@ -64532,17 +65150,17 @@ gcK
 vaA
 gcK
 fyf
-kve
+srS
 vaA
-ckf
+cau
 rFk
+gYu
+caj
+avg
+gYu
 uhi
-ltb
-mmY
-uhi
-shn
 vIt
-uhi
+gYu
 pdx
 gcK
 gcK
@@ -64703,29 +65321,29 @@ fyf
 fyf
 gts
 dCV
-mfq
-onz
-onz
-onz
-onz
-onz
-thc
+ehV
+fmO
+fmO
+fmO
+fmO
+fmO
+hYR
 uCO
-jWk
-wwE
-aRz
-aRz
+jzN
+kjB
+kiW
+kiW
 dCV
 gts
-fQr
+aka
+pMI
+nWl
 tvr
-ilh
 tvr
+nUj
 tvr
-cHH
-tvr
-pUi
-akJ
+pCf
+pMf
 mvv
 ofL
 bpD
@@ -64735,9 +65353,9 @@ fyf
 fyf
 sYX
 sYX
-tOf
+sPJ
 sYX
-tOf
+sPJ
 sYX
 sYX
 kGc
@@ -64747,6 +65365,21 @@ dFQ
 gmX
 koD
 dMW
+tWu
+sYX
+lBv
+rpu
+fyf
+tBN
+mvv
+mvv
+mvv
+xsD
+mvv
+oMj
+mvv
+bpD
+tWu
 fyf
 fyf
 fyf
@@ -64754,27 +65387,12 @@ fyf
 fyf
 fyf
 fyf
-doo
-fyf
-fyf
-uVs
-fyf
-xJA
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-xJA
-nuB
+lyk
+pvP
 mvv
 mvv
 mvv
@@ -64787,7 +65405,7 @@ gcK
 gcK
 gcK
 vaA
-wAp
+kOH
 tFR
 tFR
 vaA
@@ -64798,8 +65416,8 @@ pdx
 pdx
 pdx
 vIt
-czA
-uhi
+aup
+gYu
 pdx
 gcK
 gcK
@@ -64960,13 +65578,13 @@ fyf
 fyf
 gts
 dCV
-mgu
-onz
-tUS
-onz
-onz
-onz
-onz
+eip
+fmO
+fQt
+fmO
+fmO
+fmO
+fmO
 dCV
 dCV
 dCV
@@ -64974,15 +65592,15 @@ dCV
 dCV
 dCV
 dCV
-fQr
-tvr
+akY
+pMI
 tvr
 tvr
 tvr
 tvr
 tvr
 gKP
-xnh
+xXh
 mvv
 mvv
 bpD
@@ -64991,11 +65609,11 @@ fyf
 fyf
 fyf
 sYX
-uZv
-kuZ
+sAL
+sQj
 xjA
 rpu
-lPx
+tpN
 sDp
 kGc
 unI
@@ -65004,41 +65622,41 @@ cdc
 snB
 koD
 dMW
+tWu
+sYX
+lGV
+rpu
+fyf
+tBN
+mvv
+wER
+mvv
+xuM
+mvv
+fML
+mvv
+bpD
+tWu
+fyf
+lqi
+fyf
+lqi
+fyf
+lqi
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-xJA
-fyf
-fyf
-fyf
-ijv
-fyf
-ijv
-fyf
-ijv
-fyf
-fyf
-fyf
-fyf
-fyf
-xJA
-ocU
+lyk
+nbX
 mvv
 mvv
 mvv
 mvv
 mvv
 bpD
-xJA
+lyk
 fyf
 fyf
 gcK
@@ -65056,7 +65674,7 @@ fyf
 pdx
 vIt
 vIt
-uhi
+gYu
 pdx
 gcK
 gcK
@@ -65218,37 +65836,37 @@ gts
 gts
 dCV
 uCO
-oTB
-oTB
-oTB
-oTB
+fmX
+fmX
+fmX
+fmX
 uCO
-wjF
+ibs
 dCV
-iWW
-rvx
-slQ
+jAf
+klx
+liO
 cpK
-xhB
+mdc
 dCV
-fQr
-tvr
-cHH
-vcV
-tvr
-tvr
+aun
+pMI
+nUj
+oqu
 tvr
 tvr
-pUi
-jde
+tvr
+tvr
+pCf
+mcz
 mvv
-vGl
+onz
 wDc
 fyf
 fyf
 fyf
 cuv
-rJB
+sBQ
 rpu
 rpu
 gXY
@@ -65261,24 +65879,21 @@ cdc
 gmX
 koD
 dMW
+tWu
+sYX
+sYX
+sYX
 fyf
-fyf
-bBm
-doo
-uVs
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-xJA
-fyf
-fyf
-fyf
-fyf
-fyf
+nlO
+mfD
+mfD
+wVk
+mfD
+mfD
+mfD
+mfD
+hCg
+tWu
 fyf
 fyf
 fyf
@@ -65287,15 +65902,18 @@ fyf
 fyf
 fyf
 fyf
-xJA
-cuZ
+fyf
+fyf
+fyf
+lyk
+nYX
 mvv
 mvv
 rjH
 rjH
 rjH
 bpD
-xJA
+lyk
 fyf
 fyf
 gcK
@@ -65313,7 +65931,7 @@ fyf
 pdx
 vIt
 vIt
-oUY
+kby
 pdx
 gcK
 gcK
@@ -65474,21 +66092,21 @@ gts
 dCV
 dCV
 dCV
-moO
-pSC
-pSo
-pSC
-pSC
+ekp
+foN
+fQE
+foN
+foN
 uCO
-rdC
+oIQ
 dCV
-fBs
+jEd
 kdJ
-vpH
+jPN
 rRt
 cpK
 dCV
-xfG
+mPk
 dCV
 gts
 gts
@@ -65505,9 +66123,9 @@ fyf
 fyf
 fyf
 sYX
-jnV
+sCF
 rpu
-keg
+sXy
 bHo
 rpu
 sYX
@@ -65518,27 +66136,27 @@ cdc
 gmX
 koD
 dMW
+dKT
+cuz
+cuz
+cuz
+cuz
+cuz
+cuz
+cuz
+cuz
+cuz
+cuz
+cuz
+gZM
+cuz
+mlz
 fyf
+lqi
 fyf
+lqi
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-xJA
-fyf
-fyf
-fyf
-ijv
-fyf
-ijv
-fyf
-ijv
+lqi
 fyf
 lPT
 uqa
@@ -65551,14 +66169,14 @@ mvv
 mvv
 mvv
 mvv
-vGl
-iEn
-pjn
+onz
+wzd
+jpg
 fyf
 gcK
-sZF
-jhB
-eSC
+ujK
+rUj
+gur
 fyf
 fyf
 fyf
@@ -65568,9 +66186,9 @@ fyf
 fyf
 fyf
 pdx
-pJq
+keV
 vIt
-uhi
+gYu
 pdx
 gcK
 gcK
@@ -65729,15 +66347,15 @@ fyf
 fyf
 gts
 dCV
-kwe
+cTc
 uCO
-mPa
-oqu
-rdC
-ryc
-rdC
-rdC
-uKA
+ems
+fqS
+oIQ
+grC
+oIQ
+oIQ
+ier
 dCV
 dCV
 dCV
@@ -65745,7 +66363,7 @@ cpK
 cpK
 gdY
 dCV
-hdi
+mPw
 dCV
 dCV
 dCV
@@ -65763,8 +66381,8 @@ fyf
 fyf
 cuv
 rpu
-dqo
-aXy
+yao
+sXN
 cSH
 gXY
 sYX
@@ -65787,7 +66405,7 @@ sYX
 sYX
 sYX
 sYX
-xJA
+lyk
 fyf
 fyf
 fyf
@@ -65796,29 +66414,29 @@ fyf
 fyf
 fyf
 fyf
-kLh
+wzr
 uqa
 cSH
 rpu
-xBH
-ufb
-drN
+lUY
+mAl
+jLV
 mvv
-tzY
-mvv
-mvv
+hIb
 mvv
 mvv
-daM
+mvv
+mvv
+aPg
 doX
-ghx
-sZF
-oVa
-bEy
-rvP
-eSC
+bKs
+ujK
+oQR
+vVt
+rWv
+gur
 fyf
-urm
+koe
 fyf
 pis
 fyf
@@ -65827,7 +66445,7 @@ fyf
 pdx
 vIt
 vIt
-uhi
+gYu
 pdx
 gcK
 gcK
@@ -65978,7 +66596,7 @@ pXq
 xVu
 fyf
 fyf
-uey
+fyf
 qOV
 cWG
 hpm
@@ -65986,32 +66604,32 @@ wDc
 fyf
 gts
 dCV
-kxq
-lzW
+cVw
+djk
+lmw
+lmw
 oIQ
-oIQ
-rdC
-oIQ
-oIQ
-oIQ
-oIQ
-xwW
-xwW
+lmw
+lmw
+lmw
+lmw
+iMc
+iMc
 dCV
 gdY
 cpK
 cah
-iBv
+gZD
 rEc
 uqa
-lRA
-lhk
-tsW
-nev
-oIQ
+nZV
+ovE
+oTB
+oXd
+lmw
 uqa
-uTH
-xxV
+pNk
+obr
 dCV
 nGq
 bpD
@@ -66019,8 +66637,8 @@ fyf
 fyf
 fyf
 sYX
-vHV
-dqw
+sDj
+sQl
 rpu
 rpu
 irP
@@ -66036,45 +66654,45 @@ sUr
 sUr
 sUr
 sUr
-wKP
-bvq
+wWb
+xTF
 sUr
 tKZ
-bwb
-xxq
+dCi
+kyh
 dhC
 sYX
-xJA
+lyk
 fyf
-ijv
+lqi
 fyf
-ijv
+lqi
 fyf
-ijv
+lqi
 fyf
 fyf
 fyf
 uqa
-vVb
+olV
 rpu
 rpu
-evc
+cSh
 uqa
 mvv
 mvv
 rjH
 rjH
 rjH
-lbx
-ncC
+acK
+ucL
 xGH
-aGh
-huA
+rVl
+rqZ
 sUr
-mkV
-dro
-rvP
-kQe
+mzC
+dCw
+rWv
+oMP
 fyf
 fyf
 fyf
@@ -66082,9 +66700,9 @@ fyf
 fyf
 fyf
 pdx
-uhi
-uhi
-mvK
+gYu
+gYu
+cEm
 pdx
 gcK
 gcK
@@ -66235,7 +66853,7 @@ boN
 azC
 fyf
 fyf
-qOV
+sND
 daU
 mvv
 mvv
@@ -66243,32 +66861,32 @@ bpD
 fyf
 gts
 dCV
-ktX
+cWB
 uCO
 uCO
+lmw
+fSz
 oIQ
-rHE
-rdC
-uOr
-rdC
-uSz
-xya
-xya
-hsk
+gVd
+oIQ
+gVE
+iMi
+iMi
+klI
 dkg
 dkg
 dkg
 dCV
-rEc
+avO
 oFP
-dkf
-oIQ
-oIQ
-oIQ
-oIQ
-ceL
-oIQ
-uTH
+oat
+lmw
+lmw
+lmw
+lmw
+pDd
+lmw
+pNk
 dCV
 nGq
 bpD
@@ -66288,20 +66906,20 @@ hbW
 apk
 gmX
 tBB
-wKP
-wKP
+wWb
+wWb
 sUr
-uAX
-wAZ
-akO
-lox
-wKP
+vQU
+wFf
+uVF
+xUc
+wWb
 tKZ
 gEY
-omd
-gkS
+eVh
+ibO
 sYX
-xJA
+lyk
 fyf
 fyf
 fyf
@@ -66312,10 +66930,10 @@ fyf
 fyf
 fyf
 uqa
-oTj
-nSQ
+mov
+oqA
 rpu
-xUt
+wec
 uqa
 mfD
 mfD
@@ -66323,17 +66941,17 @@ mfD
 mfD
 mfD
 hCg
-xJA
-ocU
-aGh
-huA
+lyk
+nbX
+rVl
+rqZ
 sUr
-mkV
-nZd
+mzC
+bDb
 erY
-rvP
-mWT
-ohH
+rWv
+qrJ
+nlz
 vPU
 fyf
 fyf
@@ -66492,40 +67110,40 @@ fbq
 azC
 fyf
 fyf
-tBN
+fyf
 mvv
 mvv
-gfR
+bHr
 hCg
 fyf
 gts
 dCV
 dCV
-lzV
-oEF
-rdC
-rHT
-tYd
-sCF
+dkd
+eov
 oIQ
-rdC
-xya
-xya
-hsk
-bUF
+fSE
+gsV
+fXP
+lmw
+oIQ
+iMi
+iMi
+klI
+lmV
 cam
 dkg
 dCV
-rEc
+bfr
 oFP
-xxV
-oIQ
-oIQ
-tFK
-nlG
+obr
+lmw
+lmw
+ovR
+oZC
 uqa
-oIQ
-oIQ
+lmw
+lmw
 dCV
 nGq
 bpD
@@ -66533,7 +67151,7 @@ fyf
 fyf
 fyf
 tKZ
-iuG
+sDr
 irP
 rpu
 sYX
@@ -66545,26 +67163,26 @@ hbW
 erY
 gmX
 tBB
-wKP
+wWb
 sUr
 vfu
-wKP
+wWb
 sYX
-tOf
-tOf
-sYX
-sYX
+sPJ
+sPJ
 sYX
 sYX
-jYo
 sYX
-xJA
+sYX
+xll
+sYX
+lyk
 fyf
-ijv
+lqi
 fyf
-ijv
+lqi
 fyf
-ijv
+lqi
 fyf
 fyf
 fyf
@@ -66575,23 +67193,23 @@ sDp
 uqa
 uqa
 uqa
-drN
+jLV
 uqa
-drN
+jLV
 uqa
-drN
+jLV
 uqa
-thR
-dHl
-huA
+oLT
+sjA
+rqZ
 sUr
-mkV
-doZ
-fAN
+mzC
+gmB
+uRN
 gmX
 tBB
 vfu
-fIV
+xKE
 vPU
 fyf
 fyf
@@ -66749,7 +67367,7 @@ cGu
 azC
 fyf
 fyf
-tBN
+fyf
 mvv
 mvv
 bpD
@@ -66759,39 +67377,39 @@ gts
 gts
 dCV
 uCO
-oJm
-qbe
-sDj
-urt
-sDj
-oIQ
-oIQ
-xwW
-nEi
+eqo
+fru
+fTW
+gtY
+fTW
+lmw
+lmw
+iMc
+jEX
 dCV
-eyp
+loo
 cpK
-xUO
-qKz
-kIM
+mdE
+mwa
+mTT
 oFP
-jsw
-tFK
-oIQ
-oIQ
-xem
+obV
+ovR
+lmw
+lmw
+pbr
 uqa
-vhu
-oIQ
+pOe
+lmw
 dCV
 gts
 gts
 fyf
 fyf
 fyf
-dPw
+suq
 sKH
-eyN
+sQo
 rpu
 sYX
 fyf
@@ -66802,27 +67420,27 @@ hbW
 erY
 gmX
 tBB
-dNg
+ubS
 vfu
-akO
+uVF
 vfu
 sYX
-oIQ
-tIE
-nEa
-gpv
-hUG
-fYv
-oIQ
+lmw
+vib
+dPF
+eGp
+euO
+bLX
+lmw
 sYX
-xJA
+lyk
 fyf
 fyf
 fyf
 fyf
 fyf
 uqa
-drN
+jLV
 uqa
 uqa
 uqa
@@ -66831,25 +67449,25 @@ lRW
 lRW
 rpu
 ivi
-oYd
+bqw
 ivi
 rpu
-hYI
-oYd
+vaZ
+bqw
 ivi
 uqa
 uqa
 fyf
-huA
+rqZ
 sUr
-nZT
-nZd
-fAN
+agk
+bDb
+uRN
 gmX
-qoJ
-rcP
+xac
+aFx
 sUr
-fIV
+xKE
 vPU
 fyf
 fyf
@@ -67006,7 +67624,7 @@ gjP
 gjP
 fyf
 fyf
-nlO
+fyf
 mfD
 mfD
 hCg
@@ -67016,30 +67634,30 @@ fyf
 gts
 dCV
 uCO
-mvV
+esj
+lmw
 oIQ
-rdC
+lmw
 oIQ
-rdC
-uSz
-uMZ
+gVE
+ihm
 dCV
 uqa
 eMW
-gmR
+lpd
 rRt
 cpK
 dCV
 dCV
 oFP
-wBA
-oIQ
-oIQ
-dpC
-hXu
+oco
+lmw
+lmw
+oXV
+pcP
 uqa
-kTz
-vhu
+pOo
+pOe
 dCV
 dCV
 gts
@@ -67048,7 +67666,7 @@ fyf
 fyf
 tKZ
 oeL
-fcw
+sQC
 iGO
 sYX
 fyf
@@ -67061,53 +67679,53 @@ gmX
 tBB
 sUr
 sUr
-kyA
+uXa
 sUr
-lzW
-oIQ
-oIQ
-sDi
-nCp
-oIQ
-gHW
-oIQ
-qbA
-xJA
+djk
+lmw
+lmw
+xor
+eeJ
+lmw
+vdE
+lmw
+wFp
+lyk
 fyf
-ijv
+lqi
 fyf
 fyf
 fyf
 uqa
-hNw
+uHl
 csO
-eqx
+bEe
 uqa
 lRW
 lRW
-ptt
+tRJ
 lRW
 ivi
 rpu
-yej
-nSQ
+uqd
+oqA
 ivi
 rpu
 ivi
 plt
 uqa
-sZF
-oVa
+ujK
+oQR
 sUr
-exn
-nZd
-iIc
+sfB
+bDb
+bqC
 gmX
-pNY
+ycD
 sUr
 sUr
 sUr
-fIV
+xKE
 vPU
 fyf
 fyf
@@ -67249,7 +67867,7 @@ bFJ
 gjP
 jTq
 vFz
-bcx
+lly
 uRJ
 cbk
 uRJ
@@ -67267,32 +67885,32 @@ fyf
 fyf
 fyf
 fyf
-wSj
+bJe
 fyf
 fyf
 gts
 dCV
 uCO
-mEn
-oON
-rdC
-rdC
-rdC
-rdC
+esE
+frx
 oIQ
-xMP
-ruj
-kzW
+oIQ
+oIQ
+oIQ
+lmw
+iMV
+jKV
+kmQ
 dkg
 cpK
 cpK
-mkV
+mzC
 fQr
 oFP
 oFP
 oFP
 gts
-bFr
+oYu
 lPT
 lPT
 lPT
@@ -67318,18 +67936,18 @@ gmX
 tBB
 vfu
 sUr
-akO
-dNg
+uVF
+ubS
 sYX
-gHW
-oIQ
-oIQ
-gQA
-voQ
-oIQ
-hoS
+vdE
+lmw
+lmw
+xWT
+xnr
+lmw
+adu
 sYX
-xJA
+lyk
 fyf
 fyf
 fyf
@@ -67338,29 +67956,29 @@ fyf
 sDp
 rpu
 rpu
-bHX
+gSZ
 uqa
-dpA
+bHZ
 lRW
-dim
+osT
 lRW
 ivi
 rpu
 ivi
-jZk
+cQU
 ivi
 rpu
 ivi
 rpu
 uqa
-huA
-nlL
+rqZ
+gCp
 sUr
-daW
-vIN
+nmv
+uQN
 mmK
 gmX
-wTf
+ymd
 sUr
 sUr
 sUr
@@ -67530,31 +68148,31 @@ fyf
 gts
 dCV
 dCV
-mGh
-qcS
-rLi
-rdC
+etg
+frz
+uFK
 oIQ
-oIQ
-qyz
-rLi
+lmw
+lmw
+iiG
+uFK
 uqa
-jVZ
+ykD
 dkg
 cpK
 gdY
-mkV
-hkG
+mzC
+iLr
 uqa
-hJM
+ocy
 mvv
-iRN
+oUj
 mvv
-mzS
+nwh
 mvv
-aGj
+pOL
 fyf
-djY
+qHZ
 dCV
 gts
 fyf
@@ -67575,31 +68193,31 @@ gmX
 tBB
 sUr
 sUr
-akO
-wKP
-qbA
-oIQ
-oIQ
-xxV
-vHI
-hZm
-tRa
-gUb
-qbA
-xJA
+uVF
+wWb
+wFp
+lmw
+lmw
+obr
+bkV
+weD
+ury
+vrw
+wFp
+lyk
 fyf
-ijv
+lqi
 fyf
 fyf
 fyf
 uqa
-wfC
+hpj
 rpu
-uUd
+rpu
 sDp
 lRW
 lRW
-rVr
+nHc
 lRW
 lRW
 lRW
@@ -67610,11 +68228,11 @@ lRW
 lRW
 rpu
 yjG
-huA
-wKP
+rqZ
+wWb
 sUr
-xoZ
-sZD
+xya
+hEq
 nBC
 gmX
 tBB
@@ -67770,7 +68388,7 @@ uRJ
 usn
 jnX
 uRJ
-buO
+uRJ
 uRJ
 uRJ
 nbI
@@ -67788,30 +68406,30 @@ gts
 gts
 dCV
 uCO
-qAc
-sCF
-rdC
-uSz
+fsQ
+fXP
 oIQ
-sCF
-xPh
-drN
-hpJ
+gVE
+lmw
+fXP
+iNN
+jLV
+knw
 dkg
 gdY
-jGl
+ipj
 pBv
-mUy
-lWJ
+mUS
+ntg
 mvv
 mvv
 mvv
-rjH
 mvv
 mvv
-alN
+mvv
+pSo
 fyf
-pvS
+qIE
 dCV
 gts
 fyf
@@ -67835,7 +68453,7 @@ sYX
 sYX
 sYX
 sYX
-jYo
+xll
 sYX
 sYX
 sYX
@@ -67843,36 +68461,36 @@ tKZ
 tKZ
 sYX
 sYX
-xJA
+lyk
 fyf
 fyf
 fyf
 fyf
 fyf
 uqa
-rbc
-nSQ
-uUd
+tDv
+oqA
+rpu
 uqa
-dpA
+bHZ
 lRW
-dwk
+nrv
 lRW
 ivi
 rpu
 ivi
 rpu
-yej
+uqd
 rpu
 ivi
 rpu
 uqa
-huA
-qCu
+rqZ
+lrq
 sUr
-mkV
-sZD
-fAN
+mzC
+hEq
+uRN
 nBC
 tBB
 vfu
@@ -68020,7 +68638,7 @@ uaf
 ndV
 uRJ
 mvJ
-buO
+uRJ
 wXv
 dJg
 uRJ
@@ -68045,28 +68663,28 @@ gts
 dCV
 dCV
 uCO
-oQv
-qlE
-oIQ
-xSa
-xSa
-uQx
-qlE
+fuc
+fXY
+lmw
+gWh
+gWh
+iiH
+fXY
 uqa
-fjN
+kpL
 dkg
 cam
 cah
 ajD
-uze
-rjH
+mUU
 mvv
 mvv
 rjH
 rjH
 mvv
-mvv
-iec
+rjH
+rjH
+pSC
 fyf
 fyf
 dCV
@@ -68088,21 +68706,21 @@ erY
 gmX
 tBB
 sYX
-afK
-ibg
-fps
+urt
+uXU
+vWq
 sYX
-voQ
-xxV
-gQA
-lwJ
-oIQ
-oIQ
-oIQ
+xnr
+obr
+xWT
+dso
+lmw
+lmw
+lmw
 sYX
-xJA
+lyk
 fyf
-ijv
+lqi
 fyf
 fyf
 fyf
@@ -68110,10 +68728,10 @@ uqa
 nfp
 rpu
 oeL
-iub
+nzf
 lRW
 lRW
-ptt
+tRJ
 lRW
 ivi
 rpu
@@ -68122,13 +68740,13 @@ rpu
 ivi
 rpu
 ivi
-fsO
+qbL
 uqa
-dGR
-sHM
-sHM
-mkV
-doZ
+uKb
+uJP
+uJP
+mzC
+gmB
 erY
 gmX
 tBB
@@ -68197,7 +68815,7 @@ pMI
 fyf
 fyf
 upX
-hAC
+fyf
 fyf
 fyf
 fyf
@@ -68304,26 +68922,26 @@ dCV
 dCV
 dCV
 dCV
-qDM
-sDr
-sDr
-sDr
+gfc
+rdC
+rdC
+rdC
 dCV
 dCV
-mbr
-qCu
-jGl
+kqe
+lrq
+adD
 dkg
-nhv
-smp
-rjH
-mvv
-mvv
+mCO
+qot
 mvv
 mvv
 rjH
 rjH
-lsW
+mvv
+rjH
+rjH
+pVp
 fyf
 fyf
 dCV
@@ -68345,19 +68963,19 @@ erY
 gmX
 tBB
 tKZ
-tRa
-puN
-oIQ
+ury
+uZg
+lmw
 sYX
-sDi
-xVh
-pIK
-gKg
-xVh
-kND
-oIQ
+xor
+xUW
+jlW
+utk
+xUW
+nQy
+lmw
 sYX
-xJA
+lyk
 fyf
 fyf
 fyf
@@ -68366,27 +68984,27 @@ fyf
 uqa
 uqa
 uqa
-drN
+jLV
 uqa
 lRW
 lRW
 lRW
 rpu
 ivi
-hOC
+tVd
 ivi
 rpu
 ivi
-wXR
+iGP
 ivi
 uqa
 uqa
 fyf
-eqo
-dGR
-jXw
-aJK
-lLP
+dUk
+uKb
+xeH
+aFv
+eRK
 erY
 tBB
 ioU
@@ -68557,30 +69175,30 @@ fyf
 fyf
 gts
 dCV
-lCi
-lCi
-oUj
+dlb
+dlb
+fuN
 dCV
-uJP
-yht
-sbj
-uRN
-qwq
-jRC
-dHO
+gvN
+hbK
+hAN
+ijm
+iNR
+jMz
+krd
 cam
-jGl
+ipj
 dkg
 jIB
-mUw
-rjH
-rjH
-mvv
+jfx
 mvv
 mvv
 rjH
 rjH
-iTV
+mvv
+rjH
+rjH
+qbe
 fyf
 fyf
 dCV
@@ -68600,27 +69218,27 @@ unI
 hbW
 erY
 gmX
-oJS
+tJk
 tKZ
-nvc
-kvC
-oIQ
-cvI
-gHW
-tqs
-mUP
-tqs
-mUP
-tqs
-ryc
-qbA
-xJA
+urL
+uZj
+lmw
+wFL
+vdE
+xWu
+obz
+xWu
+obz
+xWu
+grC
+wFp
+lyk
 fyf
-ijv
+lqi
 fyf
-ijv
+lqi
 fyf
-ijv
+lqi
 fyf
 fyf
 fyf
@@ -68631,21 +69249,21 @@ sDp
 uqa
 uqa
 uqa
-drN
+jLV
 uqa
-drN
+jLV
 uqa
-drN
+jLV
 uqa
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
-lwT
-lvy
-pNj
+lEo
+hfk
+mrA
 jIe
 fyf
 fyf
@@ -68814,32 +69432,32 @@ upX
 fyf
 gts
 dCV
-rWL
-xdD
-xdD
-qyj
-rJO
+dop
+pSk
+pSk
+fZm
+gwn
 ioU
-mbq
+hAX
 kdJ
 dkg
 cpK
 cpK
 dkg
-jPG
+xdD
 cam
 ajD
 lPT
-mzS
+nwh
 ovN
 mvv
 mvv
 mvv
 mvv
-rjH
-ciL
-hqC
-hqC
+mvv
+qcS
+cht
+cht
 dCV
 gts
 fyf
@@ -68849,7 +69467,7 @@ fyf
 fyf
 fyf
 fyf
-doo
+umW
 fyf
 fyf
 kGc
@@ -68859,19 +69477,19 @@ erY
 gmX
 tBB
 tKZ
-mXy
-gHW
-daY
+usO
+vdE
+vZs
 tKZ
-bpo
-gQA
-oIQ
-oIQ
-ioV
-oIQ
+xos
+xWT
+lmw
+lmw
+eCi
+lmw
 dWt
-qbA
-xJA
+wFp
+lyk
 fyf
 fyf
 fyf
@@ -68882,22 +69500,22 @@ fyf
 fyf
 fyf
 uqa
-sUT
-kPI
+iTt
+gvp
 rpu
-noD
+fvX
 uqa
-brr
+oLv
 cpK
 cpK
-wKP
-wKP
+wWb
+wWb
 sUr
 eme
 vPU
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
@@ -69062,7 +69680,7 @@ gjP
 gjP
 fyf
 fyf
-fyf
+gSt
 fyf
 gSt
 igz
@@ -69071,32 +69689,32 @@ igz
 igz
 gts
 dCV
-lCo
-xdD
-xdD
+doF
+pSk
+pSk
 dCV
 dkg
 nPX
 fyf
-paY
+ilc
 dkg
 cpK
 cpK
 cpK
 cpK
-sKG
+mdM
 ajD
-dEY
-nxL
+mVc
+nwp
 lKw
-wEJ
-wEJ
-wEJ
+oAS
+oAS
+oAS
 lKw
-nxL
-lWJ
-nxL
-flI
+nwp
+ntg
+nwp
+qJR
 dCV
 gts
 fyf
@@ -69116,38 +69734,38 @@ erY
 gmX
 tBB
 tKZ
-ohc
-tIE
-xxV
+uul
+vib
+obr
 tKZ
-oIQ
-tIE
-hzX
-myF
-tIE
-vcb
-rxo
+lmw
+vib
+uIz
+nIs
+vib
+rgE
+cdQ
 sYX
-xJA
+lyk
 fyf
-ijv
+lqi
 fyf
-ijv
+lqi
 fyf
-ijv
+lqi
 fyf
-rMd
+mWv
 fyf
 uqa
-fQv
+qcL
 uqa
 rpu
 gvW
 uqa
 cpK
 cpK
-wKP
-wKP
+wWb
+wWb
 sUr
 sUr
 ioU
@@ -69319,40 +69937,40 @@ sJw
 xgV
 fyf
 fyf
-fyf
+wIK
 fyf
 wIK
 hkW
 sTa
 ybI
-hxQ
+chX
 gts
 dCV
-lEx
-lEx
-lEx
-qDM
+dpS
+dpS
+dpS
+gfc
 pgl
-sOD
-ucw
+hhK
+hEa
 wIK
 ybI
 ybI
-lXd
+kru
 ybI
 ybI
-llP
+meU
 onk
 ybI
-dpc
-eTL
-lhp
-lhp
-lhp
-eTL
+nwu
+odc
+oBu
+oBu
+oBu
+odc
 ybI
 ybI
-jRv
+qxN
 pMI
 dCV
 gts
@@ -69373,19 +69991,19 @@ erY
 gmX
 tBB
 sYX
-hRF
-dWz
-xxV
+uyD
+viv
+obr
 sYX
-oON
-tIE
-hEe
-cuf
-tIE
-xVh
-wIG
+frx
+vib
+ivz
+jqa
+vib
+xUW
+bqP
 sYX
-xJA
+lyk
 fyf
 fyf
 fyf
@@ -69396,14 +70014,14 @@ fyf
 fyf
 fyf
 uqa
-wGY
-kPI
-nSQ
+jRW
+gvp
+oqA
 gvW
 uqa
 cpK
-wKP
-wKP
+wWb
+wWb
 sUr
 sUr
 ioU
@@ -69413,7 +70031,7 @@ fyf
 fyf
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
@@ -69485,7 +70103,7 @@ fyf
 fyf
 fyf
 fyf
-hAC
+fyf
 fyf
 fyf
 kdJ
@@ -69576,7 +70194,7 @@ aJb
 fJv
 fyf
 sZA
-fyf
+hCs
 fyf
 hCs
 rnx
@@ -69584,11 +70202,11 @@ aJb
 aJb
 aJb
 aJb
-lEG
+cXB
 aJb
 hBN
 aJb
-sNM
+gfR
 tUb
 pWN
 plq
@@ -69598,7 +70216,7 @@ aJb
 tUb
 idu
 idu
-jMO
+mfq
 idu
 idu
 idu
@@ -69608,7 +70226,7 @@ rnx
 aJb
 tUb
 idu
-jMO
+mfq
 xtl
 pMI
 dCV
@@ -69636,21 +70254,21 @@ tKZ
 tKZ
 tKZ
 sYX
-tOf
+sPJ
 sYX
 sYX
-tOf
+sPJ
 sYX
 sYX
-eCJ
-cgi
-cgi
-cgi
-cgi
-cgi
-cgi
-cgi
-ykw
+uRi
+lmU
+lmU
+lmU
+lmU
+lmU
+lmU
+lmU
+txp
 uxC
 uqa
 uqa
@@ -69658,9 +70276,9 @@ uqa
 uqa
 uqa
 uqa
-wKP
-wKP
-wKP
+wWb
+wWb
+wWb
 sUr
 ioU
 jIe
@@ -69678,11 +70296,11 @@ fyf
 fyf
 fyf
 fyf
-vCY
-vIe
-vIe
-iGk
-pAd
+lVu
+dYe
+dYe
+qQT
+xxs
 bpD
 fyf
 gcK
@@ -69739,7 +70357,7 @@ gcK
 gcK
 gcK
 gcK
-hAC
+fyf
 fyf
 fyf
 fyf
@@ -69833,7 +70451,7 @@ kjQ
 pWN
 uPP
 fyf
-fyf
+mEL
 fyf
 mEL
 wKo
@@ -69841,11 +70459,11 @@ dmL
 ehN
 hOl
 hOl
-lEG
+cXB
 hOl
 hOl
 hOl
-lEG
+cXB
 erY
 wGJ
 wGJ
@@ -69857,7 +70475,7 @@ wGJ
 erY
 erY
 wGJ
-wtJ
+naF
 erY
 erY
 wGJ
@@ -69866,13 +70484,13 @@ wGJ
 erY
 erY
 erY
-aRG
+qyj
 dCV
 dCV
 nGq
-hxQ
+chX
 ybI
-dpc
+nwu
 ybI
 ybI
 ybI
@@ -69885,61 +70503,61 @@ onk
 hbW
 erY
 gmX
-kFW
-fQc
-fQc
-fQc
-fQc
-gWm
-pWw
-fQc
-vNW
-vNW
-vVK
-sTm
-pFZ
-trJ
-fQc
-qjZ
-fQc
-pWw
-pWw
-wvH
-cSF
-cSF
-cwS
+tJx
+pJt
+pJt
+pJt
+pJt
+wGz
+qiU
+pJt
+oAX
+oAX
+ing
+nvP
+giQ
+mLe
+pJt
+nDN
+pJt
+qiU
+qiU
+ftN
+wbi
+wbi
+eqj
 fyf
 fyf
-xGz
-epy
-pWw
-pWw
-cSF
-fQc
-fQc
-gDJ
-cSF
-cwS
+uRs
+xrm
+qiU
+qiU
+wbi
+pJt
+pJt
+aAn
+wbi
+eqj
 fyf
 fyf
-eqo
+dUk
 fyf
 sqA
-eqo
+dUk
 fyf
 fyf
 fyf
 pis
 fyf
-eqo
+dUk
 fyf
 fyf
 qOV
-fAB
-uls
-frO
+wKv
+dXN
+tPA
 cbr
-shu
+kYB
 hCg
 fyf
 gcK
@@ -69997,7 +70615,7 @@ gcK
 gcK
 gcK
 fyf
-hAC
+fyf
 fyf
 sND
 fyf
@@ -70098,14 +70716,14 @@ btW
 kaM
 kaM
 kaM
-lEG
-moo
-oUy
-oUy
-sQo
-oUy
-sPJ
-ier
+cXB
+dsi
+etN
+etN
+ghx
+etN
+hiG
+hET
 qoS
 qoS
 kaM
@@ -70124,62 +70742,59 @@ erY
 erY
 kjQ
 kjQ
-ijs
+qKe
 hBN
-uWb
-pIN
-pIN
-pIN
-pIN
-pIN
-pIN
-pIN
-pIN
-pIN
-pIN
-pIN
+rDT
+pGa
+pGa
+pGa
+pGa
+pGa
+pGa
+pGa
+pGa
+pGa
+pGa
+pGa
 idu
 ehN
 ehN
 ehN
-wzg
-pIN
-pIN
-pIN
-pIN
-wzg
-wzg
-pIN
-pIN
-pIN
-uVn
-wzg
-wzg
-uWb
-pIN
-pIN
-pIN
-wzg
-uWb
-oCb
-dSx
-wzg
-lHZ
+tNI
+pGa
+pGa
+pGa
+pGa
+tNI
+tNI
+pGa
+pGa
+pGa
+yjB
+tNI
+tNI
+rDT
+pGa
+pGa
+pGa
+tNI
+rDT
+ubc
+vIJ
+tNI
+ygL
 fyf
 fyf
-wld
-ygP
-wzg
-wzg
-wzg
-uWb
-pIN
-uVn
-wzg
-lHZ
-fyf
-fyf
-fyf
+oGE
+xqe
+tNI
+tNI
+tNI
+rDT
+pGa
+yjB
+tNI
+ygL
 fyf
 fyf
 fyf
@@ -70188,15 +70803,18 @@ fyf
 fyf
 fyf
 fyf
-eqo
+fyf
+fyf
+fyf
+dUk
 nZr
 qOV
 daU
-kvr
+cVj
 cbr
-lJf
-cPV
-qcT
+vcu
+lPj
+fKq
 fyf
 fyf
 gcK
@@ -70351,37 +70969,37 @@ fyf
 fyf
 fyf
 ars
-gmZ
+bOG
 ees
-hEa
+cjG
 gts
 gts
-mrg
+dwx
 sYX
 sYX
 sYX
 sYX
-sQC
-uet
-uUZ
-xTF
+hjb
+hFY
+ilh
+iNX
 muk
 hbW
 erY
 wGJ
 wGJ
 erY
-pyM
-jZg
+ndT
+nwB
 wGJ
-iGP
+oEF
 apk
 wGJ
 erY
 erY
 erY
-vFh
-krR
+qzr
+qMj
 hOl
 hOl
 hOl
@@ -70399,42 +71017,42 @@ hOl
 sgz
 dmL
 sgz
-fSD
-vat
-djH
-djH
-sPJ
-hiX
-fSD
-vat
-iIc
-sPJ
-fSD
-hiX
-hiX
-djH
-djH
-djH
-djH
-hiX
-hiX
-vat
-djH
-sPJ
-rvP
-eSC
+tOP
+ucw
+uyP
+uyP
+hiG
+wHu
+tOP
+ucw
+bqC
+hiG
+tOP
+wHu
+wHu
+uyP
+uyP
+uyP
+uyP
+wHu
+wHu
+ucw
+uyP
+hiG
+rWv
+gur
 fyf
-lwT
-lLP
-fSD
-hiX
-vat
-djH
-iIc
-sPJ
-vat
-rvP
-eSC
+lEo
+eRK
+tOP
+wHu
+ucw
+uyP
+bqC
+hiG
+ucw
+rWv
+gur
 fyf
 fyf
 fyf
@@ -70447,13 +71065,13 @@ fyf
 fyf
 fyf
 qOV
-dwS
+rDU
 mvv
-iDJ
-iJG
+dqZ
+gJx
 cbr
-frO
-qcT
+tPA
+fKq
 fyf
 fyf
 gcK
@@ -70614,31 +71232,31 @@ ptf
 gts
 dCV
 sYX
-mPk
+eyg
 rpu
-qEj
+ghE
 sYX
 sYX
 sYX
 sYX
-cfS
+iOF
 ajD
 hbW
 hOl
 wGJ
-rrA
+mgo
 qac
 qac
-dpZ
+nxj
 wGJ
 erY
-kjF
+oUy
 apk
-kwy
-qBf
-voE
-xzU
-lEG
+pcT
+pEs
+qcT
+qAc
+cXB
 qoS
 qoS
 qoS
@@ -70656,61 +71274,61 @@ ehN
 qoS
 btW
 fvz
-kaj
+tPt
 oBQ
 oBQ
 oBQ
 oBQ
-hRA
-kaj
+wLB
+tPt
 oBQ
 oBQ
 oBQ
-hRA
-kaj
+wLB
+tPt
 oBQ
 oBQ
 oBQ
 oBQ
 oBQ
-fSD
-gkv
-mZk
+tOP
+nXd
+uCB
 oBQ
-hRA
-dNt
-wnU
+wLB
+ecS
+wOT
 fyf
 fyf
-wZn
-kaj
-kaj
-gkv
-vpJ
+uzM
+tPt
+tPt
+nXd
+hUr
 oBQ
 oBQ
-gkv
-dNt
-wnU
+nXd
+ecS
+wOT
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
-pJR
+cex
 cWG
 cWG
 wDc
 fyf
 qOV
-nGJ
-wEJ
+cgC
+oAS
 mvv
-eMZ
-gZx
-gZx
-gZx
-vtD
+oQq
+cRJ
+cRJ
+cRJ
+pKF
 fyf
 fyf
 gcK
@@ -70875,30 +71493,30 @@ sYX
 aug
 rpu
 sYX
-sUd
-ueL
+hjP
+hHD
 sYX
 cpK
-uaJ
-ogB
+jNj
+ktX
 hOl
 wGJ
 erY
 hOl
-bAX
+neN
 cdc
 wGJ
 ubg
 wGJ
-wVk
-aHN
+nzq
+pjQ
 dCV
-kDd
-kDd
-nmU
-lMB
+qed
+qed
+qPQ
+qWG
 gts
-hEa
+cjG
 ees
 muk
 hbW
@@ -70913,56 +71531,56 @@ gmX
 geM
 ees
 ees
-dqk
-gqj
-dqk
-dqk
-dqk
-dqk
-dqk
-dqk
-dqk
-dqk
-dqk
-dqk
-dqk
-dqk
-dqk
-gqj
-dqk
-dqk
-dqk
-bWt
-dqk
-dqk
-kiB
+eUp
+udf
+eUp
+eUp
+eUp
+eUp
+eUp
+eUp
+eUp
+eUp
+eUp
+eUp
+eUp
+eUp
+eUp
+udf
+eUp
+eUp
+eUp
+vDu
+eUp
+eUp
+xzU
 fyf
 fyf
 fyf
-xdL
-dqk
-dqk
-dqk
-dqk
-gqj
-dqk
-dqk
-kiB
+wiZ
+eUp
+eUp
+eUp
+eUp
+udf
+eUp
+eUp
+xzU
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-ocU
+nbX
 mvv
 mvv
 bpD
 fyf
 tBN
 mvv
-wEJ
-wZG
+oAS
+nBU
 mvv
 mvv
 mvv
@@ -71128,13 +71746,13 @@ fyf
 gts
 dCV
 sYX
-mPw
-oUR
+eyI
+fvt
 rpu
-rPM
+gzD
 rpu
 vXh
-uVF
+ilq
 gdY
 ajD
 hbW
@@ -71143,17 +71761,17 @@ hOl
 wGJ
 cdc
 hOl
-dpZ
+nxj
 wGJ
 wGJ
-nTc
-rrA
-aHN
+oUR
+mgo
+pjQ
 dCV
-uXd
-rgI
-rgI
-xdD
+qhs
+dza
+dza
+pSk
 gts
 ptf
 gNA
@@ -71211,9 +71829,9 @@ uxC
 uxC
 uxC
 uxC
-kne
+kcZ
 pXo
-adn
+eJr
 bpD
 fyf
 tBN
@@ -71369,7 +71987,7 @@ gjP
 hAC
 fyf
 ijg
-aWF
+uRJ
 gjP
 uRJ
 gjP
@@ -71385,7 +72003,7 @@ fyf
 gts
 dCV
 sYX
-mUU
+eAK
 rpu
 rpu
 sYX
@@ -71398,19 +72016,19 @@ agH
 erY
 hOl
 lZP
-hnx
+mDr
 cdc
 wGJ
 wGJ
-dpZ
+nxj
 wGJ
 wGJ
-iHr
-iIS
-xdD
-xdD
-xdD
-xdD
+pnw
+pHc
+pSk
+pSk
+pSk
+pSk
 gts
 fyf
 kGc
@@ -71468,14 +72086,14 @@ fyf
 fyf
 fyf
 fyf
-thR
+oLT
 mfD
-tSF
+mmH
 bpD
 fyf
 tBN
-czR
-ljA
+nSX
+tCo
 mvv
 mvv
 mvv
@@ -71642,32 +72260,32 @@ fyf
 gts
 dCV
 uTq
-mXF
+eAS
 rpu
 rpu
-rTY
+gzG
 rpu
-iyu
-jAf
+hHR
+ilI
 dkg
 ajD
-mLa
+kvT
 wGJ
 cdc
 wGJ
-ixC
-tDb
-wVk
-mGA
-roh
+mEn
+nfz
+nzq
+odS
+oIF
 cdc
 ubg
 gmX
-iIS
-uZR
-oum
-xdD
-rgI
+pHc
+qjj
+qAS
+pSk
+dza
 gts
 fyf
 kGc
@@ -71727,7 +72345,7 @@ gts
 gts
 fyf
 fyf
-ddf
+uWE
 hCg
 fyf
 tBN
@@ -71878,7 +72496,7 @@ uRJ
 uRJ
 uRJ
 hOJ
-aWF
+uRJ
 gjP
 yeJ
 lae
@@ -71889,7 +72507,7 @@ gjP
 gjP
 fyf
 fyf
-sND
+fyf
 fyf
 fyf
 fyf
@@ -71899,32 +72517,32 @@ fyf
 gts
 dCV
 uTq
-neN
+eCJ
 rpu
-qHx
-rTY
+ghG
+gzG
 rpu
-iyu
-uXa
+hHR
+ilM
 dkg
 ajD
-iPN
+kwe
 wGJ
 dmL
-okJ
-mYF
-okJ
+mgu
+mGo
+mgu
 uVo
-mGA
-iJw
+odS
+oJm
 wGJ
 wGJ
 gmX
-iIS
-lEC
-vXM
-aET
-fmO
+pHc
+qjF
+qBq
+qPW
+qZO
 gts
 fyf
 kGc
@@ -71932,7 +72550,7 @@ unI
 hbW
 cdc
 erY
-oua
+sEn
 fAt
 erY
 erY
@@ -72131,7 +72749,7 @@ koD
 bFJ
 xql
 ako
-aWF
+uRJ
 cpH
 xMe
 uRJ
@@ -72156,32 +72774,32 @@ fyf
 gts
 dCV
 uTq
-ngg
+eDx
 rpu
 rpu
 sYX
 rpu
-iyu
+hHR
 sYX
 cam
 ajD
 hbW
-jmm
-dCJ
-gAv
-giH
-okJ
+lrB
+lEG
+mkP
+mJu
+mgu
 cdc
-mGA
-iJw
+odS
+oJm
 wGJ
 wGJ
 ubg
 dCV
-iBv
+gZD
 dCV
 dCV
-xdD
+pSk
 gts
 fyf
 kGc
@@ -72246,7 +72864,7 @@ fyf
 fyf
 nlO
 xGH
-rEg
+uzb
 mvv
 aBH
 hCg
@@ -72406,21 +73024,21 @@ fyf
 fyf
 fyf
 fyf
-wSj
+bJe
 fyf
 fyf
 fyf
 gts
 dCV
 uTq
-nlv
+eDT
 rpu
 rpu
-rPM
+gzD
 aug
-iyu
+hHR
 sYX
-xUW
+iSE
 ajD
 xhJ
 kaM
@@ -72429,14 +73047,14 @@ kaM
 qoS
 qoS
 qoS
-bUR
-mgP
+ofe
+oKy
 qoS
 qoS
 qoS
 sYX
-pxs
-pxs
+qoj
+qoj
 uqa
 uqa
 gts
@@ -72670,15 +73288,15 @@ fyf
 gts
 dCV
 uTq
-nqU
+eEC
 rpu
 rpu
 sYX
-tdv
+hlQ
 vcM
 uTq
 cpK
-dJs
+jPG
 ees
 dNT
 gQv
@@ -72689,19 +73307,19 @@ ees
 ees
 gQv
 jZE
-qJl
+oYI
 ees
-yiM
-rgI
-rgI
-plH
-uUK
+pHi
+dza
+dza
+qQe
+rbF
 gts
 fyf
 kGc
 unI
 hbW
-oua
+sEn
 erY
 erY
 fAt
@@ -72931,10 +73549,10 @@ sYX
 sYX
 uTq
 uTq
-bWF
-ufP
+hmc
+hJd
 sYX
-yaw
+iSV
 cpK
 cpK
 dkg
@@ -72942,7 +73560,7 @@ dkg
 dkg
 dkg
 cpK
-xtm
+nAI
 dkg
 dkg
 dkg
@@ -72951,7 +73569,7 @@ iIG
 uqa
 uqa
 uqa
-gxv
+qTa
 uqa
 gts
 fyf
@@ -73016,7 +73634,7 @@ thG
 fyf
 fyf
 qOV
-sOS
+xRS
 mvv
 bpD
 fyf
@@ -73189,27 +73807,27 @@ dCV
 dCV
 dCV
 dCV
-iBv
+gZD
 sYX
-kKZ
+iVd
 cpK
-jPG
-jGl
-jGl
-jGl
-jPG
+xdD
+ipj
+ipj
+ipj
+xdD
 dkg
-dxG
+nCx
 dkg
 dkg
 dkg
 rRt
-vmg
+pqP
 uqa
-kGP
+qpJ
 uqa
 vcM
-bto
+rgI
 gts
 fyf
 kGc
@@ -73231,7 +73849,7 @@ fyf
 cuv
 eOZ
 fqg
-irf
+wMy
 sYX
 iAz
 rpu
@@ -73440,34 +74058,34 @@ gts
 dCV
 giZ
 giZ
-bet
+dwS
 giZ
 giZ
 giZ
 giZ
 dCV
-ulU
+hMs
 dkg
 cpK
 cpK
-wHo
-kBa
-eRU
-odk
-odk
-uND
-kBa
-oGL
-ykD
-sbk
+cah
+lsC
+lFI
+mnv
+mnv
+nhX
+lsC
+ofh
+iWi
+oVF
 uCW
-cFx
+prs
 uqa
-ruN
+qqQ
 xjA
 vlz
-buC
-pNN
+rpa
+rHE
 fyf
 kGc
 unI
@@ -73688,7 +74306,7 @@ uRJ
 ijg
 fyf
 fyf
-pis
+fyf
 fyf
 fyf
 fyf
@@ -73696,35 +74314,35 @@ fyf
 gts
 dCV
 giZ
-vlg
-vlg
-vlg
-oWU
-qHZ
+kXv
+kXv
+kXv
+fxf
+gim
 giZ
 giZ
-iBT
+hNY
 dkg
 gdY
 cpK
 dit
 dit
-aFD
-uCS
-uCS
-fkW
+lGG
+qZI
+qZI
+nkq
 dit
-fcr
-fYZ
-yel
+ogO
+oMA
+iVn
 uCW
-aOg
+psR
 uqa
-wXK
-gqo
+qrw
+qDM
 rpu
 rpu
-vdB
+rHT
 fyf
 kGc
 unI
@@ -73953,34 +74571,34 @@ fyf
 gts
 dCV
 giZ
-kIZ
-vlg
-vlg
-vlg
-oWU
-saf
-bet
-iFr
+cYT
+kXv
+kXv
+kXv
+fxf
+gzQ
+dwS
+hPV
 dkg
 dkg
 cpK
 dit
-jvN
-ucN
-qkB
-qkB
-tqi
+ltq
+lIX
+moo
+moo
+nlv
 dit
 dit
-kBa
+lsC
 dit
 uCW
 uCW
 uqa
-mLC
-bQy
+qul
+qDY
 vcM
-bVp
+rvT
 gts
 fyf
 kGc
@@ -74041,7 +74659,7 @@ gts
 fyf
 fyf
 thG
-eqo
+dUk
 fyf
 nlO
 mfD
@@ -74210,29 +74828,29 @@ fyf
 gts
 dCV
 giZ
-kPZ
-lKK
-dWR
-oXd
-eTZ
-sap
-twP
+tWd
+dyH
+eEK
+fyo
+gjM
+gBj
+hoX
 dkg
 cah
 dkg
 cpK
 dit
-uCS
-ucN
-ucN
-ucN
-rOF
+qZI
+lIX
+lIX
+lIX
+nlD
 dit
-qoj
-rbF
+ohx
+oOG
 dit
 uCW
-nNm
+puP
 uqa
 uqa
 uqa
@@ -74296,7 +74914,7 @@ rpu
 rpu
 gts
 fyf
-eqo
+dUk
 thG
 fyf
 fyf
@@ -74310,7 +74928,7 @@ fyf
 fyf
 fyf
 fyf
-eqo
+dUk
 gcK
 gcK
 ktB
@@ -74467,26 +75085,26 @@ fyf
 gts
 dCV
 giZ
-kXv
-lRT
-nwp
-dWR
-dWR
-sgr
-twP
-jPG
-jGl
+cZT
+dyO
+eGo
+eEK
+eEK
+gBT
+hoX
+xdD
+ipj
 dkg
 cpK
 dit
-rpD
-ucN
-qkB
-qkB
-ucN
-pSk
-qot
-rgI
+lun
+lIX
+moo
+moo
+lIX
+nGh
+oiz
+dza
 dit
 dCV
 dCV
@@ -74553,7 +75171,7 @@ ohk
 rpu
 gts
 fyf
-eqo
+dUk
 thG
 fyf
 fyf
@@ -74561,13 +75179,13 @@ fyf
 fyf
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
 fyf
-eqo
-eqo
+dUk
+dUk
 gcK
 gcK
 ktB
@@ -74707,7 +75325,7 @@ uRJ
 uRJ
 mvJ
 gjP
-aWF
+uRJ
 uRJ
 xql
 uRJ
@@ -74727,23 +75345,23 @@ giZ
 giZ
 giZ
 giZ
-vlg
-vlg
-sgr
-twP
-jPG
-jPG
-yel
-vpH
+kXv
+kXv
+gBT
+hoX
+xdD
+xdD
+iVn
+jPN
 dit
-pnB
-uCS
-uCS
-uCS
-xwZ
+luD
+qZI
+qZI
+qZI
+nnA
 dit
-rWL
-rgI
+dop
+dza
 dit
 dCV
 gts
@@ -74805,15 +75423,15 @@ fyf
 acn
 rpu
 rpu
-ofd
+bbK
 uzJ
 rpu
 gts
 fyf
-eqo
+dUk
 thG
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
@@ -74823,8 +75441,8 @@ fyf
 fyf
 fyf
 wjt
-eqo
-eqo
+dUk
+dUk
 gcK
 gcK
 ktB
@@ -74968,12 +75586,12 @@ uRJ
 iFb
 jnX
 uRJ
-aWF
+uRJ
 uRJ
 gjP
 fyf
 fyf
-sND
+fyf
 fyf
 fyf
 fyf
@@ -74984,23 +75602,23 @@ giZ
 giZ
 giZ
 giZ
-xdD
-xdD
+pSk
+pSk
 giZ
 giZ
 cpK
-jPG
-ykD
+xdD
+iWi
 cpK
 dit
 dit
 dit
-fhs
-fhs
+moH
+moH
 dit
 dit
-xdD
-rgI
+pSk
+dza
 dit
 dCV
 gts
@@ -75071,11 +75689,11 @@ fyf
 thG
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
-eqo
+dUk
 wjt
 fyf
 fyf
@@ -75215,7 +75833,7 @@ koD
 cam
 gjP
 iKm
-aWF
+uRJ
 pPe
 ijO
 uRJ
@@ -75238,26 +75856,26 @@ fyf
 gts
 dCV
 giZ
-noH
-rgI
-nwu
-xdD
-xdD
-sln
+dau
+dza
+eHB
+pSk
+pSk
+gCq
 giZ
 cpK
 uCW
-ykD
-mrQ
-wFz
+iWi
+jWx
+kBr
 dit
-tWt
-uCS
-uCS
-mJW
-fRM
-xdD
-rgI
+lKK
+qZI
+oKI
+noH
+nHi
+pSk
+dza
 dit
 dCV
 gts
@@ -75328,11 +75946,11 @@ fyf
 thG
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 wjt
-eqo
+dUk
 fyf
 fyf
 fyf
@@ -75402,7 +76020,7 @@ gts
 fyf
 fyf
 fyf
-hAC
+fyf
 fyf
 fyf
 fyf
@@ -75474,7 +76092,7 @@ gjP
 udt
 uRJ
 pPe
-aWF
+uRJ
 wyI
 uRJ
 jnX
@@ -75495,26 +76113,26 @@ fyf
 gts
 dCV
 giZ
-noH
-rgI
-xdD
-xdD
-eVh
-slT
+dau
+dza
+pSk
+pSk
+gmW
+gCu
 giZ
 cpK
-uZj
-ueN
+ish
+iXz
 cpK
-kzW
+kmQ
 dit
 dit
-whh
-lCs
-flj
+moO
+mMe
+npl
 dit
-xdD
-rgI
+pSk
+dza
 dit
 dCV
 gts
@@ -75589,7 +76207,7 @@ fyf
 fyf
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
@@ -75659,7 +76277,7 @@ gcK
 fyf
 fyf
 fyf
-hAC
+fyf
 fyf
 fyf
 fyf
@@ -75752,26 +76370,26 @@ fyf
 gts
 dCV
 giZ
-aDX
-xdD
-alM
-xdD
-qIE
-qIE
+dba
+pSk
+eIg
+pSk
+gmZ
+gmZ
 giZ
-jPG
+xdD
 cam
 gdY
 dkg
-rHA
+kBC
 dit
-ggk
+lKV
 dit
-xdJ
+mMI
 dit
 dit
-bnf
-rgI
+ojL
+dza
 dit
 dCV
 gts
@@ -75823,7 +76441,7 @@ fyf
 fyf
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
@@ -75846,7 +76464,7 @@ sqA
 fyf
 fyf
 fyf
-eqo
+dUk
 wjt
 fyf
 fyf
@@ -75916,7 +76534,7 @@ gcK
 fyf
 fyf
 fyf
-hAC
+fyf
 gts
 gts
 gts
@@ -76009,26 +76627,26 @@ fyf
 gts
 dCV
 giZ
+pSk
+pSk
+eLJ
+fAP
+gne
+gCN
+hpY
 xdD
 xdD
-oYI
-oXV
-sVs
-eDz
-lTx
-jPG
-jPG
 dkg
 dkg
-igy
+kCA
 dit
-rgI
-fAG
-xdD
-xdD
-psR
-rgI
-iRz
+dza
+moR
+pSk
+pSk
+nIj
+dza
+oON
 dit
 dCV
 gts
@@ -76103,7 +76721,7 @@ fyf
 fyf
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
@@ -76173,7 +76791,7 @@ gcK
 gcK
 fyf
 fyf
-hAC
+fyf
 gts
 qPp
 qIv
@@ -76270,22 +76888,22 @@ giZ
 giZ
 giZ
 giZ
-qIE
-snA
-lTx
+gmZ
+gDl
+hpY
 cpK
-vpa
-kQC
+isL
+jeX
 cpK
-lKV
+kIZ
 dit
-frv
+lMp
 dit
 dit
-xdD
-xdD
-rgI
-uwZ
+pSk
+mVn
+dza
+oOZ
 dit
 dCV
 gts
@@ -76528,21 +77146,21 @@ gts
 dCV
 giZ
 giZ
-uMU
+gET
 ids
 ids
-vuH
+itI
 rRt
 cpK
-oXA
+kKZ
 dit
-rgI
-gFA
-ccG
-rgI
-xdD
-xdD
-xdD
+dza
+mqy
+mMN
+dza
+pSk
+pSk
+pSk
 dit
 dCV
 gts
@@ -76559,7 +77177,7 @@ hbW
 erY
 erY
 erY
-srt
+tjy
 wGJ
 erY
 erY
@@ -76788,18 +77406,18 @@ dCV
 dCV
 dCV
 sYX
-jPN
+iyo
 cpK
 cpK
-ecx
+kNH
 dit
-aPF
-alk
-slU
-feM
-hsc
-omV
-uhp
+lOp
+mrg
+mNB
+npS
+nJc
+okc
+oQv
 dit
 dCV
 gts
@@ -76816,7 +77434,7 @@ hbW
 wGJ
 erY
 erY
-srt
+tjy
 wGJ
 erY
 erY
@@ -76850,7 +77468,7 @@ fyf
 fyf
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
@@ -77046,9 +77664,9 @@ gts
 gts
 dCV
 dCV
-gJI
+uCT
 ids
-lTx
+hpY
 dit
 dit
 dit
@@ -77073,7 +77691,7 @@ hbW
 cdc
 wGJ
 erY
-srt
+tjy
 wGJ
 erY
 erY
@@ -77107,7 +77725,7 @@ fyf
 fyf
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
@@ -77119,7 +77737,7 @@ gts
 gts
 aYG
 rpu
-jUw
+ipl
 hKY
 gts
 fyf
@@ -77291,7 +77909,7 @@ gjP
 fyf
 fyf
 fyf
-wSj
+bJe
 fyf
 fyf
 fyf
@@ -77360,11 +77978,11 @@ fyf
 fyf
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
@@ -77383,11 +78001,11 @@ fyf
 fyf
 thG
 fyf
-xKa
-vgc
-vgc
-vgc
-aTh
+hnk
+osJ
+osJ
+osJ
+kJj
 fyf
 fyf
 fyf
@@ -77542,7 +78160,7 @@ uRJ
 uRJ
 ijg
 uRJ
-buO
+uRJ
 uRJ
 srw
 fyf
@@ -77587,7 +78205,7 @@ hbW
 erY
 wGJ
 wGJ
-srt
+tjy
 wGJ
 erY
 wGJ
@@ -77603,7 +78221,7 @@ uCO
 uCO
 uCO
 uCO
-uRw
+kHf
 rpu
 cuv
 fyf
@@ -77617,11 +78235,11 @@ fyf
 fyf
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
@@ -77632,7 +78250,7 @@ dpO
 rpu
 gts
 rpu
-kyu
+rXu
 ioh
 rkZ
 gts
@@ -77640,14 +78258,14 @@ fyf
 fyf
 thG
 fyf
-uCt
-jEP
-khJ
-vHg
-jvt
+qmc
+wAq
+gzM
+moV
+cfc
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 gcK
@@ -77786,7 +78404,7 @@ yeJ
 srw
 nSK
 oDC
-bwo
+cnX
 hpc
 gjP
 gjP
@@ -77799,7 +78417,7 @@ uRJ
 jZb
 ijg
 wSw
-xVI
+cnX
 wSw
 srw
 fyf
@@ -77878,12 +78496,12 @@ fyf
 fyf
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
 gts
-hiB
+lvw
 wcA
 dGK
 rpu
@@ -77897,17 +78515,17 @@ fyf
 fyf
 thG
 fyf
-uCt
-jkh
+qmc
+wwb
 cbr
-jdv
-jvt
+gyG
+cfc
 fyf
 fyf
 fyf
 fyf
 fyf
-fDp
+ifu
 gcK
 gcK
 gcK
@@ -78043,7 +78661,7 @@ bFJ
 gjP
 gva
 uRJ
-bzq
+iFb
 uRJ
 jnX
 uRJ
@@ -78101,7 +78719,7 @@ hbW
 erY
 aXC
 wGJ
-srt
+tjy
 wGJ
 wGJ
 cdc
@@ -78127,7 +78745,7 @@ fyf
 fyf
 fyf
 fyf
-eqo
+dUk
 fyf
 fyf
 fyf
@@ -78154,14 +78772,14 @@ fyf
 fyf
 thG
 fyf
-uCt
-foX
-mqn
-jdv
-jvt
+qmc
+uYO
+umM
+gyG
+cfc
 fyf
 fyf
-oiP
+wuZ
 fyf
 fyf
 fyf
@@ -78305,7 +78923,7 @@ egK
 gjP
 ijg
 uRJ
-buO
+uRJ
 bAS
 ijg
 jZb
@@ -78358,7 +78976,7 @@ hbW
 wGJ
 wGJ
 wGJ
-srt
+tjy
 wGJ
 wGJ
 wGJ
@@ -78411,11 +79029,11 @@ fyf
 fyf
 thG
 fyf
-ccf
-cDk
-hKQ
-gks
-tYW
+sDO
+wqL
+uzn
+dkr
+jyf
 cWG
 wDc
 fyf
@@ -78493,8 +79111,8 @@ gcK
 gcK
 gcK
 fyf
-hAC
-hAC
+fyf
+fyf
 fyf
 kGc
 ajD
@@ -78581,7 +79199,7 @@ fyf
 fyf
 qOV
 daU
-adn
+eJr
 mvv
 bpD
 fyf
@@ -78603,7 +79221,7 @@ mvv
 mvv
 aBH
 hCg
-wSj
+bJe
 fyf
 fyf
 fyf
@@ -78617,7 +79235,7 @@ wGJ
 wGJ
 ltl
 erY
-wVk
+nzq
 wGJ
 gmX
 koD
@@ -78641,11 +79259,11 @@ fyf
 fyf
 fyf
 bIh
-dtK
+hGs
 pud
 bIh
-pSt
-dtK
+bCM
+hGs
 bIh
 bIh
 fyf
@@ -78668,14 +79286,14 @@ fyf
 fyf
 thG
 fyf
-uCt
-nJG
-jyF
+qmc
+kLm
+uCn
 cbr
-qhE
+tat
 mvv
 bpD
-eqo
+dUk
 fyf
 fyf
 fyf
@@ -78751,7 +79369,7 @@ gcK
 gcK
 gcK
 fyf
-hAC
+fyf
 fyf
 kGc
 jIB
@@ -78872,7 +79490,7 @@ hbW
 wGJ
 wGJ
 wGJ
-srt
+tjy
 erY
 sCK
 wGJ
@@ -78898,12 +79516,12 @@ fyf
 fyf
 fyf
 bIh
-kRf
-jXm
-sYw
+gMS
+cVK
+rIy
 qij
 qij
-ioY
+con
 bIh
 fyf
 fyf
@@ -78925,11 +79543,11 @@ fyf
 fyf
 thG
 fyf
-jMy
-qwn
-szQ
-jUv
-hop
+fHF
+nvx
+tMX
+lvv
+rkQ
 mfD
 hCg
 fyf
@@ -79008,7 +79626,7 @@ gcK
 gcK
 gcK
 fyf
-hAC
+fyf
 fyf
 kGc
 ofX
@@ -79160,11 +79778,11 @@ qij
 qij
 qij
 qij
-mwg
+cyU
 bIh
-dtK
+hGs
 bIh
-dtK
+hGs
 pud
 fyf
 fyf
@@ -79182,11 +79800,11 @@ sYX
 sYX
 sYX
 fyf
-rxW
-uwy
-xHC
-fKW
-lSB
+nKV
+bar
+wYh
+ptq
+dQD
 fyf
 fyf
 fyf
@@ -79386,7 +80004,7 @@ hbW
 erY
 erY
 erY
-srt
+tjy
 erY
 cdc
 erY
@@ -79402,25 +80020,25 @@ uCO
 uCO
 uCO
 uCO
-ipm
+nso
 rpu
 cuv
 fyf
 fyf
 fyf
 bIh
-pDH
-qKL
+odP
+pHJ
 pud
 tsB
 qij
 qij
-fgn
+aWs
 qij
 bix
 bIh
 hMM
-cdL
+jXJ
 hMM
 pud
 fyf
@@ -79591,14 +80209,14 @@ gjP
 gjP
 gva
 egK
-aWF
+uRJ
 hDQ
 uRJ
 uRJ
 uRJ
 uRJ
 uRJ
-buO
+uRJ
 gjP
 gjP
 fyf
@@ -79655,7 +80273,7 @@ thG
 fyf
 gcK
 gcK
-oKq
+wad
 ioh
 rkZ
 uCO
@@ -79666,19 +80284,19 @@ fyf
 fyf
 fyf
 bIh
-fmV
-qKL
-fBT
+iuW
+pHJ
+qfG
 qij
 uar
 qij
 qij
-cQM
+dfL
 qij
 bIh
-voY
+sWK
 qij
-rrk
+jDD
 pud
 fyf
 fyf
@@ -79697,11 +80315,11 @@ swx
 sYX
 fyf
 fyf
-xKa
-vgc
-vgc
-vgc
-aTh
+hnk
+osJ
+osJ
+osJ
+kJj
 fyf
 fyf
 fyf
@@ -79879,7 +80497,7 @@ fyf
 fyf
 fyf
 fyf
-wSj
+bJe
 fyf
 fyf
 fyf
@@ -79900,7 +80518,7 @@ hbW
 erY
 erY
 wGJ
-srt
+tjy
 erY
 wGJ
 erY
@@ -79913,7 +80531,7 @@ gcK
 gcK
 gcK
 gcK
-qxe
+wOj
 xVZ
 uCO
 rpu
@@ -79928,9 +80546,9 @@ pud
 bIh
 bIh
 bIh
-bSk
+byY
 tkm
-hOD
+urB
 nRc
 bIh
 qij
@@ -79954,14 +80572,14 @@ cbr
 sYX
 fyf
 fyf
-uCt
-jEP
-ctT
-tlg
-fMy
+qmc
+wAq
+odx
+vTZ
+feg
 cWG
 wDc
-oiP
+wuZ
 fyf
 fyf
 hwC
@@ -80130,12 +80748,12 @@ fyf
 fyf
 sND
 fyf
-vJr
-mDf
-mDf
-mDf
-mDf
-nnh
+jfV
+jXV
+jXV
+jXV
+jXV
+mrS
 fyf
 fyf
 fyf
@@ -80147,8 +80765,8 @@ sYX
 sYX
 sYX
 sYX
-kom
-maS
+ejD
+xUO
 sYX
 sYX
 kGc
@@ -80157,7 +80775,7 @@ hbW
 wGJ
 erY
 wGJ
-srt
+tjy
 erY
 wGJ
 erY
@@ -80183,10 +80801,10 @@ bIh
 oqm
 pOw
 rja
-gck
+jfW
 bIh
-ixu
-xUL
+oHw
+cAJ
 vno
 qij
 bIh
@@ -80211,11 +80829,11 @@ cbr
 sYX
 fyf
 fyf
-uCt
-qwn
+qmc
+nvx
 cbr
 cbr
-shu
+kYB
 mfD
 hCg
 fyf
@@ -80387,7 +81005,7 @@ fyf
 fyf
 fyf
 fyf
-mFi
+jiP
 qyR
 qyR
 qyR
@@ -80400,13 +81018,13 @@ fyf
 fyf
 fyf
 sYX
-okz
-aEX
+eVb
+pHm
 sDp
 rpu
-wfC
-dqo
-nPP
+hpj
+yao
+pCi
 kGD
 kGc
 unI
@@ -80414,7 +81032,7 @@ hbW
 cdc
 wGJ
 cdc
-neX
+tjI
 erY
 wGJ
 erY
@@ -80437,11 +81055,11 @@ fyf
 fyf
 qOV
 bIh
-gpz
+cpY
 qij
-rrk
+jDD
 qij
-tmm
+eXb
 qij
 qij
 qij
@@ -80450,7 +81068,7 @@ pud
 qij
 bIh
 cph
-xTM
+fOy
 bIh
 fyf
 thG
@@ -80468,11 +81086,11 @@ cbr
 sYX
 fyf
 fyf
-uCt
-foX
-ucj
+qmc
+uYO
+tvV
 cbr
-qcT
+fKq
 fyf
 fyf
 fyf
@@ -80644,10 +81262,10 @@ fyf
 fyf
 fyf
 fyf
-mFi
-dxS
-rQG
-mqy
+jiP
+jZk
+kNV
+lvp
 qyR
 xNE
 fyf
@@ -80657,14 +81275,14 @@ fyf
 fyf
 fyf
 sYX
-hRZ
+sQs
 usW
 uCO
-gSp
+qEj
 rpu
 rpu
-jcu
-vtj
+rJO
+gmR
 kGc
 unI
 hbW
@@ -80681,14 +81299,14 @@ dMW
 xQu
 xQu
 xQu
-qUK
-abi
+ryO
+fGS
 xQu
 xQu
 xQu
-xLz
+xXZ
 hCg
-gJW
+xZR
 tFR
 qvN
 fyf
@@ -80725,11 +81343,11 @@ cbr
 sYX
 fyf
 fyf
-uCt
-kPF
-hHs
+qmc
+dhE
+vQz
 cbr
-qcT
+fKq
 fyf
 fyf
 fyf
@@ -80815,7 +81433,7 @@ hbW
 dFQ
 gmX
 fLc
-aLo
+sJw
 ybI
 hYJ
 ybI
@@ -80888,23 +81506,23 @@ llj
 srw
 fyf
 fyf
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lGG
-rQG
-mqy
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+jZL
+kNV
+lvp
 qyR
 xNE
 fyf
@@ -80917,7 +81535,7 @@ sYX
 tKZ
 tKZ
 sYX
-bdg
+qGa
 rpu
 rpu
 rpu
@@ -80935,15 +81553,15 @@ wGJ
 gmX
 koD
 dMW
-evP
-frO
+tIu
+tPA
 cbr
-hKQ
+uzn
 cbr
 rpu
-qCT
+wPG
 xQu
-xUc
+yaw
 fyf
 fyf
 fyf
@@ -80956,10 +81574,10 @@ bIh
 rzV
 bIh
 bIh
-dRN
-tqG
-sjy
-gbl
+gza
+aBd
+nQJ
+kIn
 pud
 qij
 bIh
@@ -80982,11 +81600,11 @@ uNQ
 sYX
 fyf
 fyf
-uCt
-shT
-gWF
-pIB
-sxy
+qmc
+vfJ
+wUo
+jia
+iJZ
 fyf
 fyf
 fyf
@@ -81072,7 +81690,7 @@ hbW
 cdc
 dFQ
 tUb
-gbS
+idu
 idu
 hBN
 aJb
@@ -81145,23 +81763,23 @@ gjP
 gjP
 fyf
 fyf
-lhN
-goK
-hFY
-iRE
-lhN
-wCA
-bPk
-wCA
-lhN
-spi
-tAS
-umi
-vAy
-lhN
-lGG
-kOi
-mqy
+swU
+bPj
+cjU
+cIm
+swU
+rvr
+dKR
+rvr
+swU
+gFV
+lav
+cXh
+dxm
+swU
+jZL
+uBE
+lvp
 qyR
 xNE
 fyf
@@ -81175,7 +81793,7 @@ fyf
 fyf
 sYX
 rkZ
-jlB
+qTr
 rpu
 rpu
 sYX
@@ -81192,22 +81810,22 @@ wGJ
 gmX
 koD
 dMW
-evP
+tIu
 cbr
-gQO
-jyF
+ueL
+uCn
 eXw
 cbr
-iBO
+uFp
 xQu
 doX
 wDc
 qLa
 fyf
 nlO
-xBX
+jQE
 upG
-wsN
+nmD
 bIh
 qlv
 qij
@@ -81239,11 +81857,11 @@ sYX
 sYX
 fyf
 fyf
-rxW
-foB
-foB
-foB
-lSB
+nKV
+wch
+wch
+wch
+dQD
 fyf
 fyf
 mwp
@@ -81329,7 +81947,7 @@ hbW
 cdc
 cdc
 rbe
-gVV
+ehN
 ehN
 ehN
 hOl
@@ -81402,23 +82020,23 @@ llj
 srw
 fyf
 fyf
-lhN
-grC
-hJd
-iSE
-kZh
-wCA
-wCA
-wCA
-qJR
+swU
+bPk
+cmj
+cJZ
+dbh
+rvr
+rvr
+rvr
+gof
+gGt
 ulE
-tCc
 nUS
-wER
-fIa
-lwG
-rQG
-cVw
+shd
+ubv
+jZM
+kNV
+lvL
 qyR
 xNE
 fyf
@@ -81430,7 +82048,7 @@ fyf
 fyf
 fyf
 fyf
-vtj
+gmR
 rMz
 vXh
 rpu
@@ -81440,7 +82058,7 @@ kGc
 unI
 hbW
 wGJ
-wVk
+nzq
 erY
 fAt
 erY
@@ -81450,9 +82068,9 @@ gmX
 koD
 dMW
 xQu
-fJj
+tRX
 cbr
-ipG
+uCS
 cbr
 cbr
 xQu
@@ -81461,14 +82079,14 @@ bGM
 bpD
 qOV
 cWG
-hhQ
+imd
 fyf
-aRT
-ajj
+qjV
+giG
 bIh
-xjS
+lwy
 rEB
-aXR
+ogq
 bIh
 gcK
 gcK
@@ -81586,7 +82204,7 @@ hbW
 cdc
 cdc
 kaM
-hAX
+kaM
 qoS
 btW
 pSn
@@ -81650,7 +82268,7 @@ uRJ
 uRJ
 uRJ
 gjP
-buO
+aDs
 uRJ
 uRJ
 gjP
@@ -81659,23 +82277,23 @@ llj
 nMl
 fyf
 fyf
-lhN
-gwn
-hNY
-iSE
-lhN
-xuM
-wCA
-wCA
-lhN
-gsV
-tIO
-ury
-wLB
-lhN
-eSF
-rSf
-mqy
+swU
+bPH
+cmF
+cJZ
+swU
+dzf
+rvr
+rvr
+swU
+gHP
+tma
+nYI
+iys
+swU
+mHY
+kPZ
+lvp
 qyR
 xNE
 fyf
@@ -81707,20 +82325,20 @@ gmX
 koD
 dMW
 xQu
-fWi
-gSq
+tUC
+ufK
 xQu
 cbr
 cbr
-qPk
+wQZ
 mvv
 mvv
 bpD
-fOQ
+qSz
 mvv
 doX
 wDc
-aRT
+qjV
 gcK
 gcK
 gcK
@@ -81843,7 +82461,7 @@ hbW
 bJB
 gmX
 uoS
-hXv
+fsm
 gQv
 jZE
 ees
@@ -81916,24 +82534,24 @@ cPn
 gjP
 wEo
 fyf
-lhN
-gQW
-hOs
-iWi
-lhN
-nJM
-wCA
-pbr
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
+swU
+bRF
+cpL
+daM
+swU
+dGZ
+rvr
+fDx
+swU
+swU
+swU
+swU
+swU
+swU
 bFJ
 qyR
 qyR
-kdS
+lRT
 xNE
 fyf
 fyf
@@ -81944,9 +82562,9 @@ fyf
 fyf
 fyf
 fyf
-ubS
+quy
 csO
-wQY
+qUC
 rpu
 sYX
 slt
@@ -81977,7 +82595,7 @@ tBN
 mvv
 mvv
 doX
-ayf
+fNE
 gcK
 gcK
 gcK
@@ -82173,25 +82791,25 @@ uey
 fyf
 thG
 fyf
-lhN
-gVd
-hVd
+swU
+bVq
+csl
 sWI
-lhN
-xuM
-wCA
-wCA
-wCA
-wCA
-wCA
-wCA
-kcY
-lhN
-inj
-bWx
-pbj
-pbj
-tRx
+swU
+dzf
+rvr
+rvr
+rvr
+rvr
+rvr
+rvr
+def
+swU
+kbS
+kQC
+lvR
+lvR
+mtX
 fyf
 fyf
 fyf
@@ -82221,12 +82839,12 @@ gmX
 koD
 dMW
 xQu
-gan
+tUH
 rpu
-iqF
+uDp
 cbr
-oLV
-iqF
+whS
+uDp
 mvv
 mvv
 bpD
@@ -82234,7 +82852,7 @@ tBN
 mvv
 mvv
 aBH
-lSz
+xGR
 gcK
 gcK
 gcK
@@ -82430,20 +83048,20 @@ igz
 bEw
 thG
 fyf
-lhN
-hgJ
+swU
+bWF
 sWI
-iXz
-lhN
-wCA
-wCA
-wCA
-wCA
-pcP
-qPQ
-uzn
-uXU
-liO
+cKC
+swU
+rvr
+rvr
+rvr
+rvr
+cwO
+eRO
+ook
+qwp
+jkj
 bFJ
 dMW
 fyf
@@ -82462,7 +83080,7 @@ sYX
 vXh
 rpu
 taN
-vtj
+gmR
 fyf
 kGc
 unI
@@ -82487,11 +83105,11 @@ uqa
 uqa
 mvv
 bpD
-kMs
+cgY
 mvv
 mvv
 bpD
-soE
+qmJ
 gcK
 gcK
 gcK
@@ -82682,25 +83300,25 @@ tdU
 srw
 uey
 kGc
-eVb
+bts
 xKx
 dMW
 thG
 fyf
-lhN
-hgJ
+swU
+bWF
 sWI
-jiP
-lhN
-lUg
-lhN
-lhN
-wCA
-gGt
-tJk
-puX
-kdi
-liO
+cKN
+swU
+dHq
+swU
+swU
+rvr
+cxy
+hqC
+cBb
+gkZ
+jkj
 bFJ
 dMW
 fyf
@@ -82715,9 +83333,9 @@ fyf
 fyf
 fyf
 fyf
-fQV
-odo
-jiX
+qwq
+qGx
+qUO
 dpO
 sYX
 fyf
@@ -82735,12 +83353,12 @@ gmX
 koD
 dMW
 fqa
-gsy
+tUS
 rpu
 rpu
 rpu
 rpu
-qQN
+wRb
 uqa
 aBH
 hCg
@@ -82930,7 +83548,7 @@ sVF
 bFJ
 srw
 rjW
-buO
+aDs
 iFb
 cpH
 gjP
@@ -82944,21 +83562,21 @@ xKx
 dMW
 thG
 fyf
-lhN
-hmc
-ilM
-jiP
-lhN
-bIV
-nyZ
-lhN
-wCA
-gCN
-nRu
-wCA
-kcY
-lhN
-miL
+swU
+bXC
+cvE
+cKN
+swU
+dIN
+eJu
+swU
+rvr
+gIA
+mgV
+rvr
+def
+swU
+ipS
 dMW
 fyf
 fyf
@@ -82977,7 +83595,7 @@ sYX
 sYX
 sYX
 sYX
-cLD
+rTY
 kGc
 unI
 hbW
@@ -82992,14 +83610,14 @@ gmX
 koD
 dMW
 xQu
-gsP
+tYd
 rpu
-iBO
+uFp
 xQu
 uqa
 uqa
 xny
-xWu
+yaT
 cWG
 daU
 bGM
@@ -83196,25 +83814,25 @@ mNS
 gjP
 fyf
 kGc
-fbH
+buO
 trd
 dMW
 thG
 fyf
-lhN
-hnq
-isL
-jzN
-lhN
-bPj
-nCx
-lhN
-wCA
-pcP
-tNI
-uzn
-uXU
-liO
+swU
+bZq
+cwB
+cNE
+swU
+dJY
+eLe
+swU
+rvr
+cwO
+pDX
+ook
+qwp
+jkj
 bFJ
 dMW
 fyf
@@ -83253,16 +83871,16 @@ xQu
 xQu
 xQu
 xQu
-iBO
+uFp
 mvv
-vFD
+xoF
 mfD
 mfD
 xGH
 mvv
 mvv
 bpD
-ksp
+bgL
 gcK
 gcK
 gcK
@@ -83360,7 +83978,7 @@ cTp
 fyf
 fyf
 fyf
-hAC
+fyf
 fyf
 fyf
 fyf
@@ -83458,20 +84076,20 @@ lae
 dMW
 thG
 fyf
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-wCA
-gGt
-qTa
-puX
-kdi
-liO
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+rvr
+cxy
+cNH
+cBb
+gkZ
+jkj
 bFJ
 dMW
 fyf
@@ -83484,8 +84102,8 @@ fyf
 fyf
 fyf
 sYX
-maS
-maS
+xUO
+xUO
 sYX
 sYX
 sYX
@@ -83506,20 +84124,20 @@ gmX
 koD
 dMW
 xQu
-gvN
+tYL
 rpu
 rpu
-lvc
-oMR
+vlg
+wmJ
 mvv
 bpD
 fyf
-sWy
+jjT
 tBN
-ulY
+ibt
 aBH
 hCg
-lYx
+oHo
 gcK
 gcK
 gcK
@@ -83617,7 +84235,7 @@ vQS
 fyf
 fyf
 fyf
-hAC
+fyf
 fyf
 fyf
 fyf
@@ -83715,20 +84333,20 @@ xKx
 dMW
 thG
 fyf
-lhN
-wCA
-wCA
-wCA
-wCA
-bPk
-wCA
-wCA
-wCA
-wCA
-wCA
-wCA
-kfx
-lhN
+swU
+rvr
+rvr
+rvr
+rvr
+dKR
+rvr
+rvr
+rvr
+rvr
+rvr
+rvr
+iyu
+swU
 bFJ
 dMW
 fyf
@@ -83740,14 +84358,14 @@ sYX
 fyf
 fyf
 fyf
-vtj
-uKT
-vPh
+gmR
+puX
+pIC
 uCO
 csO
 rpu
 rpu
-lxk
+mvV
 kGD
 kGc
 unI
@@ -83766,7 +84384,7 @@ xQu
 bHo
 cbr
 mvv
-lDd
+vpa
 mvv
 mvv
 doX
@@ -83776,7 +84394,7 @@ nlO
 mfD
 hCg
 fyf
-aRT
+qjV
 gcK
 gcK
 gcK
@@ -83872,7 +84490,7 @@ mNU
 mNU
 fyf
 fyf
-hAC
+fyf
 fyf
 fyf
 fyf
@@ -83972,39 +84590,39 @@ uaf
 dMW
 thG
 fyf
-lhN
-wCA
-pcP
-qPQ
-aYp
-bRF
-dza
-pcP
-qPQ
-wCA
-lhN
-lhN
-lhN
-lhN
+swU
+rvr
+cwO
+eRO
+ddR
+dLa
+eNC
+cwO
+eRO
+rvr
+swU
+swU
+swU
+swU
 ptf
 edA
 fyf
 fyf
 sYX
 wEO
-sft
+nqU
 sYX
 sYX
 sYX
 sYX
 sYX
-jEl
+pya
 dhC
 uCO
-kzl
+qHn
 rpu
-caq
-sph
+rym
+rPM
 sYX
 kGc
 unI
@@ -84019,15 +84637,15 @@ wGJ
 gmX
 koD
 dMW
-ewa
-gzQ
-hiG
+tIO
+uag
+ufP
 mvv
 mvv
 mvv
 mvv
 xQu
-ymd
+yel
 cWG
 cWG
 cWG
@@ -84133,7 +84751,7 @@ fyf
 fyf
 fyf
 fyf
-hAC
+fyf
 fyf
 tBN
 mvv
@@ -84149,7 +84767,7 @@ sYX
 sYX
 sYX
 fyf
-qTY
+fyf
 kGc
 ofX
 hbW
@@ -84211,7 +84829,7 @@ cpK
 gjP
 gva
 uRJ
-buO
+aDs
 uRJ
 jnX
 iFb
@@ -84224,45 +84842,45 @@ gwW
 jZb
 srw
 kGc
-foN
+bwo
 dkg
 dMW
 thG
 fyf
-lhN
+swU
+rvr
+cxy
+cNH
+rvr
+rvr
+ePh
+fEg
+cNH
+rvr
+swU
 wCA
-gGt
-qTa
-wCA
-wCA
-nHi
-pjQ
-qTa
-wCA
-lhN
-uCn
 peG
-lhN
+swU
 yeJ
 ssm
 fyf
 fyf
 sYX
-aYU
-hRZ
+mNK
+sQs
 uCO
-iNO
+okz
 uCO
-vFc
+oWn
 uCO
-vei
+pzm
 dhC
 uCO
-jKx
+qHx
 rpu
 rpu
 msy
-vtj
+gmR
 kGc
 unI
 hbW
@@ -84276,19 +84894,19 @@ wGJ
 gmX
 koD
 dMW
-fbM
-gCc
-hlh
+tIP
+ubt
+ulC
 mfD
 xGH
 xQu
 xQu
-vKd
-bHt
+xpr
+yfI
 mvv
-bHt
-nXd
-fej
+yfI
+llz
+vXw
 fiB
 daU
 mvv
@@ -84477,7 +85095,7 @@ iFb
 cpH
 gjP
 uRJ
-bzq
+bfq
 wXv
 gjP
 kGc
@@ -84486,20 +85104,20 @@ xKx
 dMW
 thG
 fyf
-lhN
-hpj
-wCA
-wCA
-wCA
-lYu
-nJM
-wCA
-wCA
-wCA
+swU
+cai
+rvr
+rvr
+rvr
+dLg
+dGZ
+rvr
+rvr
+rvr
 iwm
-uCS
-kfJ
-lhN
+qZI
+iBv
+swU
 uUS
 nPX
 uey
@@ -84738,26 +85356,26 @@ uRJ
 jZb
 gjP
 kGc
-fqS
+bwG
 xKx
 dMW
 thG
 fyf
-lhN
-wCA
-uzn
-uXU
-loo
-wCA
-nNZ
-pnw
-uXU
-wCA
-lhN
-lhN
-lhN
-lhN
-rFD
+swU
+rvr
+ook
+qwp
+deb
+rvr
+ePw
+fFT
+qwp
+rvr
+swU
+swU
+swU
+swU
+kcc
 nPX
 fyf
 fyf
@@ -85000,30 +85618,30 @@ ptf
 edA
 thG
 fyf
-lhN
-wCA
-puX
-kdi
-kcY
-lZY
-nRu
-puX
-kdi
-wCA
+swU
+rvr
+cBb
+gkZ
+def
+dSd
+mgV
+cBb
+gkZ
+rvr
 iwm
-uCS
-wQZ
-lhN
+qZI
+ebc
+swU
 uUS
 nPX
 hAC
 fyf
 sYX
 rpu
-jVg
+hXv
 rkZ
-pFS
-jVg
+olt
+hXv
 foz
 sDp
 trr
@@ -85040,7 +85658,7 @@ hbW
 wGJ
 wGJ
 erY
-srt
+tjy
 wGJ
 erY
 erY
@@ -85257,20 +85875,20 @@ fyf
 fyf
 thG
 fyf
-lhN
-wCA
-wCA
-wCA
-wCA
-mar
-wCA
-wCA
-wCA
-wCA
-lhN
-uCS
-wRb
-lhN
+swU
+rvr
+rvr
+rvr
+rvr
+dTT
+rvr
+rvr
+rvr
+rvr
+swU
+qZI
+iBT
+swU
 hzb
 jMC
 fyf
@@ -85297,7 +85915,7 @@ hbW
 erY
 wGJ
 wGJ
-srt
+tjy
 wGJ
 erY
 erY
@@ -85424,7 +86042,7 @@ gcK
 gcK
 gcK
 fyf
-hAC
+fyf
 sqA
 tBN
 mvv
@@ -85514,20 +86132,20 @@ fyf
 fyf
 thG
 fyf
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
-lhN
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
+swU
 oCi
 ssm
 hAC
@@ -85535,8 +86153,8 @@ fyf
 sYX
 sYX
 sYX
-kom
-maS
+ejD
+xUO
 sYX
 sYX
 sYX
@@ -85544,8 +86162,8 @@ yjG
 yjG
 sYX
 sYX
-kom
-qUK
+ejD
+ryO
 sYX
 sYX
 kGc
@@ -85554,7 +86172,7 @@ hbW
 erY
 cdc
 wGJ
-srt
+tjy
 wGJ
 erY
 erY
@@ -85681,7 +86299,7 @@ gcK
 gcK
 gcK
 fyf
-hAC
+fyf
 fyf
 tBN
 mvv
@@ -85769,7 +86387,7 @@ feL
 feL
 feL
 feL
-fTW
+bFY
 igz
 igz
 igz
@@ -86006,7 +86624,7 @@ hbW
 dFQ
 gmX
 fLc
-aLo
+ahK
 ybI
 ybI
 ybI
@@ -86062,13 +86680,13 @@ ybI
 ybI
 ybI
 ybI
-aLo
+ahK
 onk
 hbW
 erY
 erY
 wGJ
-srt
+tjy
 erY
 erY
 cdc
@@ -86263,7 +86881,7 @@ hbW
 toS
 dFQ
 tUb
-gbS
+ajX
 idu
 idu
 idu
@@ -86319,7 +86937,7 @@ aJb
 tUb
 idu
 dbY
-gbS
+ajX
 idu
 erY
 erY
@@ -86520,7 +87138,7 @@ agH
 cdc
 cdc
 cdc
-gVV
+alM
 ehN
 ehN
 hOl
@@ -86576,7 +87194,7 @@ dmL
 sgz
 kjQ
 dmL
-gVV
+alM
 ehN
 erY
 erY
@@ -86777,7 +87395,7 @@ hbW
 cdc
 cdc
 kaM
-hAX
+amy
 kaM
 kaM
 kaM
@@ -86833,7 +87451,7 @@ btW
 fvz
 kaM
 btW
-hAX
+amy
 kaM
 erY
 erY
@@ -87034,7 +87652,7 @@ hbW
 bJB
 gmX
 uoS
-hXv
+arb
 ees
 ees
 ees
@@ -87090,7 +87708,7 @@ ees
 ees
 ees
 ees
-hXv
+arb
 muk
 hbW
 erY
@@ -87822,10 +88440,10 @@ fyf
 jMj
 wdJ
 tsT
-fru
+bzq
 tsT
 niH
-fVZ
+bGu
 qwi
 wdJ
 naZ
@@ -88337,8 +88955,8 @@ qwi
 hsh
 qwi
 tsT
-fru
-frx
+bzq
+bzr
 wzw
 qwi
 qwi
@@ -88595,7 +89213,7 @@ qwi
 qwi
 rZf
 niH
-frz
+bzZ
 gOf
 qwi
 fyf
@@ -88638,7 +89256,7 @@ hbW
 erY
 erY
 erY
-srt
+tjy
 erY
 erY
 erY
@@ -88852,7 +89470,7 @@ hsh
 qwi
 toF
 tsT
-fuN
+bEP
 irk
 qwi
 fyf
@@ -89390,7 +90008,7 @@ unI
 hbW
 erY
 erY
-viM
+nJz
 erY
 qnz
 gmX
@@ -89666,7 +90284,7 @@ hbW
 cdc
 erY
 wGJ
-kws
+bSg
 erY
 erY
 erY
@@ -89923,7 +90541,7 @@ hbW
 erY
 erY
 wGJ
-srt
+tjy
 erY
 erY
 sCK
@@ -90218,12 +90836,12 @@ gcK
 gcK
 gcK
 hom
-wZd
-xcg
-tIY
-tFr
-tFr
-rZG
+wGx
+vDQ
+eMB
+asw
+asw
+ncN
 hom
 qOV
 cWG
@@ -90430,7 +91048,7 @@ dhC
 gts
 uCW
 cpK
-ofh
+blj
 uCW
 unI
 hbW
@@ -90475,7 +91093,7 @@ gcK
 gcK
 gcK
 hom
-xac
+afo
 hjc
 hjc
 hjc
@@ -90723,7 +91341,7 @@ hom
 cjV
 hbO
 qSM
-tTT
+vVR
 hom
 gcK
 gcK
@@ -90743,15 +91361,15 @@ tBN
 mvv
 bpD
 hom
-shW
-tTT
-shW
+xhF
+vVR
+xhF
 gUq
 gUq
 hom
 oHR
-pck
-dtI
+spC
+gPo
 hom
 gcK
 gcK
@@ -90980,7 +91598,7 @@ hom
 cjV
 cjV
 ata
-tTT
+vVR
 hom
 gcK
 gcK
@@ -90993,7 +91611,7 @@ ftz
 hjc
 hjc
 hjc
-qob
+jYG
 hjc
 hom
 tBN
@@ -91001,14 +91619,14 @@ mvv
 bpD
 hom
 kSt
-tTT
+vVR
 kSt
 gUq
-tag
+dzm
 hom
-tTT
-tTT
 vVR
+vVR
+pey
 hom
 gcK
 gcK
@@ -91243,29 +91861,29 @@ gcK
 gcK
 gcK
 gcK
-iOv
+uaD
 sVl
 hom
 hom
 hvk
 hvk
-rfx
+xIG
 hom
 dvo
 hom
 tBN
 mvv
-gue
-vfR
+cFg
+aRZ
 kSt
-tTT
+vVR
 kSt
 gUq
-oKf
+tDk
 hom
 aBk
-tTT
-pzV
+vVR
+mWE
 hom
 gcK
 gcK
@@ -91494,31 +92112,31 @@ hom
 hbO
 upj
 ata
-rfR
+kpo
 hom
 gcK
 gcK
 gcK
 gcK
-iOv
+uaD
 sVl
 hom
 nTm
-tTT
-tTT
-tTT
-xwR
-tTT
+vVR
+vVR
+vVR
+hOs
+vVR
 rgS
-xuJ
+xSa
 mvv
 mvv
 vme
-tTT
-tTT
-tTT
+vVR
+vVR
+vVR
 gUq
-oXp
+oZf
 hom
 hom
 vme
@@ -91751,35 +92369,35 @@ uGF
 cjV
 hbO
 dPe
-tTT
+vVR
 hom
 gcK
 gcK
 gcK
 gcK
-iOv
+uaD
 sVl
 hom
 jNl
 jNl
 jNl
 jNl
-tTT
-tTT
+vVR
+vVR
 rgS
-xuJ
+xSa
 mvv
-cVV
-vfR
+goK
+aRZ
 kSt
-tTT
+vVR
 kSt
 gUq
-oKf
+tDk
 hom
 kpd
-tTT
-pzV
+vVR
+mWE
 hom
 gcK
 gcK
@@ -92014,28 +92632,28 @@ gcK
 gcK
 gcK
 gcK
-iOv
+uaD
 sVl
 ucJ
 qWU
-xor
-jCg
+fCT
+qLU
 tHw
-tTT
-tTT
+vVR
+vVR
 rgS
-xuJ
+xSa
 mvv
 bpD
 hom
 kSt
-tTT
+vVR
 kSt
 gUq
-tag
+dzm
 hom
-tTT
-rfR
+vVR
+kpo
 vHe
 hom
 gcK
@@ -92203,7 +92821,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+qIE
 fyf
 fyf
 fyf
@@ -92260,40 +92878,40 @@ gcK
 gcK
 hom
 aof
-tTT
-tTT
+vVR
+vVR
 vme
 oMY
-tTT
-tTT
+vVR
+vVR
 hom
 gcK
 gcK
 gcK
 gcK
-iOv
+uaD
 sVl
 hom
-tQV
-bla
-tQV
-bla
-tTT
-tTT
+hxQ
+jGJ
+hxQ
+jGJ
+vVR
+vVR
 hom
 fbD
 mvv
 bpD
 hom
-shW
-tTT
-shW
+xhF
+vVR
+xhF
 gUq
 gUq
-iMd
-tTT
-xcL
-xcL
+kvv
+vVR
+kLk
+kLk
 hom
 gcK
 gcK
@@ -92457,7 +93075,7 @@ gcK
 gcK
 fyf
 fyf
-fyf
+qIE
 fyf
 fyf
 fyf
@@ -92521,23 +93139,23 @@ rgS
 hom
 hom
 pSu
-fMv
-tTT
+pso
+vVR
 hom
 gcK
 gcK
 gcK
-iOv
+uaD
 sVl
 sVl
 hom
 nTm
-tTT
-tTT
-tTT
-tTT
-tTT
-qIc
+vVR
+vVR
+vVR
+vVR
+vVR
+jJa
 mvv
 mvv
 bpD
@@ -92619,7 +93237,7 @@ fyf
 fyf
 fyf
 fyf
-qTY
+fyf
 fyf
 dit
 eQx
@@ -92714,22 +93332,22 @@ gcK
 fyf
 fyf
 qOV
-hqC
-hqC
-hqC
-hqC
-ghx
-fyf
-eqo
-fyf
-fyf
+cht
+cht
+cht
+cht
+bKs
+qHZ
+dUk
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-xJA
+fyf
+fyf
+lyk
 fyf
 fyf
 hej
@@ -92778,24 +93396,24 @@ cWG
 brE
 hom
 pSu
-tTT
+vVR
 oMY
 hom
 hom
 hom
 hom
-fPl
+qmp
 sVl
 sVl
 hom
-gZJ
+tQV
 fmn
 jNl
 fmn
-tTT
-tTT
+vVR
+vVR
 hom
-gaF
+gqd
 mvv
 bpD
 fyf
@@ -92986,7 +93604,7 @@ sYX
 sYX
 sYX
 fyf
-xJA
+lyk
 fyf
 fyf
 hej
@@ -93034,23 +93652,23 @@ mvv
 mvv
 mvv
 vme
-tTT
-tTT
+vVR
+vVR
 vHe
 hom
 tHw
 rEd
 hom
-fPl
+qmp
 uXj
 sVl
 ucJ
 tHw
-xBK
-tfc
-xor
-tTT
-lny
+gqR
+oyZ
+fCT
+vVR
+diJ
 rgS
 tBN
 mvv
@@ -93238,12 +93856,12 @@ fyf
 rsE
 sYX
 sYX
-qDS
-nwG
-sUu
+kcw
+kQE
+lwd
 sYX
 sYX
-xJA
+lyk
 fyf
 fyf
 hej
@@ -93289,25 +93907,25 @@ mvv
 mvv
 mvv
 mvv
-cVV
+goK
 hom
-pck
+spC
 wxR
-tTT
+vVR
 vme
-tTT
+vVR
 vHe
 hom
-fPl
+qmp
 uXj
 uXj
 hom
-tQV
-tQV
-tQV
-tQV
-tTT
-tTT
+hxQ
+hxQ
+hxQ
+hxQ
+vVR
+vVR
 rgS
 tBN
 mvv
@@ -93493,14 +94111,14 @@ bpD
 fyf
 fyf
 fyf
-srM
-lrB
-jZk
-jZk
-jZk
-cVW
+gLH
+deQ
+cQU
+cQU
+cQU
+lTx
 sYX
-xJA
+lyk
 fyf
 fyf
 hej
@@ -93548,14 +94166,14 @@ xGH
 mvv
 bpD
 rgS
-pck
+spC
 tHw
 nbD
 hom
 pBM
-tTT
+vVR
 hom
-fPl
+qmp
 uXj
 uXj
 hom
@@ -93573,7 +94191,7 @@ hom
 dUv
 vDg
 dUv
-tTT
+vVR
 hom
 hom
 hom
@@ -93736,7 +94354,7 @@ fyf
 fyf
 fyf
 sqA
-xJA
+lyk
 fyf
 fyf
 fyf
@@ -93750,14 +94368,14 @@ hCg
 fyf
 fyf
 fyf
-pya
-jZk
-jZk
-jZk
-jZk
-jZk
-srM
-xJA
+fHx
+cQU
+cQU
+cQU
+cQU
+cQU
+gLH
+lyk
 fyf
 fyf
 hej
@@ -93805,35 +94423,35 @@ vPA
 mvv
 bpD
 hom
-pck
+spC
 hzr
 nbD
 hom
 aBk
 oHR
 hom
-fPl
+qmp
 uXj
-nfu
-wSP
-eEt
-xFv
-dWw
-wlX
-wlX
-wlX
-wSS
-tdu
+gIy
+dRG
+taL
+xnJ
+wOx
+jAh
+jAh
+jAh
+onD
+uXX
 mvv
 mvv
 vme
-tTT
-tTT
-tTT
+vVR
+vVR
+vVR
 xox
 hom
 aBk
-pck
+spC
 pSp
 hom
 gcK
@@ -93993,13 +94611,13 @@ fyf
 fyf
 fyf
 fyf
-xJA
+lyk
 fyf
 qOV
-hqC
-hqC
-hqC
-ghx
+cht
+cht
+cht
+bKs
 fyf
 fyf
 fyf
@@ -94007,14 +94625,14 @@ fyf
 fyf
 fyf
 fyf
-srM
-jZk
-iMJ
-sNE
-mdM
-jZk
-spC
-xJA
+gLH
+cQU
+kcP
+kXj
+edO
+cQU
+gJI
+lyk
 fyf
 fyf
 hej
@@ -94069,29 +94687,29 @@ hom
 hom
 hom
 hom
-fPl
+qmp
 uXj
 nRz
-jEp
+mne
 bpD
-yiF
-qAR
+eEt
+aFF
 mvv
 mvv
 mvv
-bhr
-tdu
+uMR
+uXX
 mvv
 aBH
 hom
 aPB
-tTT
-lny
-tTT
+vVR
+diJ
+vVR
 vme
-lny
-tTT
-tQV
+diJ
+vVR
+hxQ
 hom
 gcK
 gcK
@@ -94250,14 +94868,14 @@ fyf
 fyf
 fyf
 fyf
-xJA
+lyk
 fyf
 tBN
 mvv
 mvv
 mvv
 bpD
-mcz
+dTY
 fyf
 fyf
 fyf
@@ -94268,10 +94886,10 @@ sYX
 uCO
 uCO
 uCO
-jZk
-aQm
+cQU
+lTZ
 sYX
-xJA
+lyk
 fyf
 fyf
 hej
@@ -94292,7 +94910,7 @@ hbW
 erY
 erY
 erY
-kws
+bSg
 wGJ
 erY
 wGJ
@@ -94326,12 +94944,12 @@ hom
 agO
 agO
 hom
-fPl
+qmp
 uXj
 nRz
 tBN
 bpD
-yiF
+eEt
 mvv
 mvv
 mvv
@@ -94347,7 +94965,7 @@ dvo
 hom
 hom
 mHy
-tTT
+vVR
 jxO
 hom
 gcK
@@ -94507,7 +95125,7 @@ fyf
 fyf
 fyf
 fyf
-xJA
+lyk
 fyf
 tBN
 bGM
@@ -94519,16 +95137,16 @@ fyf
 fyf
 fyf
 sYX
-tOP
-jZk
-wUv
-nLD
-wTE
+hsP
+cQU
+iFr
+jlB
+kcQ
 uCO
-iHP
-rZx
+lwv
+lYu
 sYX
-xJA
+lyk
 fyf
 fyf
 hej
@@ -94580,27 +95198,27 @@ fpg
 kKs
 kKs
 jIn
-tTT
+vVR
 vHe
 hom
-fPl
+qmp
 uXj
 nRz
-ozI
+jEp
 bpD
-yiF
+eEt
 mvv
 mvv
 mvv
 mvv
-uZf
+mUA
 mvv
 mvv
 bpD
 hom
 kpd
-tTT
-tTT
+vVR
+vVR
 vHe
 hom
 hom
@@ -94775,17 +95393,17 @@ fyf
 fyf
 rsE
 fyf
-spC
-jZk
-uCT
-jZk
-jZk
-iJS
+gJI
+cQU
+hTh
+cQU
+cQU
+kdi
 uCO
-jZk
-yiv
+cQU
+lZY
 tKZ
-xJA
+lyk
 fyf
 fyf
 hej
@@ -94840,28 +95458,28 @@ hom
 dvo
 rgS
 hom
-fPl
+qmp
 uXj
 nRz
-xuJ
+xSa
 bpD
-yiF
+eEt
 mvv
 mvv
 mvv
 mvv
-rqx
+gdl
 xGH
 mvv
 bpD
 hom
 qBu
-tTT
+vVR
 qBu
-tTT
+vVR
 vme
-tTT
-pck
+vVR
+spC
 tHw
 hom
 gcK
@@ -95022,7 +95640,7 @@ fyf
 fyf
 qOV
 cWG
-ghx
+bKs
 fyf
 fyf
 fyf
@@ -95032,17 +95650,17 @@ fyf
 fyf
 fyf
 fyf
-srM
-tPA
-uFK
-wXq
-jZk
-hfK
+gLH
+htQ
+hTS
+iGd
+cQU
+kfh
 uCO
-sxs
+gPQ
 uCO
 sYX
-xJA
+lyk
 fyf
 fyf
 hej
@@ -95097,29 +95715,29 @@ hom
 mvv
 mLN
 nRz
-fPl
+qmp
 uXj
 nRz
-xuJ
+xSa
 bpD
-yiF
+eEt
 mvv
 mvv
 mvv
-qAR
-bhr
-tdu
+aFF
+uMR
+uXX
 mvv
 bpD
 rgS
 nMk
-tTT
-pRl
-tTT
-hom
-tTT
-tTT
 vVR
+pRl
+vVR
+hom
+vVR
+vVR
+pey
 hom
 gcK
 gcK
@@ -95277,7 +95895,7 @@ sYX
 fyf
 fyf
 fyf
-fHx
+bER
 mvv
 bpD
 fyf
@@ -95285,21 +95903,21 @@ fyf
 fyf
 fyf
 fyf
-eqo
+dUk
 fyf
 sYX
 sYX
 sYX
-tRX
-uFK
-wXq
-mdM
-eAo
+hwn
+hTS
+iGd
+edO
+kfx
 uCO
-jZk
-eAo
+cQU
+kfx
 sYX
-xJA
+lyk
 fyf
 fyf
 hej
@@ -95354,28 +95972,28 @@ hom
 mvv
 bpD
 nRz
-fPl
+qmp
 uXj
 nRz
 bFe
 bpD
-dwG
-gRf
-gRf
-gRf
-gRf
+frY
+xJY
+xJY
+xJY
+xJY
 qip
-tdu
+uXX
 mvv
 bpD
 hom
 qBu
-tTT
+vVR
 qBu
-tTT
+vVR
 hom
 qBu
-tTT
+vVR
 qBu
 hom
 gcK
@@ -95544,19 +96162,19 @@ fyf
 qTY
 fyf
 fyf
-pya
-jZk
-jZk
-jZk
-uIK
-jZk
-jZk
-jZk
-rGT
-mdM
-iHP
-srM
-xJA
+fHx
+cQU
+cQU
+cQU
+hVd
+cQU
+cQU
+cQU
+kYv
+edO
+lwv
+gLH
+lyk
 fyf
 fyf
 gts
@@ -95627,12 +96245,12 @@ mvv
 bpD
 hom
 nMk
-lny
+diJ
 pRl
-tTT
+vVR
 hom
 poX
-tTT
+vVR
 pQL
 hom
 gcK
@@ -95802,18 +96420,18 @@ fyf
 fyf
 fyf
 sYX
-qUC
-jZk
-jZk
-jZk
-wXR
-jZk
-yiU
+gok
+cQU
+cQU
+cQU
+iGP
+cQU
+kfJ
 uCO
-jZk
-jZk
+cQU
+cQU
 sYX
-xJA
+lyk
 fyf
 fyf
 hej
@@ -95845,7 +96463,7 @@ fyf
 fyf
 fyf
 fyf
-wSj
+bJe
 fyf
 fyf
 fyf
@@ -95884,9 +96502,9 @@ mvv
 bpD
 rgS
 qBu
-tTT
+vVR
 qBu
-tTT
+vVR
 hom
 hom
 hom
@@ -96060,7 +96678,7 @@ tKZ
 sYX
 sYX
 uCO
-pya
+fHx
 uCO
 uCO
 uCO
@@ -96070,7 +96688,7 @@ uCO
 vWE
 uCO
 sYX
-xJA
+lyk
 fyf
 fyf
 hej
@@ -96138,10 +96756,10 @@ mfD
 xGH
 mvv
 mvv
-kPT
+maE
 hom
 nMk
-tTT
+vVR
 pRl
 vHe
 hom
@@ -96306,28 +96924,28 @@ fyf
 fyf
 fyf
 fyf
-xJA
+lyk
 fyf
 fyf
 sYX
 sYX
-jNj
-lrB
-jZk
-jZk
+cOg
+deQ
+cQU
+cQU
 vWE
-lrB
-mdM
-jZk
+deQ
+edO
+cQU
 vWE
-jZk
-jZk
-lrB
-jZk
-jZk
-iOF
+cQU
+cQU
+deQ
+cQU
+cQU
+cGb
 sYX
-xJA
+lyk
 fyf
 fyf
 hej
@@ -96393,8 +97011,8 @@ hom
 hom
 hom
 tBN
-jKV
-ulc
+xfl
+txE
 imv
 hom
 hom
@@ -96563,28 +97181,28 @@ fyf
 fyf
 fyf
 fyf
-xJA
+lyk
 fyf
 fyf
+kEh
+cBB
+cOi
+cQU
+dZT
+edO
+uCO
+uCO
+gPQ
+uCO
+uCO
 hsP
-iMi
-jRU
-jZk
-mdc
-mdM
-uCO
-uCO
-sxs
-uCO
-uCO
-tOP
-jZk
-mdc
-jZk
-tPA
-uIJ
-srM
-xJA
+cQU
+dZT
+cQU
+htQ
+mar
+gLH
+lyk
 fyf
 fyf
 hej
@@ -96628,7 +97246,7 @@ gcK
 gcK
 hom
 rEk
-tTT
+vVR
 xYS
 iVE
 cWG
@@ -96639,7 +97257,7 @@ mvv
 xjZ
 fyf
 nRz
-fPl
+qmp
 uXj
 eXO
 mvv
@@ -96820,28 +97438,28 @@ fyf
 fyf
 fyf
 fyf
-xJA
+lyk
 fyf
 fyf
-hsP
-iOF
-jZk
-jZk
-jZk
-nYY
+kEh
+cGb
+cQU
+cQU
+cQU
+ePQ
 uCO
 qfh
 dhC
-tUC
+hxk
 uCO
-xgC
-mdM
-jZk
-jZk
-jZk
-jZk
-srM
-xJA
+iIz
+edO
+cQU
+cQU
+cQU
+cQU
+gLH
+lyk
 fyf
 fyf
 hej
@@ -96885,7 +97503,7 @@ gcK
 gcK
 hom
 cTN
-tTT
+vVR
 tBN
 rjH
 rjH
@@ -96896,7 +97514,7 @@ mvv
 bpD
 rtR
 nRz
-fPl
+qmp
 uXj
 eXO
 mvv
@@ -96907,7 +97525,7 @@ xys
 aVY
 hom
 tBN
-mUw
+jfx
 bpD
 fyf
 sJM
@@ -97077,28 +97695,28 @@ fyf
 fyf
 fyf
 fyf
-xJA
+lyk
 fyf
 fyf
 sYX
 sYX
-jZM
-luD
-mdE
-nZV
+cRk
+dfx
+ebT
+eRC
 uCO
 gEY
-sBQ
-tUH
+gPX
+hxn
 uCO
-xll
-mdE
-afR
-mdE
-oml
-mdE
+iIS
+ebT
+kin
+ebT
+lzV
+ebT
 sYX
-xJA
+lyk
 fyf
 fyf
 hej
@@ -97142,7 +97760,7 @@ gcK
 gcK
 hom
 sgJ
-tTT
+vVR
 tBN
 rjH
 rjH
@@ -97153,7 +97771,7 @@ mvv
 bpD
 hfh
 nRz
-fPl
+qmp
 uXj
 eXO
 mvv
@@ -97164,15 +97782,15 @@ jei
 xys
 hom
 tBN
-smp
+qot
 bpD
 fyf
 fyf
 fyf
 tUc
-hoG
-hoG
-laC
+nfu
+nfu
+uKw
 gcK
 gcK
 gcK
@@ -97334,7 +97952,7 @@ fyf
 fyf
 fyf
 fyf
-xJA
+lyk
 fyf
 fyf
 fyf
@@ -97349,13 +97967,13 @@ sYX
 sYX
 sYX
 sYX
-hsP
+kEh
 sYX
-qLT
+kZh
 sYX
-qLT
+kZh
 sYX
-xJA
+lyk
 fyf
 fyf
 gts
@@ -97399,7 +98017,7 @@ gcK
 gcK
 hom
 mVR
-tTT
+vVR
 tBN
 rjH
 rjH
@@ -97410,7 +98028,7 @@ mvv
 bpD
 fyf
 nRz
-fPl
+qmp
 uXj
 eXO
 mvv
@@ -97421,15 +98039,15 @@ yir
 qKU
 hom
 tBN
-crW
+jdB
 rbJ
 fyf
 fyf
 fyf
 nip
 xow
-mlw
-uIV
+nWC
+hBW
 gcK
 gcK
 gcK
@@ -97667,7 +98285,7 @@ mvv
 bpD
 fyf
 nRz
-fPl
+qmp
 uXj
 eXO
 mvv
@@ -97677,16 +98295,16 @@ pon
 oxA
 dUv
 hom
-jEX
-jfx
+ozI
+wxX
 doX
 cWG
 cWG
 wDc
-lcg
+kel
 pIz
-nxj
-uIV
+aSA
+hBW
 gcK
 gcK
 gcK
@@ -97773,7 +98391,7 @@ ybI
 ybI
 ybI
 hQr
-aLg
+erY
 erY
 erY
 ajO
@@ -97824,7 +98442,7 @@ ybI
 ybI
 ybI
 hQr
-aLg
+erY
 erY
 erY
 ajO
@@ -97924,7 +98542,7 @@ mvv
 bpD
 uhY
 nRz
-fPl
+qmp
 uXj
 eXO
 mvv
@@ -97936,14 +98554,14 @@ jaV
 hom
 gcK
 isJ
-hoG
-hoG
-laC
+nfu
+nfu
+uKw
 bpD
 nip
 gVQ
 dRs
-uIV
+hBW
 gcK
 gcK
 gcK
@@ -97961,16 +98579,16 @@ ktB
 "}
 (230,1,1) = {"
 emz
-gqz
+abi
 rWr
-vDP
-vDP
-nAz
-vDP
-vDP
-vDP
-vDP
-vDP
+agP
+agP
+agP
+agP
+agP
+agP
+agP
+agP
 bTh
 mvv
 odZ
@@ -98080,20 +98698,20 @@ idu
 idu
 idu
 idu
+idu
 erY
 erY
 erY
 erY
 erY
-idu
-idu
-idu
-idu
-idu
-idu
-idu
-idu
-idu
+erY
+erY
+erY
+erY
+erY
+erY
+erY
+erY
 avu
 idu
 idu
@@ -98181,7 +98799,7 @@ mvv
 bpD
 fyf
 nRz
-fPl
+qmp
 uXj
 eXO
 mvv
@@ -98192,15 +98810,15 @@ fsV
 dUv
 hom
 gcK
-jWx
+qre
 dRs
 pIz
-uIV
+hBW
 bpD
 nip
-lPv
-ohp
-uIV
+qHq
+pdE
+hBW
 gcK
 gcK
 gcK
@@ -98438,7 +99056,7 @@ mvv
 bpD
 sJM
 nRz
-fPl
+qmp
 uXj
 eXO
 mvv
@@ -98449,12 +99067,12 @@ dZE
 dUv
 hom
 gcK
-jWx
-kbS
+qre
+rHV
 pIz
-xNm
+kBW
 bpD
-lpd
+cyJ
 gfY
 gfY
 xMN
@@ -98661,7 +99279,7 @@ erY
 erY
 wGJ
 wGJ
-srt
+tjy
 erY
 wGJ
 cdc
@@ -98695,7 +99313,7 @@ mvv
 bpD
 hfh
 nRz
-fPl
+qmp
 uXj
 eXO
 mvv
@@ -98706,10 +99324,10 @@ moX
 vWC
 hom
 gcK
-jWx
+qre
 gVQ
 dRT
-uIV
+hBW
 bpD
 gcK
 gcK
@@ -98918,7 +99536,7 @@ erY
 erY
 erY
 erY
-srt
+tjy
 erY
 erY
 wGJ
@@ -98952,7 +99570,7 @@ mvv
 bpD
 fyf
 nRz
-fPl
+qmp
 uXj
 eXO
 mvv
@@ -98963,7 +99581,7 @@ hom
 hom
 hom
 gcK
-jZL
+mUQ
 gfY
 gfY
 xMN
@@ -99200,22 +99818,22 @@ ezG
 nCl
 xfy
 ntJ
-tTT
-tTT
-tTT
+vVR
+vVR
+vVR
 vme
 mvv
 mvv
 bpD
 fyf
 nRz
-fPl
+qmp
 uXj
 eXO
 mvv
 bpD
 hom
-tTT
+vVR
 mTN
 hcr
 hom
@@ -99432,7 +100050,7 @@ erY
 erY
 erY
 erY
-srt
+tjy
 wGJ
 cdc
 erY
@@ -99449,15 +100067,15 @@ ktB
 gcK
 ktB
 hom
-wgf
-tTT
+mLh
+vVR
 wPS
 wPS
 hom
 ooz
 cjV
 ntJ
-lSf
+fvw
 oMY
 nvL
 hom
@@ -99466,14 +100084,14 @@ mvv
 bpD
 fyf
 nRz
-fPl
+qmp
 uXj
 eXO
 mvv
 bpD
 hHk
 oMY
-peH
+xWG
 uhW
 hom
 gcK
@@ -99706,7 +100324,7 @@ gcK
 gcK
 ktB
 hom
-wmJ
+mNL
 oMY
 wPS
 wPS
@@ -99716,14 +100334,14 @@ hom
 pqs
 uFt
 awT
-tTT
+vVR
 rgS
 mvv
 mvv
 doX
 wDc
-syr
-qHg
+mus
+bDu
 uXj
 eXO
 mvv
@@ -99928,7 +100546,7 @@ erY
 erY
 erY
 erY
-jqM
+bhJ
 erY
 erY
 dFQ
@@ -99963,9 +100581,9 @@ ktB
 gcK
 hom
 hom
-woy
-tTT
-idC
+bjI
+vVR
+xNm
 wPS
 hom
 oFC
@@ -99978,8 +100596,8 @@ hom
 gcK
 gcK
 mvv
-syr
-jEd
+mus
+seg
 uXj
 uXj
 eXO
@@ -100017,16 +100635,16 @@ ktB
 "}
 (238,1,1) = {"
 emz
-gqz
-rWr
-vDP
-vDP
-vDP
-vDP
-vDP
-vDP
-vDP
-vDP
+adn
+aep
+agX
+agX
+agX
+agX
+agX
+agX
+agX
+agX
 bTh
 gVp
 mvv
@@ -100036,6 +100654,130 @@ uXj
 odZ
 mvv
 gCd
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
 oBQ
 oBQ
 oBQ
@@ -100052,131 +100794,7 @@ oBQ
 oBQ
 oBQ
 oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-oBQ
-vpJ
+hUr
 oBQ
 oBQ
 oBQ
@@ -100219,8 +100837,8 @@ gcK
 ktB
 gcK
 hom
-vxb
-wqe
+iAw
+gZW
 jfu
 wPS
 wPS
@@ -100229,13 +100847,13 @@ nCl
 hbO
 ntJ
 oMY
-tTT
+vVR
 lAD
 hom
 gcK
 gcK
 bcM
-iOv
+uaD
 sVl
 hom
 hom
@@ -100477,7 +101095,7 @@ gcK
 ktB
 hom
 ime
-tTT
+vVR
 wPS
 wPS
 wPS
@@ -100486,13 +101104,13 @@ hom
 hom
 hom
 vKl
-hPL
+agI
 ooh
 kRD
 gcK
 ggK
 ggK
-iOv
+uaD
 sVl
 hom
 kQJ
@@ -100504,11 +101122,11 @@ juc
 mvv
 mvv
 mvv
-jFb
+ahC
 lVe
 ggK
 ggK
-kFf
+idC
 ggK
 wnA
 gcK
@@ -100733,23 +101351,23 @@ gcK
 ktB
 gcK
 hom
-vJq
+lvA
 ime
 mes
-idC
+xNm
 wPS
 hom
 hbO
 xfy
 hbO
-rfR
+kpo
 oMY
 abC
 hom
 gcK
 ggK
-iMc
-jEd
+syr
+seg
 sVl
 hom
 wFo
@@ -100761,7 +101379,7 @@ xGH
 mvv
 qHQ
 pyZ
-jFb
+ahC
 ggK
 ggK
 gcK
@@ -100974,7 +101592,7 @@ hbW
 erY
 wGJ
 wGJ
-srt
+tjy
 cdc
 wGJ
 erY
@@ -100990,7 +101608,7 @@ gcK
 gcK
 gcK
 hom
-vQU
+uSp
 hJf
 wPS
 fKN
@@ -101000,12 +101618,12 @@ tZW
 tZW
 lez
 vHR
-tTT
+vVR
 udT
 fBx
 ggK
 ggK
-iOv
+uaD
 sVl
 sVl
 hom
@@ -101020,7 +101638,7 @@ hom
 hom
 kRD
 hom
-kFf
+idC
 wnA
 gcK
 gcK
@@ -101231,7 +101849,7 @@ hbW
 wGJ
 wGJ
 cdc
-srt
+tjy
 wGJ
 wGJ
 erY
@@ -101250,7 +101868,7 @@ hom
 hom
 hom
 hom
-wzm
+qLv
 hom
 hom
 cRh
@@ -101261,8 +101879,8 @@ hom
 hom
 mCf
 ggK
-iMc
-jEd
+syr
+seg
 sVl
 sVl
 hom
@@ -101507,7 +102125,7 @@ aBk
 oMY
 dvo
 ime
-qpx
+fLB
 hom
 ggK
 ggK
@@ -101518,7 +102136,7 @@ gcK
 gcK
 gcK
 ggK
-iOv
+uaD
 sVl
 sVl
 gcK
@@ -101530,7 +102148,7 @@ oMY
 cfp
 oMY
 oMY
-qpx
+fLB
 oMY
 kTP
 mCf
@@ -101763,8 +102381,8 @@ hom
 qCv
 nvL
 hom
-pck
-tTT
+spC
+vVR
 vme
 ggK
 ggK
@@ -101775,7 +102393,7 @@ gcK
 gcK
 rwv
 ggK
-iOv
+uaD
 sVl
 sVl
 gcK
@@ -102020,8 +102638,8 @@ hom
 hom
 hom
 hom
-wrG
-wzn
+eVj
+bhF
 rgS
 ggK
 ggK
@@ -102032,7 +102650,7 @@ ggK
 ggK
 ggK
 ggK
-iOv
+uaD
 sVl
 sVl
 gcK
@@ -102289,7 +102907,7 @@ ggK
 ggK
 ggK
 ggK
-iOv
+uaD
 sVl
 ggK
 gcK
@@ -102546,7 +103164,7 @@ gcK
 gcK
 gcK
 ggK
-iOv
+uaD
 sVl
 ggK
 gcK
@@ -102803,7 +103421,7 @@ gcK
 gcK
 ggK
 ggK
-iOv
+uaD
 sVl
 ggK
 rwv
@@ -103060,7 +103678,7 @@ gcK
 ggK
 ggK
 ggK
-iOv
+uaD
 sVl
 ggK
 ggK
@@ -103284,14 +103902,14 @@ mGC
 mGC
 oZc
 rEi
-bQB
+bpX
 vDP
 vDP
 mKe
 vDP
 vDP
 vDP
-sTw
+twP
 hoo
 mGC
 mGC
@@ -103317,7 +103935,7 @@ ggK
 ggK
 ggK
 ggK
-iOv
+uaD
 sVl
 ggK
 ggK
@@ -103543,12 +104161,12 @@ oZc
 rEi
 vDP
 vDP
-bQB
+bpX
 mKe
 vDP
 vDP
 vDP
-sTw
+twP
 hoo
 mGC
 gcK
@@ -103574,7 +104192,7 @@ ggK
 ggK
 ggK
 ggK
-iOv
+uaD
 sVl
 ggK
 ggK
@@ -103799,13 +104417,13 @@ mGC
 oZc
 rEi
 vDP
-bQB
-bQB
+bpX
+bpX
 mKe
 vDP
 vDP
 vDP
-sTw
+twP
 hoo
 mGC
 gcK
@@ -103831,7 +104449,7 @@ bbV
 hom
 wPS
 ggK
-iOv
+uaD
 sVl
 ggK
 ggK
@@ -104056,13 +104674,13 @@ mGC
 tvl
 rEi
 vDP
-bQB
+bpX
 nAz
-uld
+bWL
 vDP
 vDP
 vDP
-sTw
+twP
 gjC
 mGC
 gcK
@@ -104088,7 +104706,7 @@ fqL
 mCf
 wPS
 ggK
-iOv
+uaD
 sVl
 ggK
 ggK
@@ -104319,7 +104937,7 @@ bXM
 gqz
 gqz
 gqz
-nfv
+tyL
 wuR
 mGC
 gcK
@@ -104343,9 +104961,9 @@ hom
 hom
 hom
 hom
-wOj
+saq
 oYb
-iOv
+uaD
 sVl
 oYb
 oYb

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -14,10 +14,16 @@
 /turf/open/water,
 /area/f13/caves)
 "aaS" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermainleft"
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/white/box,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/building)
+/obj/item/stack/crafting/armor_plate/ten,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/ncr)
 "abd" = (
 /obj/structure/decoration/hatch{
 	dir = 4
@@ -251,7 +257,7 @@
 /obj/structure/rack,
 /obj/item/seeds/cannabis,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "aip" = (
 /obj/structure/rack,
 /obj/item/storage/backpack/spearquiver,
@@ -387,7 +393,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "alE" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt{
@@ -623,8 +629,15 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "atX" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/wasteland)
 "aug" = (
 /turf/open/floor/f13/wood{
@@ -1087,7 +1100,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/floor/wood/f13/stage_tl,
-/area/f13/legion)
+/area/f13/wasteland)
 "aKD" = (
 /obj/structure/chair/left{
 	dir = 8
@@ -1325,8 +1338,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aRc" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
+/obj/structure/chair/office/light,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/wasteland)
 "aRz" = (
@@ -1554,7 +1568,7 @@
 /obj/item/reagent_containers/pill/fixer,
 /obj/item/reagent_containers/pill/insulin,
 /turf/open/floor/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "aYu" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/barber{
@@ -1703,7 +1717,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "bej" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalcorroded"
@@ -1754,7 +1768,7 @@
 /obj/structure/table/wood,
 /obj/item/kitchen/knife,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "bgY" = (
 /turf/closed/indestructible/riveted,
 /area/f13/tcoms)
@@ -1766,7 +1780,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "bhC" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road{
@@ -2135,7 +2149,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "brZ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -2210,13 +2224,6 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"buG" = (
-/obj/structure/fence/wooden{
-	dir = 4;
-	icon_state = "post_wood"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
 "buO" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken";
@@ -2375,8 +2382,9 @@
 	},
 /area/f13/building)
 "bzf" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/wasteland)
 "bzm" = (
 /obj/structure/flora/grass/wasteland{
@@ -2419,8 +2427,13 @@
 	},
 /area/f13/building)
 "bzV" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13/wood,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/wasteland)
 "bAe" = (
 /obj/structure/table/wood,
@@ -2510,11 +2523,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "bCm" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
+/obj/effect/landmark/start/f13/ncrlogisticsofficer,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "bCG" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -2687,7 +2700,7 @@
 /area/f13/brotherhood)
 "bIV" = (
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "bIX" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/ruins{
@@ -2702,7 +2715,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "bJB" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -2840,7 +2853,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "bPk" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -2848,11 +2861,16 @@
 /turf/open/floor/wood,
 /area/f13/building)
 "bPH" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
+/obj/structure/bed,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/obj/item/bedsheet/brown,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/wasteland)
 "bPU" = (
 /obj/structure/cable{
 	icon_state = "1-2";
@@ -3157,7 +3175,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/floor/wood/f13/stage_tr,
-/area/f13/legion)
+/area/f13/wasteland)
 "ccf" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibleg"
@@ -3541,12 +3559,16 @@
 	},
 /area/f13/building)
 "crW" = (
-/obj/structure/simple_door/metal/fence{
-	door_type = "fence_wood";
-	icon_state = "fence_wood"
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "post_wood"
+	},
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "csk" = (
 /turf/open/water,
 /area/f13/caves)
@@ -3856,7 +3878,7 @@
 	icon_state = "sheetUSA"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "cIm" = (
 /obj/structure/table/wood/bar,
 /turf/open/floor/f13/wood,
@@ -4196,7 +4218,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "cVW" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/f13/wood{
@@ -4236,7 +4258,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "cWU" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4699,7 +4721,7 @@
 	dir = 8;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "dlX" = (
 /obj/structure/chair/wood,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5071,7 +5093,7 @@
 	dir = 8;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "dwR" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -5356,7 +5378,7 @@
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "dFQ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left"
@@ -5594,7 +5616,7 @@
 "dNW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/legion)
+/area/f13/caves)
 "dOg" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -5659,7 +5681,10 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "dRs" = (
-/turf/closed/wall/f13/tentwall,
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "dRI" = (
 /obj/machinery/light{
@@ -5676,12 +5701,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "dRT" = (
-/obj/effect/decal/remains/human,
-/obj/item/clothing/suit/armor/f13/slavelabor,
-/obj/item/clothing/under/f13/legslavef,
-/obj/item/clothing/shoes/f13/rag,
-/obj/effect/landmark/start/f13/slave,
-/turf/open/floor/f13/wood,
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
+	},
+/obj/item/soap/homemade,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "dSx" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -5749,7 +5774,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "dWz" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/wood/f13/oakbroken3,
@@ -6619,9 +6644,14 @@
 	},
 /area/f13/building)
 "eDx" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/machinery/door/airlock/security/glass{
+	name = "Armory";
+	req_access_txt = "121"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/wasteland)
 "eDz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6629,11 +6659,14 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "eEt" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4"
+	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "eEz" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6916,7 +6949,7 @@
 	id = "legionmine"
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/legion)
+/area/f13/caves)
 "eMR" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -7278,7 +7311,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "eXR" = (
 /obj/structure/closet,
 /obj/item/picket_sign,
@@ -7404,7 +7437,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "fbE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -8009,12 +8042,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"frY" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
 "fsl" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8155,12 +8182,17 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "fyI" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetblue"
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/landmark/start/f13/ncrheavytrooper,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/ncr)
 "fyO" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/machinery/light/small/broken{
@@ -8357,7 +8389,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/floor/wood/f13/stage_br,
-/area/f13/legion)
+/area/f13/wasteland)
 "fFu" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/desert,
@@ -8419,10 +8451,14 @@
 	},
 /area/f13/building)
 "fGl" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/landmark/start/f13/ncrmp,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/ncr)
 "fGr" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
@@ -8433,7 +8469,7 @@
 	},
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "fGC" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -8464,12 +8500,16 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "fIk" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/legion)
+/obj/effect/landmark/start/f13/ncrmp,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/ncr)
 "fIn" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -8662,17 +8702,8 @@
 	},
 /area/f13/wasteland)
 "fPl" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_y = 12
-	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "hole"
-	},
+/obj/effect/decal/riverbank,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "fPL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8956,7 +8987,7 @@
 "fYt" = (
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/legion)
+/area/f13/caves)
 "fYv" = (
 /obj/structure/chair/wood/modern{
 	dir = 1;
@@ -9009,7 +9040,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "gaV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt{
@@ -9066,10 +9097,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gbS" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottomleft"
+/obj/effect/decal/riverbank{
+	dir = 5
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "gbW" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -9143,11 +9175,10 @@
 	},
 /area/f13/wasteland)
 "gfY" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
+/obj/structure/barricade/tentclothedge{
+	dir = 4
 	},
-/obj/item/instrument/harmonica,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "ggb" = (
 /obj/machinery/light/broken{
@@ -9451,7 +9482,7 @@
 /obj/item/modular_computer/laptop/preset/civillian,
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/grimy,
-/area/f13/wasteland)
+/area/f13/building)
 "goO" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -9583,7 +9614,7 @@
 	layer = 2.4
 	},
 /turf/open/floor/plasteel/grimy,
-/area/f13/wasteland)
+/area/f13/building)
 "gsa" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/water,
@@ -9642,7 +9673,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
-/area/f13/wasteland)
+/area/f13/building)
 "gtj" = (
 /obj/structure/simple_door/metal/fence{
 	dir = 8
@@ -9680,7 +9711,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "guh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -9760,7 +9791,7 @@
 /obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
 /obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
 /turf/open/floor/plasteel/grimy,
-/area/f13/wasteland)
+/area/f13/building)
 "gws" = (
 /obj/machinery/shower{
 	dir = 4
@@ -9962,7 +9993,7 @@
 "gCN" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "gDn" = (
 /obj/structure/fence{
 	dir = 8
@@ -9970,7 +10001,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "gDs" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road,
@@ -10036,7 +10067,7 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 5
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "gGu" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -10249,9 +10280,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "gPQ" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/obj/structure/pondlily_small,
+/obj/effect/decal/riverbank,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "gPR" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -10311,7 +10343,7 @@
 	icon_state = "storewindowtop"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "gRa" = (
 /obj/structure/barricade/bars,
 /obj/structure/fence,
@@ -10327,7 +10359,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "gRk" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -10420,7 +10452,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/wood/f13/carpet,
-/area/f13/wasteland)
+/area/f13/building)
 "gVh" = (
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt,
@@ -10439,9 +10471,10 @@
 /area/f13/village)
 "gVQ" = (
 /obj/structure/bed/mattress{
-	icon_state = "mattress6"
+	icon_state = "mattress3"
 	},
-/turf/open/floor/f13/wood,
+/obj/item/instrument/harmonica,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "gVV" = (
 /obj/structure/simple_door/house,
@@ -10749,7 +10782,7 @@
 	pixel_y = 9
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "hft" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
@@ -10789,7 +10822,7 @@
 /obj/item/cultivator,
 /obj/item/shovel/spade,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "hgg" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1"
@@ -10828,14 +10861,14 @@
 	pixel_y = 30
 	},
 /turf/open/floor/wood/f13/carpet,
-/area/f13/wasteland)
+/area/f13/building)
 "hgM" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "hgS" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
@@ -11006,7 +11039,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/f13/carpet,
-/area/f13/wasteland)
+/area/f13/building)
 "hmd" = (
 /obj/structure/car/rubbish4,
 /obj/effect/decal/cleanable/glass,
@@ -11055,7 +11088,7 @@
 	},
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood/f13/carpet,
-/area/f13/wasteland)
+/area/f13/building)
 "hnx" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/road{
@@ -11084,10 +11117,10 @@
 	},
 /area/f13/building)
 "hoG" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
+/obj/structure/barricade/tentclothedge{
+	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "hoS" = (
 /obj/machinery/vending/nukacolavend,
@@ -11102,7 +11135,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "hpm" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt{
@@ -11544,11 +11577,11 @@
 /turf/open/floor/carpet/green,
 /area/f13/ncr)
 "hAX" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/effect/decal/riverbankcorner{
+	dir = 1
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "hBr" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
@@ -11557,10 +11590,6 @@
 	icon_state = "verticalleftborderright2top"
 	},
 /area/f13/wasteland)
-"hBW" = (
-/obj/structure/simple_door/tent,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "hCa" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -11708,7 +11737,7 @@
 	pixel_x = -30
 	},
 /turf/open/floor/plasteel/grimy,
-/area/f13/wasteland)
+/area/f13/building)
 "hGr" = (
 /obj/machinery/shower{
 	dir = 4
@@ -11803,7 +11832,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
-/area/f13/wasteland)
+/area/f13/building)
 "hJf" = (
 /obj/structure/bed/dogbed,
 /turf/open/floor/wood/f13/oak,
@@ -11977,7 +12006,7 @@
 /obj/item/folder/blue,
 /obj/item/pen,
 /turf/open/floor/plasteel/grimy,
-/area/f13/wasteland)
+/area/f13/building)
 "hNZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
@@ -11995,7 +12024,7 @@
 	icon_state = "storewindowbottom"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "hOC" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12040,7 +12069,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "hRl" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
@@ -12157,10 +12186,10 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
 "hUW" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "hVb" = (
 /mob/living/simple_animal/hostile/eyebot,
@@ -12174,7 +12203,7 @@
 	name = "minimoog"
 	},
 /turf/open/floor/wood/f13/carpet,
-/area/f13/wasteland)
+/area/f13/building)
 "hVp" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13/wood,
@@ -12225,9 +12254,10 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "hXv" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 9
+/obj/effect/decal/riverbankcorner{
+	dir = 4
 	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "hXP" = (
 /obj/structure/cargocrate,
@@ -12293,10 +12323,10 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "hZs" = (
-/obj/structure/chair/wood/worn{
+/obj/effect/decal/riverbank{
 	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "hZv" = (
 /obj/structure/bed/mattress/pregame,
@@ -12315,7 +12345,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "hZD" = (
 /obj/structure/chair,
 /turf/open/floor/f13,
@@ -12483,11 +12513,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ier" = (
-/obj/structure/fence{
-	dir = 8
+/obj/structure/wreck/trash/two_tire,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "iez" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/oil{
@@ -12546,8 +12576,11 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
 "igy" = (
-/turf/open/floor/wood,
-/area/f13/wasteland)
+/obj/structure/wreck/trash/five_tires,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/building)
 "igz" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -12654,7 +12687,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ilh" = (
-/turf/open/floor/wood/f13/carpet,
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_2"
+	},
+/turf/open/water,
 /area/f13/wasteland)
 "ill" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -12689,7 +12725,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/f13/carpet,
-/area/f13/wasteland)
+/area/f13/building)
 "ime" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12705,12 +12741,16 @@
 /turf/closed/indestructible/f13/matrix,
 /area/f13/wasteland)
 "imv" = (
-/obj/structure/destructible/tribal_torch,
+/obj/structure/fence/wooden,
+/obj/structure/flora/grass/wasteland{
+	pixel_x = 9;
+	pixel_y = 14
+	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "imT" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13/wood,
@@ -12733,7 +12773,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "inl" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /obj/effect/decal/cleanable/dirt,
@@ -12909,18 +12949,10 @@
 	},
 /area/f13/village)
 "isJ" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "post_wood"
+/obj/structure/barricade/tentclothcorner{
+	dir = 1
 	},
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "isL" = (
 /obj/structure/table/wood/poker,
@@ -12930,7 +12962,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/wood/f13/carpet,
-/area/f13/wasteland)
+/area/f13/building)
 "isO" = (
 /obj/item/radio/intercom{
 	frequency = 1891;
@@ -13372,8 +13404,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iGP" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 1
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
+	},
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole"
 	},
 /area/f13/wasteland)
 "iGS" = (
@@ -13409,10 +13449,11 @@
 	},
 /area/f13/wasteland)
 "iHr" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
+/obj/structure/wreck/trash/five_tires,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "iHt" = (
 /obj/structure/bed/mattress,
 /obj/effect/landmark/start/f13/pusher,
@@ -13513,10 +13554,13 @@
 	},
 /area/f13/wasteland)
 "iIS" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 4
+/obj/structure/window/fulltile/wood,
+/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#845f58"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "iJc" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -13575,7 +13619,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/legion)
+/area/f13/caves)
 "iKG" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -13606,9 +13650,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "iMc" = (
-/obj/item/storage/trash_stack,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/obj/effect/decal/riverbank{
+	dir = 9
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "iMd" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/carpet/airless,
@@ -13731,13 +13777,9 @@
 	},
 /area/f13/building)
 "iOv" = (
-/obj/machinery/button/door{
-	id = "frontgateshut";
-	name = "gate shutters";
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/obj/effect/decal/riverbank,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "iOB" = (
 /obj/effect/landmark/poster_spawner/prewar,
 /turf/closed/wall/f13/store,
@@ -13877,7 +13919,7 @@
 "iRE" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/grimy,
-/area/f13/wasteland)
+/area/f13/building)
 "iRN" = (
 /obj/structure/closet/crate/wicker,
 /turf/open/indestructible/ground/outside/dirt,
@@ -13935,7 +13977,7 @@
 /area/f13/village)
 "iSE" = (
 /turf/open/floor/plasteel/grimy,
-/area/f13/wasteland)
+/area/f13/building)
 "iTk" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -14005,7 +14047,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "iVW" = (
 /obj/structure/sink{
 	dir = 8
@@ -14022,7 +14064,7 @@
 "iWi" = (
 /obj/structure/simple_door/glass,
 /turf/open/floor/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "iWV" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/helmet/f13/raider/eyebot,
@@ -14047,7 +14089,7 @@
 "iXz" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/wood/f13/carpet,
-/area/f13/wasteland)
+/area/f13/building)
 "iXX" = (
 /obj/structure/rack,
 /obj/item/clothing/neck/tie,
@@ -14315,8 +14357,11 @@
 	dir = 4;
 	icon_state = "post_wood"
 	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "jfD" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/strong,
@@ -14372,6 +14417,7 @@
 	pixel_x = 25;
 	pixel_y = 18
 	},
+/obj/effect/decal/riverbank,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "jhe" = (
@@ -14419,7 +14465,7 @@
 	pixel_y = -30
 	},
 /turf/open/floor/wood/f13/carpet,
-/area/f13/wasteland)
+/area/f13/building)
 "jiR" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -14561,7 +14607,7 @@
 	},
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "jmZ" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -14768,7 +14814,7 @@
 	pixel_y = 14
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "juw" = (
 /obj/structure/table/wood/settler,
 /obj/item/storage/backpack,
@@ -14984,7 +15030,7 @@
 	pixel_y = -30
 	},
 /turf/open/floor/wood/f13/carpet,
-/area/f13/wasteland)
+/area/f13/building)
 "jAf" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -15080,10 +15126,11 @@
 	},
 /area/f13/caves)
 "jEd" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 10
+/obj/effect/decal/riverbankcorner{
+	dir = 1
 	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "jEl" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/knife,
@@ -15094,25 +15141,32 @@
 	},
 /area/f13/building)
 "jEp" = (
-/obj/structure/chair/bench,
+/obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "jEP" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
 /area/f13/building)
 "jEX" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 6
+/obj/structure/fermenting_barrel{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/structure/fermenting_barrel{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "jFb" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 8
-	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
 "jFl" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -15234,7 +15288,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jKV" = (
-/turf/open/floor/plasteel/chapel,
+/obj/structure/fence/corner/wooden{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "jLK" = (
 /obj/structure/closet,
@@ -15498,7 +15555,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "jTQ" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ghoul,
@@ -15641,11 +15698,11 @@
 	},
 /area/f13/brotherhood)
 "jWx" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
+/obj/structure/barricade/tentclothedge{
 	dir = 1;
-	icon_state = "dirt"
+	pixel_y = -3
 	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "jWM" = (
 /obj/item/reagent_containers/pill/patch/turbo,
@@ -15762,12 +15819,11 @@
 	},
 /area/f13/wasteland)
 "jZL" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetbrown"
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
 	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "jZM" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood{
@@ -15824,10 +15880,12 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "kbS" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
+/obj/effect/decal/remains/human,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/under/f13/legslavef,
+/obj/item/clothing/shoes/f13/rag,
+/obj/effect/landmark/start/f13/slave,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "kbU" = (
 /obj/structure/bed/mattress/pregame,
@@ -16389,7 +16447,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "kuI" = (
 /obj/item/toy/beach_ball/holoball{
 	pixel_x = 15
@@ -16762,9 +16820,9 @@
 	},
 /area/f13/bunker)
 "kFf" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kFi" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/f13/wood,
@@ -16824,7 +16882,7 @@
 "kGL" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "kGP" = (
 /obj/item/clothing/suit/f13/duster,
 /obj/item/clothing/suit/f13/autumn,
@@ -17087,9 +17145,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "kPT" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/costumes,
-/turf/open/floor/f13/wood,
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
 "kPX" = (
 /obj/structure/fence/corner/wooden{
@@ -17099,7 +17159,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "kPZ" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13{
@@ -17351,11 +17411,11 @@
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "kZh" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "kZp" = (
 /obj/structure/rack,
 /obj/item/storage/belt/tribe_quiver,
@@ -17378,8 +17438,11 @@
 	},
 /area/f13/ncr)
 "laC" = (
-/turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/obj/structure/barricade/tentclothcorner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "laZ" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -17400,9 +17463,13 @@
 	},
 /area/f13/wasteland)
 "lcg" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/obj/structure/simple_door/tentflap_cloth{
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/legion)
 "lcq" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2top";
@@ -17755,7 +17822,7 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "los" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -17785,9 +17852,13 @@
 	},
 /area/f13/wasteland)
 "lpd" = (
-/obj/item/twohanded/required/kirbyplants/dead,
-/turf/open/floor/wood,
-/area/f13/wasteland)
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/legion)
 "lpu" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/box/dice,
@@ -18669,12 +18740,12 @@
 	},
 /area/f13/wasteland)
 "lPv" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbroken"
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "lPx" = (
 /obj/item/ammo_casing/caseless{
 	dir = 4;
@@ -18876,7 +18947,7 @@
 	icon_state = "glassclosing"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "lUk" = (
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/store,
@@ -18912,7 +18983,7 @@
 	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/legion)
+/area/f13/caves)
 "lVn" = (
 /obj/item/clothing/under/f13/rag,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19275,7 +19346,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "mjg" = (
 /obj/machinery/button/door{
 	id = "badboys";
@@ -19323,9 +19394,11 @@
 	},
 /area/f13/wasteland)
 "mlw" = (
-/obj/structure/bookcase,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "mlD" = (
 /obj/structure/table/wood/settler,
 /obj/item/paper_bin,
@@ -19853,7 +19926,7 @@
 /obj/structure/table/wood,
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "mDf" = (
 /obj/structure/fence{
 	dir = 1
@@ -20704,8 +20777,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nfu" = (
+/obj/structure/fence/corner/wooden{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "nfv" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
@@ -20822,11 +20898,13 @@
 /turf/open/water,
 /area/f13/caves)
 "nip" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2";
-	pixel_y = 7
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
 	},
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
 /area/f13/legion)
 "niD" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -21127,7 +21205,7 @@
 "nvr" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/legion)
+/area/f13/wasteland)
 "nvH" = (
 /obj/structure/closet/crate/freezer/blood{
 	pixel_y = 20
@@ -21195,11 +21273,12 @@
 /turf/closed/wall/f13/wood,
 /area/f13/village)
 "nxj" = (
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/f13/wasteland)
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/under/f13/legslave,
+/obj/item/clothing/shoes/f13/rag,
+/obj/effect/landmark/start/f13/slave,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "nxL" = (
 /obj/structure/fence/wooden{
 	dir = 1
@@ -21237,7 +21316,7 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "nzJ" = (
 /obj/item/seeds/poppy/broc,
 /turf/open/indestructible/ground/outside/dirt,
@@ -21328,7 +21407,7 @@
 	id = "radio"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "nCS" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -21709,11 +21788,12 @@
 /turf/open/floor/wood,
 /area/f13/building)
 "nRz" = (
-/obj/structure/fence/corner/wooden{
-	dir = 8
+/obj/structure/fence/wooden{
+	dir = 4;
+	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "nSc" = (
 /obj/structure/rack,
 /obj/item/flashlight/seclite,
@@ -21831,7 +21911,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "nUT" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -22215,11 +22295,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ohp" = (
-/obj/structure/decoration/clock{
-	pixel_y = 30
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "ohH" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22554,12 +22634,6 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
-"oqA" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
-	tag = "icon-housewood2-broken"
-	},
-/area/f13/wasteland)
 "orm" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -22776,10 +22850,11 @@
 	},
 /area/f13/village)
 "ozI" = (
+/obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "oAe" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -23333,7 +23408,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "oSH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -23559,7 +23634,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "oYI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/workbench,
@@ -23621,7 +23696,7 @@
 "pbr" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "pbX" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
@@ -23682,7 +23757,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "pek" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -24240,10 +24315,6 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"puP" = (
-/obj/structure/dresser,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "puX" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 4
@@ -24406,7 +24477,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "pzJ" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/relaxedwear,
@@ -24493,11 +24564,6 @@
 	tag = "icon-housewood2"
 	},
 /area/f13/building)
-"pCi" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "pCy" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -24644,14 +24710,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"pIa" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowvertical"
-	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "pIi" = (
 /obj/structure/closet,
 /obj/item/clothing/under/f13/doctor,
@@ -24664,17 +24722,6 @@
 "pIn" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"pIy" = (
-/obj/structure/sink{
-	pixel_y = 15
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
 /area/f13/wasteland)
 "pIz" = (
 /turf/open/indestructible/ground/outside/dirt,
@@ -24890,12 +24937,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"pOe" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "pOo" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
@@ -25552,7 +25593,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "qiN" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/wood,
@@ -25845,10 +25886,6 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qul" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
 "quy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/settler,
@@ -25898,14 +25935,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"qwf" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbroken"
-	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "qwi" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/radiation)
@@ -25977,7 +26006,7 @@
 /area/f13/building)
 "qyZ" = (
 /turf/open/floor/wood/f13/stage_b,
-/area/f13/legion)
+/area/f13/wasteland)
 "qzt" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26032,7 +26061,7 @@
 "qAR" = (
 /obj/item/claymore/machete/training,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "qBf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice{
@@ -26249,7 +26278,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "qHR" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -26335,7 +26364,7 @@
 "qJR" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "qJZ" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/f13{
@@ -26949,7 +26978,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "rcC" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -27313,7 +27342,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "rqW" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -27375,11 +27404,6 @@
 "rsE" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"rtf" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
 /area/f13/wasteland)
 "rtl" = (
 /turf/open/indestructible/ground/outside/ruins{
@@ -27663,7 +27687,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "rGl" = (
 /obj/structure/chalkboard,
 /obj/machinery/light/small/broken{
@@ -27806,19 +27830,12 @@
 /obj/item/shovel,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"rMl" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetgrey"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "rMq" = (
 /obj/structure/fence/corner/wooden{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "rMz" = (
 /obj/structure/chair/wood/worn{
 	dir = 8
@@ -28151,7 +28168,7 @@
 	icon_state = "fence_wood"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "rXF" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -28526,7 +28543,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "shn" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/plating,
@@ -28861,7 +28878,7 @@
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/glass,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "spt" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -29048,20 +29065,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"swi" = (
-/obj/structure/fermenting_barrel{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/structure/fermenting_barrel{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/legion)
 "swx" = (
 /obj/item/mining_scanner,
 /turf/open/indestructible/ground/outside/dirt,
@@ -29121,8 +29124,11 @@
 	},
 /area/f13/building)
 "syr" = (
+/obj/effect/decal/riverbank{
+	dir = 9
+	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/legion)
+/area/f13/wasteland)
 "syA" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/small/broken{
@@ -29297,7 +29303,7 @@
 	dir = 8;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "sDi" = (
 /turf/open/floor/wood/f13/oakbroken2,
 /area/f13/building)
@@ -29427,7 +29433,7 @@
 /obj/item/reagent_containers/glass/bucket/wood,
 /obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "sJw" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2bottom"
@@ -29439,7 +29445,7 @@
 	pixel_y = 14
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "sJP" = (
 /obj/structure/sign/poster/contraband/pinup_shower,
 /turf/closed/wall/f13/wood/house,
@@ -29990,7 +29996,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/floor/wood/f13/stage_bl,
-/area/f13/legion)
+/area/f13/wasteland)
 "sZT" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -30130,7 +30136,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "tdv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -30309,12 +30315,6 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
-"tjI" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
 "tjQ" = (
 /obj/structure/closet,
 /obj/item/reagent_containers/pill/patch/jet,
@@ -30462,7 +30462,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "tom" = (
 /obj/structure/toilet{
 	dir = 1
@@ -30830,9 +30830,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"tyL" = (
-/turf/closed/wall/rust,
-/area/f13/wasteland)
 "tyQ" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -30913,7 +30910,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "tBm" = (
 /obj/structure/table/wood/settler,
 /obj/item/clothing/head/helmet/f13/deathskull,
@@ -30949,7 +30946,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "tCh" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -31143,11 +31140,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
-"tIP" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/legion)
+/area/f13/building)
 "tIY" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
@@ -31505,11 +31498,12 @@
 	},
 /area/f13/wasteland)
 "tUc" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
+/obj/structure/barricade/tentclothcorner{
+	dir = 1
 	},
-/obj/item/soap/homemade,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
 /area/f13/legion)
 "tUf" = (
 /obj/structure/safe,
@@ -31762,12 +31756,6 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"uag" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
 "uar" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
@@ -31789,18 +31777,6 @@
 	dir = 8;
 	icon_state = "horizontalinnermain2left"
 	},
-/area/f13/wasteland)
-"ubt" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
-"ubD" = (
-/obj/structure/simple_door/room,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "ubJ" = (
 /obj/structure/barricade/sandbags,
@@ -32059,7 +32035,7 @@
 "uhY" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "uij" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
@@ -32089,11 +32065,12 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/wasteland)
 "ulc" = (
+/obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "uld" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -32123,7 +32100,7 @@
 /area/f13/brotherhood)
 "ulE" = (
 /turf/open/floor/plasteel/stairs/old,
-/area/f13/wasteland)
+/area/f13/building)
 "ulH" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/desert,
@@ -32152,7 +32129,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "umD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -32210,8 +32187,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uok" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/structure/table/reinforced,
+/obj/item/taperecorder,
+/obj/item/pda/engineering,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/wasteland)
 "uom" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32290,7 +32271,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "urg" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -32324,7 +32305,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "urA" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -32858,9 +32839,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uIV" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "uJd" = (
 /obj/structure/decoration/clock/old{
@@ -33128,11 +33108,6 @@
 /obj/effect/holodeck_effect/cards,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
-"uPD" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottomright"
-	},
-/area/f13/building)
 "uPP" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
@@ -33165,10 +33140,6 @@
 "uRa" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"uRj" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "uRw" = (
 /obj/machinery/vending/cola/random,
@@ -33471,6 +33442,12 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "frontgateshut";
+	name = "gate shutters";
+	pixel_x = -5;
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "uXj" = (
@@ -33529,7 +33506,7 @@
 /obj/structure/simple_door/metal/fence,
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "uZg" = (
 /obj/structure/table/wood,
 /obj/item/trash/waffles,
@@ -34350,7 +34327,7 @@
 /area/f13/caves)
 "vzG" = (
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/legion)
+/area/f13/caves)
 "vzM" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib6-old"
@@ -34388,7 +34365,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "vAM" = (
 /obj/machinery/vending/dinnerware,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -34840,14 +34817,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"vPi" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/wasteland)
 "vPz" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/floor/plasteel/barber{
@@ -34863,7 +34832,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "vPU" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -34923,8 +34892,12 @@
 /obj/structure/fence/corner/wooden{
 	dir = 8
 	},
+/obj/structure/fence/wooden{
+	dir = 4;
+	icon_state = "post_wood"
+	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "vSH" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 1
@@ -35137,7 +35110,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "wbd" = (
 /obj/structure/table/wood,
 /obj/machinery/processor/chopping_block,
@@ -35417,7 +35390,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "wmI" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -35600,10 +35573,6 @@
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"wsE" = (
-/obj/structure/flora/stump,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
 "wsJ" = (
 /obj/structure/fence/corner{
 	dir = 9
@@ -35893,10 +35862,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/village)
-"wBx" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
 "wBA" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/wood/f13/oak,
@@ -35908,10 +35873,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"wBI" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "wCu" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -36005,7 +35966,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "wFo" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/wood/f13/oak,
@@ -36086,9 +36047,6 @@
 	dir = 4;
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
-"wHN" = (
-/turf/closed/wall/f13/wood/house/broken,
 /area/f13/wasteland)
 "wHR" = (
 /obj/structure/fluff/rails{
@@ -36203,7 +36161,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland)
+/area/f13/building)
 "wLO" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/dirt,
@@ -36467,7 +36425,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "wSS" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -36476,7 +36434,7 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "wSX" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13{
@@ -36526,12 +36484,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"wUm" = (
-/obj/structure/chair/wood/worn{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "wUv" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -36649,13 +36601,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
-"wXH" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbrokenvertical"
-	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "wXK" = (
 /obj/effect/landmark/start/f13/sheriff,
 /obj/effect/decal/cleanable/dirt,
@@ -36956,7 +36901,7 @@
 /area/f13/brotherhood)
 "xes" = (
 /turf/open/floor/wood/f13/stage_t,
-/area/f13/legion)
+/area/f13/wasteland)
 "xeG" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/f13/wood,
@@ -37122,9 +37067,6 @@
 	icon_state = "verticalinnermain2"
 	},
 /area/f13/wasteland)
-"xiy" = (
-/turf/closed/wall/f13/wood/interior,
-/area/f13/wasteland)
 "xiB" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13{
@@ -37169,7 +37111,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "xkj" = (
 /obj/machinery/mineral/wasteland_vendor/advcomponents,
 /turf/open/floor/f13{
@@ -37330,13 +37272,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "xow" = (
-/obj/item/clothing/suit/armor/f13/slavelabor,
-/obj/item/clothing/under/f13/legslave,
-/obj/item/clothing/shoes/f13/rag,
-/obj/effect/landmark/start/f13/slave,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
 	},
+/obj/item/soap/homemade,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "xox" = (
 /obj/item/twohanded/required/kirbyplants,
@@ -37550,7 +37490,7 @@
 "xuM" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "xvg" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
@@ -37704,12 +37644,6 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
-"xAq" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
 "xAB" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb,
@@ -37791,12 +37725,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
-"xCX" = (
-/obj/machinery/vending/cola/random,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/building)
 "xDA" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/f13{
@@ -37862,7 +37790,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "xFL" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/f13{
@@ -38032,12 +37960,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"xJY" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
 "xKa" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 1
@@ -38149,12 +38071,8 @@
 	},
 /area/f13/village)
 "xMN" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2";
-	pixel_y = 7
-	},
-/obj/item/soap/homemade,
-/turf/open/floor/f13/wood,
+/obj/structure/barricade/tentclothcorner,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "xMP" = (
 /obj/structure/noticeboard{
@@ -38172,7 +38090,8 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "xNm" = (
-/turf/open/floor/f13/wood,
+/obj/structure/simple_door/tentflap_cloth,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "xNE" = (
 /obj/structure/fence{
@@ -38278,7 +38197,7 @@
 "xRp" = (
 /obj/structure/barricade/wooden,
 /turf/closed/mineral/random/low_chance,
-/area/f13/legion)
+/area/f13/caves)
 "xRv" = (
 /obj/structure/chair/wood/fancy{
 	dir = 1
@@ -38479,9 +38398,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"xXh" = (
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "xXl" = (
 /obj/item/clothing/under/f13/police,
 /obj/item/clothing/head/f13/police,
@@ -38546,7 +38462,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "xZh" = (
 /obj/machinery/iv_drip,
 /obj/machinery/light{
@@ -38580,11 +38496,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/farm)
-"yao" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "yau" = (
 /obj/structure/rack,
 /obj/item/seeds/cabbage,
@@ -38897,7 +38808,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "yiJ" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
@@ -39415,7 +39326,7 @@ gcK
 gcK
 gcK
 ims
-uXj
+fPl
 uXj
 ims
 gcK
@@ -39672,7 +39583,7 @@ gcK
 gcK
 gcK
 xZu
-uXj
+fPl
 uXj
 xZu
 gcK
@@ -39929,7 +39840,7 @@ gcK
 gcK
 gcK
 xZu
-uXj
+fPl
 uXj
 xZu
 gcK
@@ -40186,7 +40097,7 @@ gbL
 gbL
 gbL
 xZu
-uXj
+fPl
 uXj
 xZu
 gcK
@@ -40443,7 +40354,7 @@ gbL
 gbL
 gbL
 xZu
-uXj
+fPl
 uXj
 xZu
 gbL
@@ -40700,7 +40611,7 @@ gbL
 gbL
 gbL
 xZu
-uXj
+fPl
 uXj
 xZu
 gbL
@@ -40889,8 +40800,8 @@ kzs
 sNC
 kzs
 xGv
-kzs
-sed
+fGl
+fIk
 sHu
 xEc
 xEc
@@ -40957,7 +40868,7 @@ gbL
 gbL
 gbL
 xZu
-uXj
+fPl
 uXj
 xZu
 gcK
@@ -41214,7 +41125,7 @@ gbL
 gbL
 gbL
 xZu
-uXj
+fPl
 uXj
 xZu
 gcK
@@ -41471,7 +41382,7 @@ gcK
 gcK
 gcK
 xZu
-uXj
+fPl
 uXj
 xZu
 gcK
@@ -41728,7 +41639,7 @@ gcK
 gcK
 gcK
 xZu
-uXj
+fPl
 uXj
 xZu
 gcK
@@ -41985,7 +41896,7 @@ gcK
 gcK
 gcK
 xZu
-uXj
+fPl
 uXj
 xZu
 gcK
@@ -42242,7 +42153,7 @@ gcK
 gcK
 gcK
 xZu
-uXj
+fPl
 uXj
 xZu
 gcK
@@ -42499,7 +42410,7 @@ gcK
 gcK
 gcK
 xZu
-uXj
+fPl
 uXj
 xZu
 gcK
@@ -42756,7 +42667,7 @@ gcK
 gcK
 gcK
 xZu
-uXj
+fPl
 uXj
 xZu
 eoI
@@ -43013,7 +42924,7 @@ gcK
 gbL
 gbL
 xZu
-uXj
+fPl
 uXj
 uXj
 eoI
@@ -43271,7 +43182,7 @@ gcK
 gbL
 xZu
 mwO
-uXj
+fPl
 uXj
 eoI
 cos
@@ -43528,7 +43439,7 @@ gcK
 gcK
 gbL
 mwO
-uXj
+fPl
 uXj
 eoI
 cos
@@ -43785,7 +43696,7 @@ qFk
 qFk
 qFk
 mwO
-uXj
+fPl
 uXj
 eoI
 cos
@@ -44557,7 +44468,7 @@ otr
 qLC
 lwj
 lwj
-uXj
+fPl
 uXj
 uXj
 rjE
@@ -44815,7 +44726,7 @@ sLr
 xGH
 aBH
 cFe
-uXj
+fPl
 uXj
 uXj
 uXj
@@ -44825,8 +44736,8 @@ uXj
 uXj
 lwj
 lwj
-uXj
-mvv
+syr
+hZs
 gcK
 gcK
 gcK
@@ -45073,7 +44984,7 @@ tBN
 bpD
 ekW
 gaV
-uXj
+fPl
 uXj
 uXj
 uXj
@@ -45082,7 +44993,7 @@ uXj
 uXj
 lwj
 lwj
-uXj
+fPl
 uXj
 gcK
 gcK
@@ -45339,7 +45250,7 @@ mfD
 xGH
 lwj
 lwj
-uXj
+fPl
 uXj
 gcK
 gcK
@@ -45596,7 +45507,7 @@ fyf
 tBN
 lwj
 lwj
-uXj
+fPl
 uXj
 gcK
 gcK
@@ -45853,7 +45764,7 @@ fyf
 jnN
 lwj
 lwj
-uXj
+fPl
 uXj
 uXj
 gcK
@@ -46110,7 +46021,7 @@ wUL
 tBN
 lwj
 lwj
-uXj
+fPl
 kCH
 uXj
 gcK
@@ -46273,11 +46184,11 @@ tXe
 nPy
 nPZ
 sGG
-cpK
-uok
-atX
-atX
-uok
+vUA
+vUA
+vUA
+vUA
+vUA
 cpK
 cpK
 bTf
@@ -46367,7 +46278,7 @@ qFk
 tBN
 lwj
 lwj
-uXj
+fPl
 uXj
 uXj
 uXj
@@ -46530,11 +46441,11 @@ tNa
 cpK
 lvS
 eJe
-cpK
+vUA
 uok
 atX
-atX
-uok
+bzf
+vUA
 cpK
 cpK
 elT
@@ -46624,7 +46535,7 @@ cny
 sLr
 lwj
 lwj
-lqV
+fPl
 uXj
 uXj
 uXj
@@ -46787,11 +46698,11 @@ tXe
 cpK
 jSN
 eJe
-cpK
-uok
-atX
-atX
-uok
+vUA
+aRc
+bzV
+bzf
+eDx
 cpK
 cpK
 rRi
@@ -46881,7 +46792,7 @@ peu
 gun
 lwj
 lwj
-uXj
+fPl
 uXj
 uXj
 uXj
@@ -47044,11 +46955,11 @@ cpK
 cpK
 cpK
 eJe
-cpK
-uok
-atX
-atX
-uok
+vUA
+bzf
+bCm
+bzf
+vUA
 cpK
 cpK
 cpK
@@ -47138,7 +47049,7 @@ peu
 oWC
 lwj
 lwj
-uXj
+fPl
 uXj
 kCH
 uXj
@@ -47301,11 +47212,11 @@ sCz
 sCz
 sCz
 qLO
-cpK
-cpK
-cpK
+vUA
+bzf
+bPH
 hUW
-cpK
+vUA
 cpK
 cpK
 cpK
@@ -47395,7 +47306,7 @@ peu
 gun
 lwj
 lwj
-uXj
+fPl
 uXj
 uXj
 uXj
@@ -47559,7 +47470,7 @@ ezX
 rhr
 rhr
 ezX
-rhr
+raV
 ezX
 ezX
 ezX
@@ -47652,9 +47563,9 @@ cny
 sLr
 lwj
 lwj
+fPl
 uXj
-uXj
-uXj
+lqV
 uXj
 uXj
 uXj
@@ -47810,7 +47721,7 @@ sgz
 sgz
 koD
 ezX
-qQf
+aaS
 mfN
 qQf
 qQf
@@ -47909,7 +47820,7 @@ qFk
 vAe
 lwj
 lwj
-uXj
+fPl
 uXj
 uXj
 uXj
@@ -48166,8 +48077,8 @@ cWG
 cWG
 daU
 bpD
-uXj
-lqV
+gbS
+hXv
 uXj
 uXj
 uXj
@@ -48424,7 +48335,7 @@ mfD
 xGH
 bpD
 fyf
-uXj
+fPl
 uXj
 uXj
 uXj
@@ -48849,7 +48760,7 @@ ohV
 pfb
 uVw
 xdt
-rPR
+fyI
 ezX
 cpK
 cpK
@@ -48931,7 +48842,7 @@ rss
 tBN
 bpD
 vJP
-kCH
+gPQ
 xKi
 gwi
 vAe
@@ -49187,8 +49098,8 @@ uRJ
 unW
 tBN
 bpD
-uXj
-uXj
+syr
+hAX
 uXj
 uXj
 lqV
@@ -49363,7 +49274,7 @@ onx
 pfb
 uVw
 xdt
-rPR
+fyI
 rhr
 cpK
 cpK
@@ -49444,8 +49355,8 @@ uRJ
 nrV
 tBN
 bpD
-uXj
-uXj
+gbS
+hXv
 ush
 uXj
 uXj
@@ -49959,7 +49870,7 @@ uRJ
 mvv
 bpD
 vAe
-uXj
+fPl
 kCH
 qNM
 uXj
@@ -59515,11 +59426,11 @@ uxC
 fyf
 fyf
 uxC
-laC
-pIa
-wXH
-pIa
-laC
+sYX
+maS
+abi
+maS
+sYX
 fyf
 fyf
 fyf
@@ -59772,11 +59683,11 @@ fyf
 fyf
 fyf
 fyf
-fGl
+kGD
 bgk
-kFf
-pCi
-qwf
+rkZ
+nPP
+vtj
 fyf
 fyf
 fyf
@@ -60029,11 +59940,11 @@ fyf
 fyf
 fyf
 fyf
-laC
-yao
-xXh
+sYX
+dqo
+rpu
 jmY
-laC
+sYX
 fyf
 fyf
 fyf
@@ -60286,11 +60197,11 @@ fyf
 fyf
 fyf
 fyf
-wBI
-xXh
-uRj
-oqA
-laC
+yjG
+rpu
+klA
+nSQ
+sYX
 fyf
 fyf
 oFM
@@ -60538,16 +60449,16 @@ fyf
 fyf
 fyf
 fyf
-laC
-laC
-wHN
-laC
-laC
-laC
-lcg
-xXh
-hZs
-lPv
+sYX
+sYX
+tKZ
+sYX
+sYX
+sYX
+oeL
+rpu
+hFM
+fqa
 fyf
 fyf
 fyf
@@ -60795,16 +60706,16 @@ fyf
 fyf
 fyf
 fyf
-laC
-pIy
-vPi
-xiy
-kPT
-ubD
-rtf
-xXh
-kFf
-fGl
+sYX
+okz
+wEO
+uCO
+etg
+wtp
+vXh
+rpu
+rkZ
+kGD
 fyf
 fyf
 fyf
@@ -61052,16 +60963,16 @@ fyf
 fyf
 fyf
 fyf
-laC
+sYX
 hQS
 vZs
-xiy
+uCO
 aim
-ubD
-xXh
+wtp
+rpu
 fGA
-wUm
-lPv
+rMz
+fqa
 fyf
 fyf
 uey
@@ -61309,16 +61220,16 @@ fyf
 fyf
 fyf
 fyf
-laC
-xiy
+sYX
+uCO
 shg
-xiy
-xiy
-xiy
-ohp
-xXh
-mlw
-laC
+uCO
+uCO
+uCO
+aYG
+rpu
+tzk
+sYX
 fyf
 fyf
 qOV
@@ -61566,16 +61477,16 @@ fyf
 fyf
 fyf
 fyf
-wHN
+tKZ
 dFM
-xXh
+rpu
 oYh
-puP
-xiy
-xXh
-iMc
-mlw
-laC
+csO
+uCO
+rpu
+foz
+tzk
+sYX
 fyf
 fyf
 tBN
@@ -61823,16 +61734,16 @@ fyf
 fyf
 fyf
 fyf
-wHN
-xXh
-xXh
-xXh
-xXh
-bzV
-xXh
-xXh
-xXh
-laC
+tKZ
+rpu
+rpu
+rpu
+rpu
+sDp
+rpu
+rpu
+rpu
+sYX
 fyf
 fyf
 tBN
@@ -62080,16 +61991,16 @@ fyf
 fyf
 fyf
 fyf
-laC
+sYX
 cIh
-rMl
-jZL
-fyI
-xiy
-xXh
-aRc
-xXh
-laC
+ccF
+msy
+lxk
+uCO
+rpu
+aug
+rpu
+sYX
 fyf
 fyf
 nlO
@@ -62337,16 +62248,16 @@ fyf
 fyf
 fyf
 fyf
-laC
-laC
-wXH
-pIa
-laC
-laC
-wXH
-pIa
-laC
-laC
+sYX
+sYX
+abi
+maS
+sYX
+sYX
+abi
+maS
+sYX
+sYX
 fyf
 fyf
 fyf
@@ -64655,9 +64566,9 @@ aRz
 rpu
 dCV
 gts
-gts
 fQr
 tvr
+ilh
 tvr
 tvr
 cHH
@@ -64912,8 +64823,8 @@ dCV
 dCV
 dCV
 dCV
-gts
 fQr
+tvr
 tvr
 tvr
 tvr
@@ -70043,7 +69954,7 @@ oUy
 oUy
 oUy
 sPJ
-kaM
+ier
 kaM
 kaM
 kaM
@@ -70306,13 +70217,13 @@ xTF
 muk
 hbW
 erY
-fPl
+wGJ
 wGJ
 erY
 pyM
 jZg
 wGJ
-erY
+iGP
 apk
 wGJ
 erY
@@ -71343,9 +71254,9 @@ wGJ
 dpZ
 wGJ
 wGJ
-gmX
-dCV
-iOv
+iHr
+iIS
+xdD
 xdD
 xdD
 xdD
@@ -71601,7 +71512,7 @@ roh
 cdc
 ubg
 gmX
-dCV
+iIS
 uZR
 oum
 xdD
@@ -71858,7 +71769,7 @@ iJw
 wGJ
 wGJ
 gmX
-dCV
+iIS
 lEC
 vXM
 aET
@@ -73657,7 +73568,7 @@ fYZ
 yel
 uCW
 aOg
-mST
+uqa
 wXK
 gqo
 rpu
@@ -75958,7 +75869,7 @@ jPG
 jPG
 dkg
 dkg
-kzW
+igy
 dit
 rgI
 fAG
@@ -80826,20 +80737,20 @@ llj
 srw
 fyf
 fyf
-tyL
-tyL
-tyL
-tyL
-tyL
-tyL
-tyL
-tyL
-tyL
-tyL
-tyL
-tyL
-tyL
-tyL
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
 lGG
 rQG
 mqy
@@ -81083,20 +80994,20 @@ gjP
 gjP
 fyf
 fyf
-tyL
+lhN
 goK
 hFY
 iRE
-tyL
-igy
-nxj
-igy
-tyL
+lhN
+wCA
+bPk
+wCA
+lhN
 spi
 tAS
 umi
 vAy
-tyL
+lhN
 lGG
 kOi
 mqy
@@ -81340,14 +81251,14 @@ llj
 srw
 fyf
 fyf
-tyL
+lhN
 grC
 hJd
 iSE
 kZh
-igy
-igy
-igy
+wCA
+wCA
+wCA
 qJR
 ulE
 tCc
@@ -81597,20 +81508,20 @@ llj
 nMl
 fyf
 fyf
-tyL
+lhN
 gwn
 hNY
 iSE
-tyL
+lhN
 xuM
-igy
-igy
-tyL
+wCA
+wCA
+lhN
 gsV
 tIO
 ury
 wLB
-tyL
+lhN
 eSF
 rSf
 mqy
@@ -81854,20 +81765,20 @@ cPn
 gjP
 wEo
 fyf
-tyL
+lhN
 gQW
 hOs
 iWi
-tyL
-bzf
-igy
+lhN
+nJM
+wCA
 pbr
-tyL
-tyL
-tyL
-tyL
-tyL
-tyL
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
 bFJ
 qyR
 qyR
@@ -82111,16 +82022,16 @@ uey
 fyf
 thG
 fyf
-tyL
+lhN
 gVd
 hVd
-ilh
-tyL
+sWI
+lhN
 xuM
-igy
-igy
-igy
-igy
+wCA
+wCA
+wCA
+wCA
 wCA
 wCA
 kcY
@@ -82368,21 +82279,21 @@ igz
 bEw
 thG
 fyf
-tyL
+lhN
 hgJ
-ilh
+sWI
 iXz
-tyL
-igy
-igy
-igy
-igy
-hXv
+lhN
+wCA
+wCA
+wCA
+wCA
+pcP
 qPQ
 uzn
 uXU
 liO
-iHr
+bFJ
 dMW
 fyf
 fyf
@@ -82625,21 +82536,21 @@ xKx
 dMW
 thG
 fyf
-tyL
+lhN
 hgJ
-ilh
+sWI
 jiP
-tyL
+lhN
 lUg
-tyL
-tyL
-igy
+lhN
+lhN
+wCA
 gGt
 tJk
 puX
 kdi
 liO
-iHr
+bFJ
 dMW
 fyf
 fyf
@@ -82882,15 +82793,15 @@ xKx
 dMW
 thG
 fyf
-tyL
+lhN
 hmc
 ilM
 jiP
-tyL
+lhN
 bIV
 nyZ
-tyL
-igy
+lhN
+wCA
 gCN
 nRu
 wCA
@@ -83139,21 +83050,21 @@ trd
 dMW
 thG
 fyf
-tyL
+lhN
 hnq
 isL
 jzN
-tyL
+lhN
 bPj
 nCx
-tyL
-igy
-hXv
+lhN
+wCA
+pcP
 tNI
 uzn
 uXU
 liO
-iHr
+bFJ
 dMW
 fyf
 hAC
@@ -83396,21 +83307,21 @@ lae
 dMW
 thG
 fyf
-tyL
-tyL
-tyL
-tyL
-tyL
-tyL
-tyL
-tyL
-igy
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+lhN
+wCA
 gGt
 qTa
 puX
 kdi
 liO
-iHr
+bFJ
 dMW
 fyf
 fyf
@@ -83653,11 +83564,11 @@ xKx
 dMW
 thG
 fyf
-tyL
-igy
-igy
-igy
-igy
+lhN
+wCA
+wCA
+wCA
+wCA
 bPk
 wCA
 wCA
@@ -83667,7 +83578,7 @@ wCA
 wCA
 kfx
 lhN
-iHr
+bFJ
 dMW
 fyf
 hAC
@@ -83910,10 +83821,10 @@ uaf
 dMW
 thG
 fyf
-tyL
-igy
-hXv
-jEd
+lhN
+wCA
+pcP
+qPQ
 aYp
 bRF
 dza
@@ -83924,7 +83835,7 @@ lhN
 lhN
 lhN
 lhN
-bCm
+ptf
 edA
 fyf
 fyf
@@ -84167,11 +84078,11 @@ dkg
 dMW
 thG
 fyf
-tyL
-igy
+lhN
+wCA
 gGt
-jEX
-igy
+qTa
+wCA
 wCA
 nHi
 pjQ
@@ -84181,7 +84092,7 @@ lhN
 uCn
 peG
 lhN
-aaS
+yeJ
 ssm
 fyf
 fyf
@@ -84424,11 +84335,11 @@ xKx
 dMW
 thG
 fyf
-tyL
+lhN
 hpj
-igy
-igy
-igy
+wCA
+wCA
+wCA
 lYu
 nJM
 wCA
@@ -84438,7 +84349,7 @@ iwm
 uCS
 kfJ
 lhN
-xCX
+uUS
 nPX
 uey
 fyf
@@ -84681,10 +84592,10 @@ xKx
 dMW
 thG
 fyf
-tyL
-igy
-iGP
-jFb
+lhN
+wCA
+uzn
+uXU
 loo
 wCA
 nNZ
@@ -84938,11 +84849,11 @@ ptf
 edA
 thG
 fyf
-tyL
-igy
-iIS
-jKV
-lpd
+lhN
+wCA
+puX
+kdi
+kcY
 lZY
 nRu
 puX
@@ -84952,7 +84863,7 @@ iwm
 uCS
 wQZ
 lhN
-xCX
+uUS
 nPX
 hAC
 fyf
@@ -85195,11 +85106,11 @@ fyf
 fyf
 thG
 fyf
-tyL
-igy
-igy
-igy
-igy
+lhN
+wCA
+wCA
+wCA
+wCA
 mar
 wCA
 wCA
@@ -85209,7 +85120,7 @@ lhN
 uCS
 wRb
 lhN
-uPD
+hzb
 jMC
 fyf
 fyf
@@ -85452,11 +85363,6 @@ fyf
 fyf
 thG
 fyf
-tyL
-tyL
-tyL
-tyL
-tyL
 lhN
 lhN
 lhN
@@ -85466,7 +85372,12 @@ lhN
 lhN
 lhN
 lhN
-gbS
+lhN
+lhN
+lhN
+lhN
+lhN
+oCi
 ssm
 hAC
 fyf
@@ -90163,8 +90074,8 @@ tFr
 tFr
 rZG
 hom
-fIk
-uag
+qOV
+cWG
 gcK
 gcK
 gcK
@@ -90420,9 +90331,9 @@ hjc
 hjc
 hjc
 hom
-ozI
-pIz
-frY
+tBN
+mvv
+bpD
 hom
 hom
 hom
@@ -90677,9 +90588,9 @@ hjc
 hjc
 jhx
 hom
-ozI
-pIz
-frY
+tBN
+mvv
+bpD
 hom
 shW
 tTT
@@ -90934,9 +90845,9 @@ hjc
 qob
 hjc
 hom
-ozI
-pIz
-frY
+tBN
+mvv
+bpD
 hom
 kSt
 tTT
@@ -91191,8 +91102,8 @@ rfx
 hom
 dvo
 hom
-ozI
-pIz
+tBN
+mvv
 gue
 vfR
 kSt
@@ -91448,9 +91359,9 @@ tTT
 xwR
 tTT
 rgS
-jEp
-pIz
-pIz
+xuJ
+mvv
+mvv
 vme
 tTT
 tTT
@@ -91705,8 +91616,8 @@ jNl
 tTT
 tTT
 rgS
-jEp
-pIz
+xuJ
+mvv
 cVV
 vfR
 kSt
@@ -91962,9 +91873,9 @@ tHw
 tTT
 tTT
 rgS
-jEp
-pIz
-frY
+xuJ
+mvv
+bpD
 hom
 kSt
 tTT
@@ -92220,8 +92131,8 @@ tTT
 tTT
 hom
 fbD
-pIz
-frY
+mvv
+bpD
 hom
 shW
 tTT
@@ -92447,7 +92358,7 @@ ncb
 fyf
 fjT
 rwO
-ier
+xLY
 gcK
 gcK
 gcK
@@ -92465,7 +92376,7 @@ hom
 gcK
 gcK
 gcK
-sVl
+iOv
 sVl
 sVl
 hom
@@ -92476,9 +92387,9 @@ tTT
 tTT
 tTT
 qIc
-pIz
-pIz
-frY
+mvv
+mvv
+bpD
 hom
 hom
 hom
@@ -92705,14 +92616,14 @@ fyf
 fyf
 fyf
 pea
-wBx
-hom
-nfu
-nfu
-nfu
+tFR
+lPT
+fyf
+fyf
+fyf
 bea
-uag
-uag
+cWG
+cWG
 brE
 hom
 pSu
@@ -92722,7 +92633,7 @@ hom
 hom
 hom
 hom
-syr
+fPl
 sVl
 sVl
 hom
@@ -92734,9 +92645,9 @@ tTT
 tTT
 hom
 gaF
-pIz
-frY
-nfu
+mvv
+bpD
+fyf
 gcK
 gcK
 gcK
@@ -92962,15 +92873,15 @@ fyf
 fyf
 fyf
 gDn
-uag
-uag
-uag
-uag
-uag
-kbS
-pIz
-pIz
-pIz
+cWG
+cWG
+cWG
+cWG
+cWG
+daU
+mvv
+mvv
+mvv
 vme
 tTT
 tTT
@@ -92979,8 +92890,8 @@ hom
 tHw
 rEd
 hom
-syr
-syr
+fPl
+uXj
 sVl
 ucJ
 tHw
@@ -92990,8 +92901,8 @@ xor
 tTT
 lny
 rgS
-ozI
-pIz
+tBN
+mvv
 hgM
 hom
 hom
@@ -93219,14 +93130,14 @@ uPP
 fyf
 fyf
 uqW
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 cVV
 hom
 pck
@@ -93236,9 +93147,9 @@ vme
 tTT
 vHe
 hom
-syr
-syr
-syr
+fPl
+uXj
+uXj
 hom
 tQV
 tQV
@@ -93247,9 +93158,9 @@ tQV
 tTT
 tTT
 rgS
-ozI
-pIz
-frY
+tBN
+mvv
+bpD
 rgS
 hUf
 let
@@ -93476,15 +93387,15 @@ uit
 fyf
 fyf
 dlS
-xAq
-xAq
-xAq
-xAq
-xAq
-xAq
-xJY
-pIz
-frY
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+xGH
+mvv
+bpD
 rgS
 pck
 tHw
@@ -93493,9 +93404,9 @@ hom
 pBM
 tTT
 hom
-syr
-syr
-syr
+fPl
+uXj
+uXj
 hom
 hom
 ucJ
@@ -93504,9 +93415,9 @@ ucJ
 ucJ
 hom
 hom
-ozI
-pIz
-tjI
+tBN
+mvv
+doX
 hom
 dUv
 vDg
@@ -93732,16 +93643,16 @@ ubd
 fyf
 fyf
 fyf
-ier
-nfu
-nfu
-nfu
-nfu
-nfu
-nfu
+xLY
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 vPA
-pIz
-frY
+mvv
+bpD
 hom
 pck
 hzr
@@ -93750,8 +93661,8 @@ hom
 aBk
 oHR
 hom
-syr
-syr
+fPl
+uXj
 nfu
 wSP
 eEt
@@ -93762,8 +93673,8 @@ wlX
 wlX
 wSS
 tdu
-pIz
-pIz
+mvv
+mvv
 vme
 tTT
 tTT
@@ -93989,16 +93900,16 @@ pyf
 fyf
 fjT
 fyf
-ier
-nfu
-nfu
-nfu
-nfu
-nfu
-nfu
-ozI
-pIz
-frY
+xLY
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+tBN
+mvv
+bpD
 hom
 hom
 hom
@@ -94007,20 +93918,20 @@ hom
 hom
 hom
 hom
-syr
-syr
+fPl
+uXj
 nRz
 jEp
-frY
+bpD
 yiF
 qAR
-pIz
-pIz
-pIz
+mvv
+mvv
+mvv
 bhr
 tdu
-pIz
-ulc
+mvv
+aBH
 hom
 aPB
 tTT
@@ -94246,16 +94157,16 @@ fyf
 fyf
 fyf
 gxn
-ier
-nfu
-nfu
-nfu
-nfu
-nfu
-nfu
-ozI
-pIz
-frY
+xLY
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+tBN
+mvv
+bpD
 hom
 tvp
 gws
@@ -94264,19 +94175,19 @@ hom
 agO
 agO
 hom
-syr
-syr
-buG
-jEp
-frY
+fPl
+uXj
+nRz
+tBN
+bpD
 yiF
-pIz
-pIz
-pIz
-pIz
+mvv
+mvv
+mvv
+mvv
 kut
-kbS
-pIz
+daU
+mvv
 hgM
 hom
 hom
@@ -94503,16 +94414,16 @@ fyf
 fyf
 fyf
 fyf
-ier
+xLY
 mCG
-nfu
-nfu
-nfu
-nfu
-nfu
-ozI
-pIz
-frY
+fyf
+fyf
+fyf
+fyf
+fyf
+tBN
+mvv
+bpD
 hom
 fpg
 kKs
@@ -94521,20 +94432,20 @@ jIn
 tTT
 vHe
 hom
-syr
-syr
-buG
+fPl
+uXj
+nRz
 ozI
-frY
+bpD
 yiF
-pIz
-pIz
-pIz
-pIz
+mvv
+mvv
+mvv
+mvv
 uZf
-pIz
-pIz
-frY
+mvv
+mvv
+bpD
 hom
 kpd
 tTT
@@ -94760,16 +94671,16 @@ fyf
 tTV
 fyf
 fyf
-ier
+xLY
 mCG
-nfu
-nfu
-nfu
-nfu
-nfu
+fyf
+fyf
+fyf
+fyf
+fyf
 tnu
-pIz
-frY
+mvv
+bpD
 hom
 qSR
 hom
@@ -94778,20 +94689,20 @@ hom
 dvo
 rgS
 hom
-syr
-syr
-buG
-jEp
-frY
+fPl
+uXj
+nRz
+xuJ
+bpD
 yiF
-pIz
-pIz
-pIz
-pIz
+mvv
+mvv
+mvv
+mvv
 rqx
-xJY
-pIz
-frY
+xGH
+mvv
+bpD
 hom
 qBu
 tTT
@@ -95017,38 +94928,38 @@ fyf
 fyf
 fyf
 fyf
-ier
+xLY
 mCG
-nfu
-nfu
-nfu
-nfu
-nfu
-ozI
-pIz
-frY
+fyf
+fyf
+fyf
+fyf
+fyf
+tBN
+mvv
+bpD
 hom
 kKs
 xPI
 hFW
 hom
-pIz
-jWx
-buG
-syr
-syr
-buG
-jEp
-frY
+mvv
+mLN
+nRz
+fPl
+uXj
+nRz
+xuJ
+bpD
 yiF
-pIz
-pIz
-pIz
+mvv
+mvv
+mvv
 qAR
 bhr
 tdu
-pIz
-frY
+mvv
+bpD
 rgS
 nMk
 tTT
@@ -95274,29 +95185,29 @@ fyf
 fyf
 fyf
 fyf
-ier
+xLY
 mCG
-nfu
-nfu
-nfu
-nfu
-nfu
+fyf
+fyf
+fyf
+fyf
+fyf
 vPA
-pIz
-frY
+mvv
+bpD
 hom
 hom
 hom
 hom
 hom
-pIz
-frY
-buG
-syr
-syr
-buG
-hAX
-frY
+mvv
+bpD
+nRz
+fPl
+uXj
+nRz
+bFe
+bpD
 dwG
 gRf
 gRf
@@ -95304,8 +95215,8 @@ gRf
 gRf
 qip
 tdu
-pIz
-frY
+mvv
+bpD
 hom
 qBu
 tTT
@@ -95531,38 +95442,38 @@ fyf
 fyf
 fyf
 fyf
-ier
-nfu
-nfu
-nfu
-wsE
-nfu
-nfu
-ozI
-pIz
-tjI
-uag
-uag
+xLY
+fyf
+fyf
+fyf
+upX
+fyf
+fyf
+tBN
+mvv
+doX
+cWG
+cWG
 iVE
-ubt
-kbS
-pIz
-tjI
+qXo
+daU
+mvv
+doX
 hZw
 aKv
 sZQ
 jTJ
-kbS
-tjI
-uag
-uag
-ubt
-uag
-ubt
-uag
-kbS
-pIz
-frY
+daU
+doX
+cWG
+cWG
+qXo
+cWG
+qXo
+cWG
+daU
+mvv
+bpD
 hom
 nMk
 lny
@@ -95788,38 +95699,38 @@ fyf
 fyf
 fyf
 fyf
-ier
-nfu
-nfu
-nfu
-nfu
-nfu
-nfu
-ozI
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
+xLY
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+tBN
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 xes
 qyZ
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-frY
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+bpD
 rgS
 qBu
 tTT
@@ -96045,38 +95956,38 @@ fyf
 fyf
 fyf
 fyf
-ier
-nfu
-nfu
-nfu
-nfu
-nfu
-nfu
+xLY
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 sDc
-xAq
-xAq
-xAq
-xAq
-xAq
-xJY
-pIz
-pIz
-pIz
-pIz
+mfD
+mfD
+mfD
+mfD
+mfD
+xGH
+mvv
+mvv
+mvv
+mvv
 xes
 qyZ
-pIz
-pIz
-ulc
-xAq
-xAq
-xAq
-xAq
-xAq
-xJY
-pIz
-pIz
-frY
+mvv
+mvv
+aBH
+mfD
+mfD
+mfD
+mfD
+mfD
+xGH
+mvv
+mvv
+kPT
 hom
 nMk
 tTT
@@ -96315,23 +96226,23 @@ kZb
 kZb
 kZb
 rMq
-ozI
-pIz
-ulc
-xAq
+tBN
+mvv
+aBH
+mfD
 kPX
 cbV
 fDG
 bJo
-pIz
+mvv
 oSC
 hom
 hom
 hom
 hom
 hom
-ozI
-pIz
+tBN
+jKV
 ulc
 imv
 hom
@@ -96569,29 +96480,29 @@ rEk
 tTT
 xYS
 iVE
-uag
-eEt
-buG
-ozI
-pIz
+cWG
+wDc
+nRz
+tBN
+mvv
 xjZ
-nfu
-buG
-syr
-syr
+fyf
+nRz
+fPl
+uXj
 eXO
-pIz
-pIz
+mvv
+mvv
 dvo
 xys
 kUA
 dUv
 hom
-ozI
+tBN
 vSk
-gcK
-gcK
-gcK
+bpD
+hfh
+fyf
 gcK
 gcK
 gcK
@@ -96824,35 +96735,35 @@ gcK
 hom
 cTN
 tTT
-ozI
-qul
-qul
-frY
+tBN
+rjH
+rjH
+bpD
 rXv
-ozI
-pIz
-frY
-gPQ
-buG
-syr
-syr
+tBN
+mvv
+bpD
+rtR
+nRz
+fPl
+uXj
 eXO
-pIz
-ulc
+mvv
+aBH
 hom
 dUv
 xys
 aVY
 hom
-ozI
-jfx
-frY
-hfh
+tBN
+mUw
+bpD
+fyf
 sJM
-dRs
-dRs
-dRs
-dRs
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -97081,36 +96992,36 @@ gcK
 hom
 sgJ
 tTT
-ozI
-qul
-qul
-frY
-buG
-ozI
-pIz
-frY
+tBN
+rjH
+rjH
+bpD
+nRz
+tBN
+mvv
+bpD
 hfh
-buG
-syr
-syr
+nRz
+fPl
+uXj
 eXO
-pIz
-frY
+mvv
+bpD
 rgS
 asj
 jei
 xys
 hom
-ozI
-jfx
-frY
-nfu
-nfu
-dRs
+tBN
+smp
+bpD
+fyf
+fyf
+fyf
 tUc
 hoG
-dRs
-gcK
+hoG
+laC
 gcK
 gcK
 gcK
@@ -97338,36 +97249,36 @@ gcK
 hom
 mVR
 tTT
-ozI
-qul
-qul
-frY
-buG
-ozI
-pIz
-frY
-nfu
-buG
-syr
-syr
+tBN
+rjH
+rjH
+bpD
+nRz
+tBN
+mvv
+bpD
+fyf
+nRz
+fPl
+uXj
 eXO
-pIz
-frY
+mvv
+bpD
 rgS
 kih
 yir
 qKU
 hom
-ozI
+tBN
 crW
-frY
-nfu
-nfu
-hBW
-xNm
+rbJ
+fyf
+fyf
+fyf
+nip
 xow
-dRs
-gcK
+mlw
+uIV
 gcK
 gcK
 gcK
@@ -97595,36 +97506,36 @@ bcM
 hom
 hom
 kGL
-ozI
-qul
-qul
-frY
-buG
-ozI
-pIz
-frY
-nfu
-buG
-syr
-syr
+tBN
+rjH
+rjH
+bpD
+nRz
+tBN
+mvv
+bpD
+fyf
+nRz
+fPl
+uXj
 eXO
-pIz
-frY
+mvv
+bpD
 hom
 pon
 oxA
 dUv
 hom
-ozI
+jEX
 jfx
-frY
-nfu
-sJM
-dRs
-gfY
-pOe
-dRs
-gcK
+doX
+cWG
+cWG
+wDc
+lcg
+pIz
+nxj
+uIV
 gcK
 gcK
 gcK
@@ -97851,37 +97762,37 @@ piw
 bcM
 bcM
 hom
-nfu
-ozI
-qul
-qul
-frY
-buG
-ozI
-pIz
-frY
+fyf
+tBN
+rjH
+rjH
+bpD
+nRz
+tBN
+mvv
+bpD
 uhY
-buG
-syr
-syr
+nRz
+fPl
+uXj
 eXO
-pIz
+mvv
 hgM
 hom
 hom
 hom
 jaV
 hom
-ozI
+gcK
 isJ
-rbJ
-nfu
-nfu
-dRs
+hoG
+hoG
+laC
+bpD
 nip
 gVQ
 dRs
-gcK
+uIV
 gcK
 gcK
 gcK
@@ -98109,36 +98020,36 @@ bcM
 bcM
 okZ
 sJr
-ozI
-qul
-qul
-frY
-buG
-ozI
-pIz
-frY
-nfu
-buG
-syr
-syr
+tBN
+rjH
+rjH
+bpD
+nRz
+tBN
+mvv
+bpD
+fyf
+nRz
+fPl
+uXj
 eXO
-pIz
-tjI
+mvv
+doX
 gpo
 hom
 fsV
 dUv
 hom
-swi
 gcK
+jWx
 dRs
-dRs
-hBW
-dRs
-dRs
-dRs
-dRs
-gcK
+pIz
+uIV
+bpD
+nip
+lPv
+ohp
+uIV
 gcK
 gcK
 gcK
@@ -98365,37 +98276,37 @@ bcM
 sUl
 bcM
 iLQ
-nfu
-ozI
-qul
-qul
-frY
+fyf
+tBN
+rjH
+rjH
+bpD
 rXv
-ozI
-pIz
-frY
+tBN
+mvv
+bpD
 sJM
-buG
-syr
-syr
+nRz
+fPl
+uXj
 eXO
-pIz
-pIz
+mvv
+mvv
 xkl
 hom
 dZE
 dUv
 hom
 gcK
-gcK
-dRs
-pOe
+jWx
+kbS
+pIz
 xNm
-dRs
-gcK
-gcK
-gcK
-gcK
+bpD
+lpd
+gfY
+gfY
+xMN
 gcK
 gcK
 gcK
@@ -98624,31 +98535,31 @@ bcM
 okZ
 hge
 sDc
-xAq
-xAq
+mfD
+mfD
 all
-buG
-ozI
-pIz
-frY
+nRz
+tBN
+mvv
+bpD
 hfh
-buG
-syr
-syr
+nRz
+fPl
+uXj
 eXO
-pIz
-ulc
+mvv
+aBH
 lGd
 hom
 moX
 vWC
 hom
 gcK
-gcK
-dRs
+jWx
+gVQ
 dRT
 uIV
-dRs
+bpD
 gcK
 gcK
 gcK
@@ -98886,14 +98797,14 @@ hom
 rgS
 egn
 fbD
-pIz
-frY
-nfu
-buG
-syr
-syr
+mvv
+bpD
+fyf
+nRz
+fPl
+uXj
 eXO
-pIz
+mvv
 hgM
 uNK
 hom
@@ -98901,11 +98812,11 @@ hom
 hom
 hom
 gcK
-gcK
-dRs
+jZL
+gfY
 gfY
 xMN
-dRs
+gcK
 gcK
 gcK
 gcK
@@ -99142,16 +99053,16 @@ tTT
 tTT
 tTT
 vme
-pIz
-pIz
-frY
-nfu
-buG
-syr
-syr
+mvv
+mvv
+bpD
+fyf
+nRz
+fPl
+uXj
 eXO
-pIz
-frY
+mvv
+bpD
 hom
 tTT
 mTN
@@ -99159,10 +99070,10 @@ hcr
 hom
 gcK
 gcK
-dRs
-dRs
-dRs
-dRs
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -99399,16 +99310,16 @@ lSf
 oMY
 nvL
 hom
-eDx
-pIz
-frY
-nfu
-buG
-syr
-syr
+mEy
+mvv
+bpD
+fyf
+nRz
+fPl
+uXj
 eXO
-pIz
-frY
+mvv
+bpD
 hHk
 oMY
 peH
@@ -99656,15 +99567,15 @@ uFt
 awT
 tTT
 rgS
-pIz
-pIz
-tjI
-eEt
+mvv
+mvv
+doX
+wDc
 syr
-syr
-syr
+uXj
+uXj
 eXO
-pIz
+mvv
 rbJ
 hom
 eaA
@@ -99676,7 +99587,7 @@ gcK
 gcK
 gcK
 gcK
-wPS
+gcK
 vzG
 eMF
 gcK
@@ -99915,13 +99826,13 @@ cWq
 hom
 gcK
 gcK
-pIz
+mvv
 syr
-sVl
-syr
-bPH
+jEd
+uXj
+uXj
 eXO
-pIz
+mvv
 hgM
 hom
 hom
@@ -99932,7 +99843,7 @@ gcK
 gcK
 gcK
 gcK
-uNK
+ucZ
 dNW
 vzG
 vzG
@@ -100173,23 +100084,23 @@ hom
 gcK
 gcK
 bcM
+iOv
 sVl
-sVl
 hom
 hom
 hom
-pIz
-tjI
-uag
-uag
-uag
+mvv
+doX
+cWG
+cWG
+cWG
 cWS
 nvr
 nvr
 gcK
 gcK
 iKD
-wPS
+ggK
 vzG
 vzG
 fYt
@@ -100430,25 +100341,25 @@ kRD
 gcK
 ggK
 ggK
-sVl
+iOv
 sVl
 hom
 kQJ
 oMY
 pIz
-pIz
-pIz
+mvv
+mvv
 juc
-pIz
-pIz
-pIz
-wPS
+mvv
+mvv
+mvv
+jFb
 lVe
-wPS
-wPS
-idC
-wPS
-tIP
+ggK
+ggK
+kFf
+ggK
+wnA
 gcK
 gcK
 gcK
@@ -100686,22 +100597,22 @@ abC
 hom
 gcK
 ggK
+iMc
+jEd
 sVl
-sVl
-ggK
 hom
 wFo
 bwM
 oMY
 aWz
 pyZ
-xJY
-pIz
+xGH
+mvv
 qHQ
 pyZ
-wPS
-wPS
-wPS
+jFb
+ggK
+ggK
 gcK
 gcK
 gcK
@@ -100943,9 +100854,9 @@ udT
 fBx
 ggK
 ggK
+iOv
 sVl
 sVl
-ggK
 hom
 kIs
 oMY
@@ -100958,8 +100869,8 @@ hom
 hom
 kRD
 hom
-idC
-tIP
+kFf
+wnA
 gcK
 gcK
 gcK
@@ -101199,10 +101110,10 @@ hom
 hom
 mCf
 ggK
+iMc
+jEd
 sVl
 sVl
-sVl
-ggK
 hom
 mgg
 oMY
@@ -101215,11 +101126,11 @@ qCX
 qCX
 leX
 hom
-wPS
+ggK
 iKD
-wPS
-tIP
-wPS
+ggK
+wnA
+ggK
 gcK
 gcK
 gcK
@@ -101456,9 +101367,9 @@ gcK
 gcK
 gcK
 ggK
+iOv
 sVl
 sVl
-ggK
 gcK
 hom
 hom
@@ -101473,9 +101384,9 @@ oMY
 kTP
 mCf
 gcK
-wPS
-wPS
-wPS
+ggK
+ggK
+ggK
 gcK
 gcK
 gcK
@@ -101713,9 +101624,9 @@ gcK
 gcK
 rwv
 ggK
+iOv
 sVl
 sVl
-ggK
 gcK
 gcK
 pdn
@@ -101730,7 +101641,7 @@ oMY
 qnG
 hom
 gcK
-tIP
+wnA
 gcK
 gcK
 gcK
@@ -101970,9 +101881,9 @@ ggK
 ggK
 ggK
 ggK
+iOv
 sVl
 sVl
-ggK
 gcK
 gcK
 pdn
@@ -101987,8 +101898,8 @@ vfn
 iDk
 hom
 gcK
-wPS
-tIP
+ggK
+wnA
 xRp
 gcK
 gcK
@@ -102227,7 +102138,7 @@ ggK
 ggK
 ggK
 ggK
-sVl
+iOv
 sVl
 ggK
 gcK
@@ -102247,7 +102158,7 @@ gcK
 gcK
 gcK
 iKD
-wPS
+ggK
 gcK
 gcK
 gcK
@@ -102484,7 +102395,7 @@ gcK
 gcK
 gcK
 ggK
-sVl
+iOv
 sVl
 ggK
 gcK
@@ -102503,8 +102414,8 @@ gcK
 gcK
 gcK
 gcK
-wPS
-wPS
+ggK
+ggK
 gcK
 gcK
 gbL
@@ -102741,7 +102652,7 @@ gcK
 gcK
 ggK
 ggK
-sVl
+iOv
 sVl
 ggK
 rwv
@@ -102998,9 +102909,9 @@ gcK
 ggK
 ggK
 ggK
+iOv
 sVl
-sVl
-sVl
+ggK
 ggK
 gcK
 gcK
@@ -103255,9 +103166,9 @@ ggK
 ggK
 ggK
 ggK
+iOv
+sVl
 ggK
-sVl
-sVl
 ggK
 gcK
 gcK
@@ -103512,9 +103423,9 @@ ggK
 ggK
 ggK
 ggK
+iOv
+sVl
 ggK
-sVl
-sVl
 ggK
 ktB
 gcK
@@ -103769,9 +103680,9 @@ bbV
 hom
 wPS
 ggK
+iOv
 sVl
-sVl
-sVl
+ggK
 ggK
 ktB
 gcK
@@ -104026,7 +103937,7 @@ fqL
 mCf
 wPS
 ggK
-sVl
+iOv
 sVl
 ggK
 ggK
@@ -104283,7 +104194,7 @@ hom
 hom
 wOj
 oYb
-sVl
+iOv
 sVl
 oYb
 oYb

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -584,6 +584,15 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"arG" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop3"
+	},
+/area/f13/wasteland)
 "arT" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/f13{
@@ -1663,12 +1672,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/legion)
-"bcf" = (
-/obj/effect/decal/riverbankcorner{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
 "bcx" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -2013,12 +2016,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"bop" = (
-/obj/effect/decal/riverbank{
-	dir = 5
-	},
-/turf/open/water,
-/area/f13/wasteland)
 "boq" = (
 /obj/structure/rack,
 /obj/item/clothing/under/redeveninggown,
@@ -2324,6 +2321,12 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
+/area/f13/wasteland)
+"bxk" = (
+/obj/effect/decal/riverbankcorner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "bxl" = (
 /obj/machinery/light/small{
@@ -4188,17 +4191,6 @@
 /obj/item/seeds/wheat,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"cUN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
 "cVg" = (
 /obj/item/trash/f13/cram,
 /turf/open/floor/f13/wood,
@@ -4865,6 +4857,20 @@
 /obj/structure/table/wood,
 /obj/item/paper,
 /obj/item/pen,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"dpQ" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Bar";
+	req_one_access_txt = "28"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "barshutters"
+	},
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_y = 32
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dpZ" = (
@@ -6478,10 +6484,6 @@
 	tag = "icon-horizontaltopbordertop2"
 	},
 /area/f13/wasteland)
-"exz" = (
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "exS" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/ruins{
@@ -6514,15 +6516,6 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"eyG" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	layer = 2;
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
 "eyI" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -6689,25 +6682,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mineral/wasteland_vendor/mining,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
-"eDI" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/condiment/yeast,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
 /area/f13/building)
 "eEt" = (
 /obj/structure/flora/grass/wasteland{
@@ -7026,20 +7000,6 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
-"eNf" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Bar";
-	req_one_access_txt = "28"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "barshutters"
-	},
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_y = 32
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "eNT" = (
 /obj/machinery/light/small{
@@ -8225,6 +8185,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"fxc" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermaintop"
+	},
+/area/f13/building)
 "fxx" = (
 /obj/item/picket_sign,
 /turf/open/indestructible/ground/outside/road{
@@ -8455,26 +8421,6 @@
 	},
 /turf/open/floor/wood/f13/stage_br,
 /area/f13/wasteland)
-"fEH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "barwindowshutters";
-	name = "bar window shutters button";
-	pixel_x = 6;
-	pixel_y = -32;
-	req_one_access_txt = "28"
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters button";
-	pixel_x = -6;
-	pixel_y = -32;
-	req_one_access_txt = "28"
-	},
-/obj/machinery/light/small,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
 "fFu" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/desert,
@@ -9332,6 +9278,10 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"gie" = (
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "gin" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
@@ -10215,6 +10165,10 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"gHZ" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "gIE" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/police,
@@ -10994,6 +10948,14 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"hii" = (
+/obj/machinery/light/sign,
+/obj/structure/barricade/wooden,
+/obj/effect/decal/fakelattice,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop3"
+	},
+/area/f13/wasteland)
 "hio" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/balaclava,
@@ -11708,6 +11670,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"hCU" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner"
+	},
+/area/f13/building)
 "hDe" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11993,6 +11961,15 @@
 /obj/item/folder/yellow,
 /obj/item/reagent_containers/pill/patch/jet,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"hLj" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "hLm" = (
 /obj/structure/barricade/wooden/strong,
@@ -13395,13 +13372,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"iEG" = (
-/obj/machinery/vending/boozeomat{
-	density = 0;
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
 "iEQ" = (
 /obj/machinery/icecream_vat,
 /turf/open/floor/f13{
@@ -15240,6 +15210,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"jEC" = (
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
 "jEP" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -15578,23 +15554,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"jRo" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "jRv" = (
 /obj/structure/lamp_post/quadra,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"jRH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_east_north"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "jRQ" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
@@ -16067,6 +16032,17 @@
 "kdi" = (
 /turf/open/floor/plasteel/chapel,
 /area/f13/building)
+"kdt" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/building)
 "kdJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermaintop"
@@ -16107,11 +16083,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
-"kfi" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
 "kfo" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -16293,6 +16264,14 @@
 	},
 /turf/open/floor/plating,
 /area/f13/caves)
+"kjY" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "kkD" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
@@ -16803,12 +16782,6 @@
 /obj/item/seeds/poppy/broc,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"kAp" = (
-/obj/effect/decal/fakelattice{
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
 "kAJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -17316,17 +17289,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
-"kRq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
 "kRD" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -18828,6 +18790,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"lMI" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermaintop"
+	},
+/area/f13/building)
 "lNa" = (
 /obj/structure/closet/fridge/standard,
 /turf/open/floor/f13/wood,
@@ -19533,15 +19500,6 @@
 	tag = "icon-horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
-"mls" = (
-/obj/structure/closet/crate/trashcart{
-	name = "corpse cart"
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "mlw" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -19635,10 +19593,14 @@
 	},
 /area/f13/wasteland)
 "moo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/smartfridge/bottlerack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/wasteland)
 "moA" = (
 /obj/structure/chair{
 	dir = 8;
@@ -19685,6 +19647,12 @@
 	},
 /turf/open/water,
 /area/f13/caves)
+"mpD" = (
+/obj/effect/decal/riverbank{
+	dir = 5
+	},
+/turf/open/water,
+/area/f13/wasteland)
 "mpE" = (
 /obj/machinery/door/airlock/freezer,
 /turf/open/floor/plasteel/bar,
@@ -19739,8 +19707,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mrg" = (
-/obj/machinery/smartfridge/bottlerack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "mri" = (
 /obj/structure/simple_door/metal/store{
@@ -19772,11 +19740,9 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "mrS" = (
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_y = 3
-	},
-/turf/closed/wall/f13/wood/interior,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/smartfridge/bottlerack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "mrY" = (
 /obj/structure/closet/cabinet,
@@ -20334,9 +20300,8 @@
 	},
 /area/f13/building)
 "mMN" = (
-/obj/structure/musician/piano,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/smartfridge/bottlerack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "mNi" = (
 /obj/structure/rack,
@@ -20377,14 +20342,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "mPa" = (
-/obj/structure/chair/stool/f13stool{
-	pixel_x = -8
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_y = 3
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/oak,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "mPk" = (
 /obj/structure/ladder/unbreakable{
@@ -21299,6 +21261,11 @@
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"ntq" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2right"
+	},
+/area/f13/building)
 "ntt" = (
 /obj/structure/table/wood,
 /obj/item/pickaxe,
@@ -21464,6 +21431,10 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
+"nzz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken4,
 /area/f13/building)
 "nzJ" = (
 /obj/item/seeds/poppy/broc,
@@ -21748,12 +21719,33 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/f13/building)
+"nJS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "nJW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
+"nKl" = (
+/obj/structure/wreck/trash/five_tires,
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner"
+	},
+/area/f13/building)
 "nKq" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/bandana/gold,
@@ -22136,11 +22128,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"nXS" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
-	},
-/area/f13/building)
 "nYY" = (
 /obj/structure/chair/comfy{
 	dir = 4;
@@ -22901,6 +22888,14 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"ovV" = (
+/obj/structure/simple_door/house{
+	icon_state = "room"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "owh" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass{
@@ -23066,8 +23061,9 @@
 	},
 /area/f13/wasteland)
 "oEF" = (
-/obj/machinery/microwave/stove,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/structure/musician/piano,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "oEU" = (
 /obj/structure/chair/wood{
@@ -23075,6 +23071,16 @@
 	},
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"oFh" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outermaincornerouter"
+	},
 /area/f13/building)
 "oFp" = (
 /obj/structure/decoration/vent/rusty,
@@ -23260,12 +23266,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oJm" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/machinery/door/poddoor/shutters{
-	id = "barshutters"
+/obj/structure/chair/stool/f13stool{
+	pixel_x = -8
 	},
-/obj/structure/table/wood/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "oJp" = (
 /obj/structure/chair/office,
@@ -23317,10 +23325,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "oKy" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/microwave/stove,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "oKA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23579,7 +23585,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oTB" = (
-/turf/open/floor/wood/f13/oakbroken,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/machinery/door/poddoor/shutters{
+	id = "barshutters"
+	},
+/obj/structure/table/wood/settler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "oUj" = (
 /obj/structure/chair/f13chair2{
@@ -24162,14 +24173,6 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
-"pmM" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pne" = (
 /obj/effect/decal/remains/human,
@@ -25033,6 +25036,10 @@
 "pMI" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland)
+"pMR" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
 "pNj" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25243,8 +25250,8 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "pSC" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_north"
+/obj/structure/chair/stool/retro/backed{
+	dir = 8
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
@@ -25491,9 +25498,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "qbe" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/wood/f13/oakbroken,
 /area/f13/building)
 "qbl" = (
 /obj/structure/fence,
@@ -25553,13 +25558,10 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "qcS" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
 	},
-/obj/item/soap/deluxe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "qcT" = (
 /obj/structure/barricade/tentclothedge,
@@ -25649,12 +25651,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
-"qfH" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermaintop"
-	},
-/area/f13/building)
 "qfV" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
@@ -25961,16 +25957,6 @@
 	icon_state = "verticalrightborderleft1"
 	},
 /area/f13/wasteland)
-"qoZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters button";
-	pixel_y = 32;
-	req_one_access_txt = "28"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "qpx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oakbroken4,
@@ -26112,15 +26098,6 @@
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"qwZ" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3"
-	},
-/area/f13/wasteland)
 "qxe" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
@@ -26208,9 +26185,8 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
 "qAc" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/generic,
+/obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "qAA" = (
@@ -26319,11 +26295,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "qDM" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/barricade/wooden,
+/turf/closed/wall/r_wall/rust,
+/area/f13/wasteland)
 "qDS" = (
 /obj/structure/table/wood/settler,
 /obj/item/seeds/poppy/broc,
@@ -26630,14 +26604,6 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building)
-"qMT" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "qNa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27474,10 +27440,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "rpa" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_south"
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/item/soap/deluxe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "rpu" = (
 /turf/open/floor/f13/wood,
@@ -27927,8 +27896,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "rHT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/settler,
+/obj/structure/chair/booth{
+	dir = 4
+	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rIA" = (
@@ -27979,13 +27949,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "rLi" = (
-/obj/structure/wreck/trash/machinepiletwo{
-	layer = 3
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "rLn" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -29406,14 +29374,6 @@
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"sBv" = (
-/obj/machinery/light/sign,
-/obj/structure/barricade/wooden,
-/obj/effect/decal/fakelattice,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3"
-	},
-/area/f13/wasteland)
 "sBQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29447,6 +29407,17 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"sCm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "sCu" = (
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
@@ -29457,11 +29428,11 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "sCF" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "interiorgate2"
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "sCK" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -29756,6 +29727,7 @@
 	},
 /area/f13/village)
 "sOD" = (
+/obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleftbottom"
 	},
@@ -29816,12 +29788,10 @@
 /turf/open/floor/plating,
 /area/f13/radiation)
 "sQo" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "sQv" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -31189,11 +31159,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
-"tEA" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermaintop"
-	},
-/area/f13/building)
 "tFd" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/floor/f13/wood,
@@ -31215,6 +31180,26 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
+"tFx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "barwindowshutters";
+	name = "bar window shutters button";
+	pixel_x = 6;
+	pixel_y = -32;
+	req_one_access_txt = "28"
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters button";
+	pixel_x = -6;
+	pixel_y = -32;
+	req_one_access_txt = "28"
+	},
+/obj/machinery/light/small,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "tFK" = (
 /obj/effect/landmark/start/f13/farmer,
 /turf/open/floor/wood/f13/oak,
@@ -31380,14 +31365,6 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tKm" = (
-/obj/structure/simple_door/house{
-	icon_state = "room"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
 "tKo" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -31424,6 +31401,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"tLN" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "tLW" = (
 /obj/structure/destructible/tribal_torch,
 /obj{
@@ -31799,11 +31781,11 @@
 	},
 /area/f13/wasteland)
 "tWd" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife/cosmicdirty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "interiorgate2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland)
 "tWt" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -31864,10 +31846,12 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "tYd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland)
 "tYe" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -33028,14 +33012,10 @@
 	},
 /area/f13/building)
 "uJP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	desc = "A lighting fixture.";
-	dir = 8;
-	light_color = "#008000";
-	name = "light tube"
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/wood,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife/cosmicdirty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "uKq" = (
 /obj/structure/rack,
@@ -33064,15 +33044,9 @@
 	},
 /area/f13/building)
 "uKG" = (
-/obj/structure/wreck/trash/five_tires{
-	pixel_x = 3;
-	pixel_y = -13
-	},
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "uKJ" = (
 /obj/structure/table/wood/fancy/black,
@@ -33204,28 +33178,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uOr" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/machinery/light/small{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
 	dir = 8;
-	light_color = "#d8b1b1"
+	light_color = "#008000";
+	name = "light tube"
 	},
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "uOu" = (
 /obj/machinery/light/small/broken{
@@ -33356,11 +33316,8 @@
 	},
 /area/f13/village)
 "uSz" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/barricade/wooden,
+/turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "uSC" = (
 /obj/structure/table/wood,
@@ -33761,12 +33718,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"vbz" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outermaincornerinner";
-	tag = "icon-outermaincornerinner"
-	},
-/area/f13/building)
 "vcb" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
@@ -34385,6 +34336,13 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"vtQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "vug" = (
 /obj/structure/simple_door/room,
 /turf/open/indestructible/ground/outside/desert,
@@ -34465,6 +34423,13 @@
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"vxI" = (
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "vye" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/desert,
@@ -34789,15 +34754,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
-"vHU" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
 "vHV" = (
 /obj/structure/chair,
 /obj/effect/decal/remains/human,
@@ -35015,6 +34971,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"vPG" = (
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "vPU" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -35418,6 +35378,15 @@
 /obj/item/reagent_containers/syringe/medx,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wgE" = (
+/obj/structure/closet/crate/trashcart{
+	name = "corpse cart"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "whh" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -35468,6 +35437,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
+"whX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters button";
+	pixel_y = 32;
+	req_one_access_txt = "28"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "wim" = (
 /obj/structure/table/booth,
 /turf/open/floor/wood/wood_tiled,
@@ -36296,12 +36275,6 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
-"wKM" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outermaincornerouter"
-	},
-/area/f13/building)
 "wKP" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -36859,10 +36832,6 @@
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wYN" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
 "wYO" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -37065,6 +37034,25 @@
 	tag = "icon-verticalrightborderrighttop"
 	},
 /area/f13/wasteland)
+"xdU" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "xed" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -38340,6 +38328,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/legion)
+"xPL" = (
+/obj/machinery/vending/boozeomat{
+	density = 0;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "xPO" = (
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt,
@@ -38391,9 +38386,22 @@
 	},
 /area/f13/building)
 "xSa" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken4,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/fakelattice{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
 /area/f13/building)
+"xSl" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "xSC" = (
 /obj/structure/closet/cardboard,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -38926,8 +38934,28 @@
 	},
 /area/f13/wasteland)
 "yht" = (
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "yhv" = (
 /obj/structure/simple_door/brokenglass,
@@ -61905,7 +61933,7 @@ sYX
 fyf
 fyf
 tBN
-pmM
+xSl
 mvv
 bpD
 fyf
@@ -62666,7 +62694,7 @@ fyf
 fyf
 tBN
 mvv
-pmM
+xSl
 mvv
 mvv
 oHO
@@ -63940,12 +63968,12 @@ fyf
 gts
 dCV
 uCO
-oEF
-qcS
-tWd
-uOr
-iEG
-cUN
+oKy
+rpa
+uJP
+yht
+xPL
+sCm
 dCV
 yla
 aRz
@@ -64196,14 +64224,14 @@ fyf
 fyf
 gts
 dCV
-moo
+mrS
 pOo
 pOo
 pOo
 pOo
 pOo
 pOo
-tKm
+ovV
 vta
 vta
 vta
@@ -64453,15 +64481,15 @@ fyf
 fyf
 gts
 dCV
-mrg
+mMN
 pOo
 pOo
 qZO
 onz
 tUS
-kfi
+tLN
 dCV
-kRq
+nJS
 vta
 aRz
 eGt
@@ -64716,10 +64744,10 @@ onz
 onz
 onz
 onz
-fEH
+tFx
 uCO
-eDI
-vHU
+xdU
+hLj
 aRz
 aRz
 dCV
@@ -64972,7 +65000,7 @@ onz
 tUS
 onz
 onz
-qMT
+kjY
 onz
 dCV
 dCV
@@ -65225,12 +65253,12 @@ nGq
 gts
 dCV
 uCO
-oJm
-oJm
-oJm
-oJm
+oTB
+oTB
+oTB
+oTB
 uCO
-eNf
+dpQ
 dCV
 iWW
 rvx
@@ -65247,7 +65275,7 @@ tvr
 tvr
 tvr
 pUi
-pmM
+xSl
 mvv
 vGl
 wDc
@@ -65482,12 +65510,12 @@ pMI
 dCV
 dCV
 moO
-oKy
+pSC
 pSo
-oKy
-oKy
+pSC
+pSC
 uCO
-qoZ
+whX
 dCV
 fBs
 kdJ
@@ -65738,7 +65766,7 @@ nGq
 pMI
 kwe
 uCO
-mrS
+mPa
 oqu
 rdC
 ryc
@@ -66254,11 +66282,11 @@ ktX
 uCO
 uCO
 oIQ
-qAc
+rHT
 rdC
-uSz
+vxI
 rdC
-xSa
+nzz
 xya
 xya
 hsk
@@ -66509,17 +66537,17 @@ nGq
 dCV
 dCV
 lzV
-mMN
+oEF
 rdC
-qDM
-tYd
-rHT
+rLi
+uKG
+sQo
 oIQ
 rdC
 xya
 xya
 hsk
-mls
+wgE
 cam
 dkg
 dCV
@@ -66766,10 +66794,10 @@ nGq
 gts
 dCV
 uCO
-mPa
-oTB
+oJm
+qbe
 sDj
-uJP
+uOr
 sDj
 oIQ
 oIQ
@@ -67288,7 +67316,7 @@ rdC
 rdC
 oIQ
 xMP
-jRo
+gHZ
 kzW
 dkg
 cpK
@@ -67538,20 +67566,20 @@ gts
 dCV
 dCV
 mGh
-pSC
-rpa
+qcS
+sCF
 rdC
 oIQ
 oIQ
-jRH
-rpa
+vtQ
+sCF
 uqa
-nXS
+ntq
 dkg
 cpK
 gdY
 mkV
-bop
+mpD
 uqa
 hJM
 mvv
@@ -67795,15 +67823,15 @@ gts
 gts
 dCV
 uCO
-qbe
-rHT
+qAc
+sQo
 rdC
-xSa
+nzz
 oIQ
-rHT
+sQo
 xPh
 drN
-qwZ
+arG
 dkg
 gdY
 jGl
@@ -68055,12 +68083,12 @@ uCO
 oQv
 qlE
 oIQ
-yht
-yht
+vPG
+vPG
 uQx
 qlE
 uqa
-sBv
+hii
 dkg
 cam
 cah
@@ -68311,7 +68339,7 @@ dCV
 dCV
 dCV
 dCV
-dCV
+uSz
 sDr
 sDr
 sDr
@@ -68568,12 +68596,12 @@ lCi
 lCi
 oUj
 dCV
-uKG
-kzW
-vbz
+xSa
+kdt
+nKl
 uRN
 qwq
-kAp
+jEC
 dHO
 cam
 jGl
@@ -68826,9 +68854,9 @@ xdD
 xdD
 qyj
 rJO
-vbz
-wKM
-tEA
+hCU
+oFh
+lMI
 kzW
 ids
 cpK
@@ -69084,8 +69112,8 @@ xdD
 dCV
 kzW
 sNM
-eyG
-qfH
+dbO
+fxc
 kzW
 cpK
 cpK
@@ -69338,8 +69366,8 @@ dCV
 lEx
 lEx
 lEx
-pMI
-rLi
+qDM
+pgl
 sOD
 ucw
 wIK
@@ -69595,14 +69623,14 @@ lEG
 aJb
 hBN
 aJb
-sCF
+tWd
 tUb
-idu
-idu
-idu
-idu
-idu
-idu
+pWN
+plq
+rkr
+aJb
+aJb
+tUb
 idu
 idu
 jMO
@@ -69854,11 +69882,11 @@ hOl
 hOl
 lEG
 erY
-erY
-erY
-erY
-erY
-erY
+wGJ
+wGJ
+wGJ
+wGJ
+wGJ
 erY
 wGJ
 erY
@@ -70106,15 +70134,15 @@ kaM
 kaM
 kaM
 lEG
-kaM
-hOl
+moo
 oUy
-sQo
+oUy
+tYd
 oUy
 sPJ
 ier
-kaM
-kaM
+qoS
+qoS
 kaM
 erY
 erY
@@ -70363,7 +70391,7 @@ ees
 hEa
 gts
 gts
-sYX
+mrg
 sYX
 sYX
 sYX
@@ -70628,7 +70656,7 @@ sYX
 sYX
 sYX
 sYX
-exz
+gie
 ajD
 hbW
 hOl
@@ -77053,7 +77081,7 @@ gts
 gts
 dCV
 dCV
-wYN
+pMR
 ids
 lTx
 dit
@@ -99730,7 +99758,7 @@ mvv
 doX
 wDc
 syr
-bcf
+bxk
 uXj
 eXO
 mvv

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -222,6 +222,12 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
+"ajt" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
+	},
+/area/f13/tunnel)
 "ajJ" = (
 /obj/structure/sign/poster/prewar/poster71,
 /turf/closed/wall/r_wall,
@@ -349,6 +355,7 @@
 	dir = 1;
 	name = "light tube"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "aqs" = (
@@ -6945,6 +6952,13 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"ftv" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "clinicoutsideladder"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "ftz" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -8287,6 +8301,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"gxc" = (
+/obj/effect/landmark/start/f13/preacher,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/tunnel)
 "gxq" = (
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -8569,6 +8587,12 @@
 /obj/item/clothing/head/helmet/roman/fake,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"gNQ" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
+	},
+/area/f13/tunnel)
 "gNZ" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -9359,6 +9383,10 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"hsr" = (
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "hsv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -15086,7 +15114,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/structure/ladder/unbreakable{
 	height = 1;
-	id = "cornerladder"
+	id = "clinicoutsideladder"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
@@ -22923,6 +22951,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"tbq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
+	},
+/area/f13/tunnel)
 "tbr" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/floor/f13{
@@ -25123,6 +25158,8 @@
 /area/f13/tunnel)
 "vcz" = (
 /obj/machinery/light,
+/obj/effect/turf_decal/box/white,
+/obj/structure/closet/crate/medical/anchored,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "vcL" = (
@@ -53021,12 +53058,12 @@ oFg
 uoO
 uoO
 eLE
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 eLE
 "}
 (98,1,1) = {"
@@ -54048,7 +54085,7 @@ aGH
 oFg
 uoO
 uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -55040,9 +55077,9 @@ uoO
 eLE
 eLE
 eLE
-uoO
-uoO
-uoO
+eLE
+eLE
+eLE
 eLE
 uoO
 oFg
@@ -55551,14 +55588,14 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
+eLE
+eLE
 bYk
 oFg
 oFg
@@ -55808,14 +55845,14 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
+eLE
+eLE
 eLE
 eLE
 eLE
@@ -56064,15 +56101,15 @@ eLE
 eLE
 eLE
 eLE
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -56328,8 +56365,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+eLE
+eLE
 eLE
 eLE
 eLE
@@ -56585,8 +56622,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -56842,8 +56879,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -57099,8 +57136,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+eLE
+eLE
 eLE
 eLE
 uoO
@@ -57356,8 +57393,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+eLE
+eLE
 eLE
 eLE
 uoO
@@ -57613,8 +57650,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+eLE
+eLE
 eLE
 eLE
 uoO
@@ -57870,16 +57907,15 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-eLE
-eLE
-uoO
 eLE
 eLE
 eLE
 eLE
 uoO
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -57902,6 +57938,7 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
 uoO
 uoO
@@ -58127,25 +58164,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-eLE
-eLE
-eLE
-eLE
-eLE
-uoO
-eLE
-uoO
 eLE
 eLE
 eLE
@@ -58157,8 +58175,27 @@ eLE
 eLE
 eLE
 eLE
-uoO
-uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -63766,7 +63803,7 @@ bwR
 nrO
 nrO
 nrO
-nrO
+wVl
 nrO
 tur
 fGO
@@ -64020,7 +64057,7 @@ vuv
 vuv
 iuv
 nrO
-nrO
+wVl
 nrO
 nrO
 nrO
@@ -65288,7 +65325,7 @@ iuv
 nrO
 iuv
 nrO
-iuv
+tbq
 nrO
 iuv
 iuv
@@ -65801,11 +65838,11 @@ ivl
 dIB
 iDI
 wOt
-iuv
+xcp
 nrO
 nrO
 iuv
-nrO
+gNQ
 eoX
 uoO
 uoO
@@ -65816,7 +65853,7 @@ vuv
 tsn
 pGg
 nrO
-iuv
+tbq
 nrO
 vuv
 nXJ
@@ -66319,7 +66356,7 @@ tNA
 bTJ
 xml
 nrO
-iuv
+xcp
 nrO
 nrO
 nrO
@@ -66331,7 +66368,7 @@ nrO
 nrO
 iuv
 iuv
-nrO
+wVl
 vuv
 vuv
 iWh
@@ -66584,7 +66621,7 @@ iuv
 nrO
 iuv
 nrO
-iuv
+xcp
 nrO
 nrO
 nrO
@@ -67598,14 +67635,14 @@ npL
 npL
 gyd
 iuv
-nrO
+ajt
 jmN
 vuv
 vuv
 vuv
 vuv
 kfy
-kfy
+gxc
 dUq
 nrO
 cki
@@ -67862,7 +67899,7 @@ tAC
 xKn
 vuv
 kfy
-kfy
+gxc
 dUq
 nrO
 cki
@@ -68385,9 +68422,9 @@ weW
 weW
 lZH
 nrO
+gNQ
 nrO
-nrO
-iuv
+xcp
 bfY
 bfY
 bfY
@@ -68636,7 +68673,7 @@ kfy
 kfy
 nrO
 nrO
-nrO
+ajt
 cki
 weW
 nrO
@@ -68885,21 +68922,21 @@ uDV
 nrO
 rWP
 gDj
+wVl
+nrO
+nrO
+iuv
+iuv
+nrO
+nrO
+iuv
 nrO
 nrO
 nrO
 nrO
 nrO
 nrO
-nrO
-nrO
-nrO
-nrO
-nrO
-nrO
-nrO
-nrO
-nrO
+iuv
 nrO
 nrO
 niT
@@ -69146,16 +69183,16 @@ wOt
 uoO
 uoO
 aqr
+iuv
+nrO
+nrO
+iuv
 nrO
 nrO
 nrO
-nrO
-nrO
-nrO
-nrO
-nrO
-nrO
-nrO
+iuv
+iuv
+iuv
 mia
 nrO
 iuv
@@ -69405,12 +69442,12 @@ cql
 cql
 nrO
 nrO
+gNQ
 nrO
 nrO
-nrO
-nrO
-nrO
-nrO
+iuv
+iuv
+ajt
 nrO
 mia
 mia
@@ -69661,18 +69698,18 @@ jmN
 jmN
 cql
 nrO
+iuv
 nrO
-nrO
 uvW
 uvW
 uvW
 uvW
 jmN
+aAF
 jmN
 jmN
 jmN
-jmN
-nrO
+ajt
 bfY
 bfY
 nrO
@@ -70183,7 +70220,7 @@ xhg
 ghw
 ghw
 ghw
-cql
+ghw
 cql
 uvW
 iuv
@@ -70440,8 +70477,8 @@ ghw
 qfC
 uKs
 dZe
-cql
-cql
+ghw
+hsr
 uvW
 nrO
 vuv
@@ -70697,7 +70734,7 @@ ghw
 npL
 npL
 qMG
-cql
+ghw
 vcz
 uvW
 nrO
@@ -70951,10 +70988,10 @@ gGr
 uvW
 dQm
 ghw
-npL
-npL
-npL
-cql
+ghw
+ghw
+ghw
+ghw
 ttl
 uvW
 nrO
@@ -71214,7 +71251,7 @@ cql
 cql
 xTE
 uvW
-nrO
+ftv
 vuv
 cql
 npL
@@ -74535,7 +74572,7 @@ uoO
 uoO
 uoO
 eLE
-uoO
+dXE
 tur
 tur
 tur
@@ -74792,21 +74829,21 @@ uoO
 uoO
 uoO
 uoO
-uoO
+dXE
+aJp
 weW
 weW
 weW
 weW
 weW
 weW
+nCU
 weW
 weW
 weW
 weW
 weW
-weW
-weW
-weW
+nCU
 weW
 weW
 weW

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -9,11 +9,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"aaM" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/ash,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "abg" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/uranium{
@@ -23,10 +18,15 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "abi" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
+"abG" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plating/f13,
+/area/f13/followers)
 "abY" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/f13{
@@ -45,58 +45,62 @@
 	},
 /area/f13/building)
 "acs" = (
-/obj/structure/closet/crate/miningcar,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "acv" = (
 /obj/structure/sign/poster/prewar/poster65,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
-"acJ" = (
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "acT" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib5-old";
-	tag = "icon-gib5-old"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/machinery/light/broken{
+	dir = 1
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"acY" = (
-/obj/structure/closet/crate/large,
-/obj/item/storage/box/stockparts/basic,
-/turf/open/floor/f13{
+/turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"adc" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
+"ads" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/sleeper,
+/obj/item/circuitboard/machine/biogenerator,
+/obj/item/circuitboard/machine/seed_extractor,
+/obj/item/circuitboard/machine/chem_dispenser,
+/obj/item/circuitboard/machine/chem_master,
+/obj/item/circuitboard/machine/chem_heater,
+/obj/item/circuitboard/machine/ore_redemption,
+/obj/item/circuitboard/machine/mining_equipment_vendor,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
 	},
-/area/f13/tunnel)
-"adf" = (
-/obj/structure/destructible/tribal_torch/lit,
-/obj/structure/destructible/tribal_torch/lit,
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/area/f13/followers)
 "adx" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "adO" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
 "adY" = (
-/obj/structure/decoration/warning,
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "aej" = (
 /obj/structure/sign/poster/prewar/poster61,
 /turf/closed/wall/r_wall,
@@ -110,10 +114,28 @@
 /turf/open/water,
 /area/f13/tunnel)
 "aeS" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/item/autosurgeon,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/item/clothing/head/helmet/f13/power_armor/t45d{
+	color = "#C1C1C1";
+	desc = "(IX) It's an old pre-War power armor helmet. It's pretty hot inside of it. Nice.";
+	item_color = "#C1C1C1"
+	},
+/obj/item/defibrillator/compact/combat/loaded,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "aeZ" = (
 /obj/structure/bed/mattress,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -126,10 +148,11 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "afj" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/decoration/warning,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "afP" = (
 /obj/machinery/computer/terminal{
 	dir = 4;
@@ -138,11 +161,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"afT" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "agm" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
@@ -153,28 +171,30 @@
 	},
 /area/f13/tunnel)
 "ahe" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/warning{
-	pixel_x = -3;
-	pixel_y = -5
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/machinery/light/broken{
+	dir = 1
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"ahB" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/curtain,
 /turf/open/floor/plasteel/f13{
-	icon_state = "showroomfloor"
+	icon_state = "redrustyfull"
 	},
-/area/f13/tunnel)
-"ahI" = (
+/area/f13/bunker)
+"ahr" = (
+/turf/closed/indestructible/f13/matrix,
+/area/f13/followers)
+"ahB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/corpse/raider,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
@@ -182,10 +202,6 @@
 /obj/structure/sign/poster/prewar/poster60,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
-"aiI" = (
-/mob/living/simple_animal/hostile/raider/firefighter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "ajc" = (
 /obj/structure/curtain{
 	color = "#5c131b"
@@ -194,10 +210,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "ajk" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "showroomfloor"
-	},
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ajl" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -207,21 +222,14 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"ajn" = (
-/obj/machinery/gibber,
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
 "ajJ" = (
 /obj/structure/sign/poster/prewar/poster71,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "ajM" = (
-/obj/structure/toilet,
-/obj/structure/curtain,
-/turf/open/floor/plasteel/f13{
-	icon_state = "showroomfloor"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ajQ" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
@@ -260,20 +268,21 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"akZ" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider/thief,
+"ala" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"ala" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "showroomfloor"
-	},
-/area/f13/tunnel)
 "alw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mirror{
@@ -289,40 +298,39 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "alO" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/curtain,
-/turf/open/floor/plasteel/f13{
-	icon_state = "showroomfloor"
-	},
-/area/f13/tunnel)
+/obj/item/fishingrod,
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/water,
+/area/f13/bunker)
 "amf" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
-"any" = (
+"amL" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"anB" = (
-/obj/machinery/light/small{
-	dir = 4
+/area/f13/tunnel)
+"amV" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/geiger_counter,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "showroomfloor"
+	icon_state = "floorrustysolid"
 	},
 /area/f13/tunnel)
-"anL" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
+"aoi" = (
+/obj/effect/landmark/start/f13/prospector,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "aoj" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
@@ -332,21 +340,22 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"aoD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood,
-/obj/item/reagent_containers/food/snacks/meat/slab/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"aqg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
 "aqn" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/f13/vault,
+/area/f13/bunker)
+"aqr" = (
+/obj/machinery/light/fo13colored/Pink{
+	dir = 1;
+	name = "light tube"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"aqs" = (
+/obj/structure/closet/crate/medical,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/bunker)
 "aqP" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -355,6 +364,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"aqQ" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "aqX" = (
 /obj/structure/closet/wardrobe/pjs,
 /obj/effect/decal/cleanable/dirt,
@@ -372,17 +387,23 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"arD" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
+"arQ" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ask" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/curtain,
-/obj/item/reagent_containers/syringe,
-/obj/effect/decal/remains/human,
-/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
-/turf/open/floor/plasteel/f13{
-	icon_state = "showroomfloor"
-	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"asY" = (
+/obj/effect/landmark/start/f13/settler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "atb" = (
 /obj/structure/table,
@@ -390,21 +411,21 @@
 	dir = 9
 	},
 /area/f13/tcoms)
+"atm" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "ato" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/structure/curtain,
-/turf/open/floor/plasteel/f13{
-	icon_state = "showroomfloor"
-	},
-/area/f13/tunnel)
-"aty" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13{
-	icon_state = "showroomfloor"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "atO" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -445,22 +466,45 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/tunnel)
-"avY" = (
+"avO" = (
+/obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/weightlifter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"awf" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/mutagen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/f13/bunker)
+"awq" = (
+/obj/item/chair,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
+"awF" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "awR" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
-"axC" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/item/clothing/suit/armor/f13/power_armor/t45d/gunslinger,
+/obj/item/clothing/head/helmet/f13/power_armor/t45d/gunslinger,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ayH" = (
@@ -481,18 +525,15 @@
 	},
 /area/f13/clinic)
 "azr" = (
-/turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
-"azs" = (
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"azz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
 	},
-/area/f13/bunker)
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier9,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "azD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -502,16 +543,20 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"aAF" = (
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "133"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "clinicstorage";
+	name = "storage shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "aBb" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/tunnel)
-"aBk" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/bunker)
 "aBq" = (
 /obj/structure/toilet{
 	pixel_y = 10
@@ -531,11 +576,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "aCf" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
+/area/f13/bunker)
 "aCo" = (
 /obj/structure/foamedmetal,
 /turf/open/floor/f13{
@@ -543,13 +588,26 @@
 	},
 /area/f13/bunker)
 "aCq" = (
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste,
+/mob/living/simple_animal/hostile/abomhorror/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"aCt" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/item/storage/fancy/candle_box,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "aCu" = (
-/obj/item/reagent_containers/syringe/piercing,
-/turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "aCE" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/plasteel/f13/vault_floor/floor{
@@ -561,36 +619,21 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "aGv" = (
-/obj/structure/showcase/horrific_experiment{
-	icon_state = "pod_0"
-	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/abomhorror/nsb,
 /turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/tunnel)
-"aGz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/raider/tribal,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "aGH" = (
-/obj/machinery/light{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "purplefull"
 	},
-/obj/structure/showcase/horrific_experiment,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/tunnel)
+/area/f13/followers)
 "aGO" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/syringes,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/tunnel)
+/obj/structure/decoration/shock,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "aHj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/window/survival_pod{
@@ -617,13 +660,14 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"aIH" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
+"aIJ" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
 	},
-/area/f13/bunker)
+/area/f13/followers)
 "aIU" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/f13/combat,
@@ -632,16 +676,15 @@
 /obj/item/clothing/suit/armor/f13/combat/mk2,
 /obj/item/clothing/head/helmet/f13/combat/mk2,
 /obj/item/clothing/mask/gas/syndicate,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"aJc" = (
-/obj/machinery/button/door{
-	id = "soup";
-	name = "Door Control"
+"aJp" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/caves)
+/turf/open/water,
+/area/f13/tunnel)
 "aJR" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "bosarmoryacc";
@@ -653,86 +696,70 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"aJX" = (
-/obj/structure/frame/machine,
-/obj/item/stack/cable_coil/cut/random,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"aKV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"aLk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "aLn" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"aLr" = (
+/obj/structure/bodycontainer/crematorium,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/followers)
 "aLt" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "aLy" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/beakers,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1
 	},
-/area/f13/tunnel)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "aLA" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"aMg" = (
-/obj/machinery/light{
-	dir = 1
+"aLI" = (
+/obj/structure/sign/poster/contraband/pinup_topless{
+	pixel_x = 32
 	},
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/machinery/light/small{
+	dir = 4
 	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"aMg" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"aNr" = (
+/obj/item/flashlight/flare,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"aNB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "aND" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
-"aNG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
 "aNI" = (
-/obj/structure/showcase/horrific_experiment,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/structure/table/glass,
+/obj/item/fermichem/pHmeter,
+/obj/item/fermichem/pHmeter,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/area/f13/tunnel)
-"aNQ" = (
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
-"aOz" = (
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/bunker)
+/area/f13/followers)
 "aQg" = (
 /obj/machinery/button/door{
 	id = "bosdorm6";
@@ -778,6 +805,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
+"aSM" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "aSW" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -787,19 +827,46 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/brotherhood/offices1st)
-"aTr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+"aSX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"aTh" = (
+/obj/structure/junk/small/bed2,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"aTJ" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/tunnel)
+"aTR" = (
+/obj/machinery/light/fo13colored/Pink{
+	dir = 4;
+	name = "light tube"
+	},
+/obj/structure/wreck/trash/five_tires{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "aUo" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
+/area/f13/tunnel)
+"aVg" = (
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "aWj" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -819,12 +886,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
-"aWs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood,
-/obj/item/reagent_containers/food/snacks/meat/slab/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "aWx" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -832,14 +893,18 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "aWF" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "aWJ" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"aWS" = (
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "aXP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -849,10 +914,18 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"aYg" = (
-/obj/effect/decal/waste,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"aYc" = (
+/obj/structure/campfire/barrel,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/bunker)
+"aYf" = (
+/obj/structure/closet/wardrobe/virology_white,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
 "aYI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -1014,6 +1087,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"aZi" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "aZl" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "bosdorm6";
@@ -1024,24 +1103,40 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"aZo" = (
-/obj/structure/decoration/smokeold,
-/turf/closed/wall/r_wall/rust,
-/area/f13/bunker)
-"baE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/water,
-/area/f13/bunker)
-"baF" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/deathclaw,
-/turf/open/water,
-/area/f13/caves)
-"baX" = (
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
+"aZR" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"bad" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"baF" = (
+/obj/structure/table/wood/fancy,
+/obj/item/candle,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/tunnel)
+"baJ" = (
+/obj/structure/decoration/warning{
+	pixel_y = -2
+	},
+/obj/structure/sign/warning{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
 "bbq" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1072,6 +1167,16 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"bbB" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "bbI" = (
 /obj/structure/handrail/g_end{
 	dir = 1;
@@ -1118,13 +1223,9 @@
 	},
 /area/f13/tunnel)
 "bcv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "bcw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed,
@@ -1157,6 +1258,23 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"bdd" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"bdt" = (
+/obj/structure/guncase,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "bdB" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -1164,6 +1282,12 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/tunnel)
+"bdC" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "bdK" = (
 /obj/machinery/door/airlock/grunge{
@@ -1176,13 +1300,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"bdL" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/bunker)
 "bdP" = (
 /obj/effect/landmark/start/f13/seniorpaladin,
 /obj/effect/decal/cleanable/dirt,
@@ -1193,13 +1310,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"bek" = (
-/obj/effect/decal/remains/human,
-/obj/effect/gibspawner/human,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
 "ber" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/cigarette,
@@ -1207,27 +1317,36 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"beY" = (
-/obj/structure/window/reinforced{
+"beu" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"bez" = (
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/handrail/g_central{
+	pixel_y = -16
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/item/storage/box/stockparts/deluxe,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
+/turf/open/water,
 /area/f13/tunnel)
+"beY" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "bfh" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/black,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
+"bfj" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
+	},
+/area/f13/tunnel)
 "bfy" = (
 /turf/closed/wall/rust,
 /area/f13/enclave)
@@ -1241,6 +1360,9 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"bfY" = (
+/turf/closed/wall/f13/wood/house,
+/area/f13/tunnel)
 "bgg" = (
 /obj/structure/table/wood/settler,
 /obj/item/flashlight,
@@ -1249,17 +1371,9 @@
 	},
 /area/f13/tunnel)
 "bgu" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "bgL" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/f13{
@@ -1288,18 +1402,23 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"bis" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/closet/crate/secure/loot,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
+"bhS" = (
+/obj/machinery/autolathe,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"bib" = (
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "133"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"bis" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "biy" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/mouse/white{
@@ -1324,33 +1443,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "bjr" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "bjw" = (
-/obj/structure/window/reinforced{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/tunnel)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "bjz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -1359,24 +1462,14 @@
 	},
 /area/f13/brotherhood/leisure)
 "bjF" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/tunnel)
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/water,
+/area/f13/bunker)
 "bkU" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"blc" = (
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
 "ble" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "bosdorm9";
@@ -1387,12 +1480,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"blF" = (
-/obj/structure/window/reinforced/spawner/north,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "blH" = (
 /obj/structure/table,
 /obj/item/multitool,
@@ -1401,28 +1488,11 @@
 	},
 /area/f13/tcoms)
 "bmc" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/tunnel)
+/turf/open/water,
+/area/f13/bunker)
 "bmj" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/tunnel)
-"bmv" = (
-/mob/living/simple_animal/hostile/handy/nsb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "bmx" = (
 /obj/docking_port/stationary/bosaway,
@@ -1452,6 +1522,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
+"bmX" = (
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
+"bnv" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "bnM" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /turf/open/indestructible/ground/inside/mountain,
@@ -1460,6 +1546,25 @@
 /obj/structure/simple_door/bunker,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"boc" = (
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"bof" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "bor" = (
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white/bos,
@@ -1505,20 +1610,40 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"bqs" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
+"bql" = (
+/obj/structure/closet/cabinet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"bqs" = (
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/structure/table,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "bqO" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"bqV" = (
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/caves)
 "bqY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/wrench/crude,
@@ -1560,14 +1685,16 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"bsp" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
 "bsw" = (
-/obj/structure/chair/f13chair2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/tunnel)
+/obj/item/wrench/crude,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "bsF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/autoname{
@@ -1587,11 +1714,9 @@
 	},
 /area/f13/tunnel)
 "bsQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/caves)
+/obj/structure/table/booth,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "bta" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser/pistol,
@@ -1609,11 +1734,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"btu" = (
-/obj/structure/simple_door/fakeglass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "btB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -1622,24 +1742,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"btV" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
-	},
-/area/f13/bunker)
 "bud" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/light/broken{
+	dir = 1
 	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "bum" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
@@ -1665,25 +1773,9 @@
 	},
 /area/f13/tunnel)
 "buJ" = (
-/obj/machinery/power/rtg,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "fwindow"
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "fwindow"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "buN" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -1691,8 +1783,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "buV" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/item/pickaxe/mini,
+/turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "buZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1723,11 +1815,18 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"bvH" = (
-/mob/living/simple_animal/hostile/handy/assaultron,
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
+"bwA" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"bwR" = (
+/obj/machinery/light/fo13colored/Aqua{
+	bulb_colour = "#800080";
+	dir = 8;
+	light_color = "#800080";
+	name = "light fixture"
 	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "bxz" = (
 /obj/machinery/telecomms/receiver/preset_left,
@@ -1747,18 +1846,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
-"bxJ" = (
-/obj/item/gun/ballistic/automatic/tribalbow{
-	desc = "A simple wooden bow with small pieces of turquiose. This one looks particularly blood-covered. Who the fuck brings a /BOW/ to a /BUNKER/"
-	},
-/obj/effect/mob_spawn/human/corpse,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"bxQ" = (
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "bxU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1771,13 +1858,6 @@
 /obj/structure/window/reinforced/tinted,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
-"byb" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/bunker)
 "byA" = (
 /obj/structure/flora/grass/wasteland,
 /obj/structure/flora/rock/jungle,
@@ -1787,6 +1867,12 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water,
 /area/f13/caves)
+"byF" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "bzt" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
@@ -1800,6 +1886,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"bAq" = (
+/obj/structure/light_construct,
+/obj/structure/bed,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
 "bAx" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1810,6 +1903,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"bAz" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "bAD" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
@@ -1821,25 +1918,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bBf" = (
-/mob/living/simple_animal/hostile/handy/robobrain{
-	name = "Conscripted Engineer"
+/obj/machinery/light/broken{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "bBZ" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
+/obj/item/storage/trash_stack,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "bCf" = (
 /obj/structure/bed/pod,
 /obj/machinery/button/door{
@@ -1857,6 +1945,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whitedirtysolid"
 	},
+/area/f13/tunnel)
+"bCy" = (
+/obj/item/flag/oasis,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "bCX" = (
 /obj/structure/cable{
@@ -1880,6 +1972,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/rnd)
+"bDq" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "bDG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1893,6 +1992,20 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
+"bEp" = (
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "bEu" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -1901,17 +2014,10 @@
 	},
 /area/f13/clinic)
 "bEw" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/item/inducer,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/securitron/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "bEz" = (
 /obj/structure/table/reinforced,
 /obj/item/pda/engineering{
@@ -1938,33 +2044,33 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"bFl" = (
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
-"bFU" = (
-/obj/structure/table,
-/obj/item/fusion_fuel,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
-	},
-/area/f13/bunker)
-"bGf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
+"bFe" = (
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "bGi" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"bGm" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"bGp" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "bGF" = (
 /obj/machinery/light{
 	dir = 4
@@ -1989,33 +2095,33 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"bHz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/window/eastleft,
-/obj/item/stack/sheet/plasteel/twenty,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
+"bHt" = (
+/obj/structure/junk/small/bed,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "bHA" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"bHO" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
 "bIh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/mob/living/simple_animal/hostile/handy/protectron/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"bIH" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/obj/machinery/door/window/westright,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
+/area/f13/bunker)
+"bIJ" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "bIS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -2043,14 +2149,12 @@
 	},
 /area/f13/clinic)
 "bJG" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 35
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bKi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2069,6 +2173,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"bKB" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "bKG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -2094,10 +2202,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"bMb" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
 "bMe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -2111,18 +2215,39 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/leisure)
-"bMq" = (
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+"bMf" = (
+/obj/machinery/door/poddoor/preopen{
+	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70);
+	id = eairlock
 	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "bluemark"
+	},
+/area/f13/bunker)
+"bMq" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bMy" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"bMz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Aqua{
+	bulb_colour = "#800080";
+	dir = 8;
+	light_color = "#800080";
+	name = "light fixture"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "bMA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -2146,6 +2271,20 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/leisure)
+"bMV" = (
+/mob/living/simple_animal/hostile/handy/sentrybot,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"bNe" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "bNv" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/f13/ruins,
@@ -2181,16 +2320,18 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"bOb" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "bOf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/initiate,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
-"bOv" = (
-/obj/effect/decal/remains/robot,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "bPh" = (
 /obj/structure/simple_door/metal/dirtystore,
 /obj/structure/decoration/rag{
@@ -2209,20 +2350,50 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"bPK" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/tunnel)
+"bPV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Bar Backroom";
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"bQx" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "bRf" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
-"bRs" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
 /area/f13/tunnel)
 "bRN" = (
 /obj/machinery/shower{
@@ -2234,28 +2405,14 @@
 /obj/structure/decoration/vent,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
-"bRX" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "bSs" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
 "bSL" = (
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
-/turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
-"bSS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman/super,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
-"bSU" = (
-/mob/living/simple_animal/hostile/raider/tribal,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "bTu" = (
@@ -2271,6 +2428,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
+"bTy" = (
+/obj/effect/decal/cleanable/blood/old,
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "bTG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced/tinted{
@@ -2283,6 +2447,12 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
 	},
+/area/f13/tunnel)
+"bTJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/toolbox/drone,
+/obj/item/storage/toolbox/drone,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "bTN" = (
 /obj/structure/noticeboard{
@@ -2302,11 +2472,6 @@
 /obj/structure/wreck/trash/halftire,
 /turf/open/water,
 /area/f13/tunnel)
-"bUK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "bUX" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -2322,6 +2487,25 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
+"bVf" = (
+/obj/structure/table/snooker{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"bVh" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
+"bVn" = (
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/water,
+/area/f13/tunnel)
 "bVO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
@@ -2335,39 +2519,66 @@
 /obj/structure/sign/poster/prewar/poster91,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
-"bWa" = (
+"bWf" = (
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "bWk" = (
-/obj/machinery/camera/autoname{
-	dir = 9
+/obj/effect/decal/waste{
+	icon_state = "goo12"
 	},
-/obj/structure/showcase/horrific_experiment,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/storage/box/strange_seeds_10pack,
 /turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+	icon_state = "redrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "bWl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "pain";
+	name = "Door Control"
 	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
 /turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+	icon_state = "redrustyfull"
 	},
-/area/f13/tunnel)
-"bWq" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/bunker)
 "bWQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
+"bWY" = (
+/obj/structure/closet/fridge,
+/obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
+"bYk" = (
+/turf/closed/mineral/random/low_chance,
+/area/f13/followers)
+"bYr" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "bYK" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -2381,10 +2592,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"caq" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "caQ" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt{
@@ -2392,13 +2599,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"caS" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/indestructible/fakedoor{
-	desc = "An indestructible door. Hm.";
-	name = "Strong Door"
-	},
-/area/f13/bunker)
 "cbs" = (
 /obj/structure/fluff/railing{
 	dir = 9
@@ -2441,22 +2641,26 @@
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"ccU" = (
-/obj/machinery/workbench/advanced,
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
-/obj/item/book/granter/crafting_recipe/gunsmith_two,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
-"cda" = (
+"ccP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate{
-	anchored = 1;
-	can_be_unanchored = 1
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/tunnel)
+"cdo" = (
+/mob/living/simple_animal/hostile/enclave/soldier{
+	desc = "A former Enclave soldier, mutated by the forced evolutionary virus and grafted to the interior of his suit.";
+	extra_projectiles = 1;
+	faction = list("wastebot");
+	loot = null;
+	name = "mutated enclave soldier";
+	speak = list("AUUGHGHHH!");
+	speak_emote = list("shouts")
 	},
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier9,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "cej" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -2469,6 +2673,29 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whitedirtysolid"
+	},
+/area/f13/tunnel)
+"cep" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/caves)
+"ceu" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/geiger_counter,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/tunnel)
 "cfe" = (
@@ -2486,6 +2713,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"cfz" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "cfA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -2519,16 +2752,20 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/sewer)
-"cgm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/lit,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
-"chC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
+"cgp" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
+"cgr" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/obj/item/shard{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/bunker)
 "chW" = (
 /obj/structure/barricade/bars,
@@ -2544,12 +2781,25 @@
 	},
 /area/f13/clinic)
 "cid" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"cim" = (
+/obj/structure/closet/wardrobe/chemistry_white,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
+"ciD" = (
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 1;
+	name = "light fixture"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "ciF" = (
 /obj/structure/table,
@@ -2557,18 +2807,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"ciN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
-"ciS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "cje" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -2578,15 +2816,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/tunnel)
-"cjw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "okay";
-	name = "Door Control"
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+"cki" = (
+/obj/effect/decal/riverbank,
+/turf/open/water,
+/area/f13/tunnel)
 "ckm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -2610,13 +2843,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ckZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/structure/bookcase/manuals,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/tunnel)
+/area/f13/followers)
 "clz" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier9,
@@ -2636,15 +2867,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"clP" = (
-/obj/structure/closet/crate,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/armor/tier2,
-/obj/effect/spawner/lootdrop/f13/armor/tier1,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "clT" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -2664,10 +2886,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
-"cnA" = (
-/obj/structure/decoration/shock,
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
 "cnF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -2681,19 +2899,6 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"cnS" = (
-/obj/structure/girder/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
-"coe" = (
-/obj/machinery/door/airlock/hatch{
-	locked = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/tunnel)
 "cof" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood{
@@ -2717,6 +2922,11 @@
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"cpD" = (
+/obj/structure/wreck/trash/four_barrels,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "cpE" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13{
@@ -2740,6 +2950,33 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"cql" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"cqp" = (
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/turf/open/water,
+/area/f13/caves)
+"cqA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
+"cqB" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/f13{
+	dir = 6;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
 "cqF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -2767,29 +3004,10 @@
 	},
 /area/f13/brotherhood/operations)
 "crg" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+	icon_state = "redrustyfull"
 	},
-/area/f13/tunnel)
-"crt" = (
-/obj/item/clothing/glasses/welding,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
-"crx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "crL" = (
 /obj/structure/reagent_dispensers/barrel/two,
@@ -2810,6 +3028,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/f13/tcoms)
+"csk" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "csM" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/decal/cleanable/dirt{
@@ -2853,12 +3077,6 @@
 /obj/structure/decoration/vent,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
-"cuz" = (
-/obj/item/computer_hardware/recharger/APC,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
 "cuT" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/f13{
@@ -2882,6 +3100,20 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"cvs" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "cvO" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt,
@@ -2889,17 +3121,20 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"cwV" = (
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "cxb" = (
 /obj/structure/wreck/car/bike,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"cxy" = (
-/obj/machinery/light/small{
-	dir = 4
+"cxu" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "cxR" = (
@@ -2919,12 +3154,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"cxU" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "cyA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -2934,6 +3163,19 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/brotherhood/reactor)
+"cyC" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
+"cyG" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/closed/indestructible/fakedoor{
+	desc = "An indestructible door. Hm.";
+	name = "Strong Door"
+	},
+/area/f13/bunker)
 "cyO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced/tinted{
@@ -2944,20 +3186,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
-"cyT" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+"czc" = (
+/obj/structure/handrail/g_central{
+	pixel_y = -16
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/geiger_counter,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "czl" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2973,31 +3207,33 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/leisure)
-"cAb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+"czr" = (
+/obj/structure/table,
+/obj/item/gun/energy/laser/plasma/glock,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/door/window/eastleft,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
+"czF" = (
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "cAf" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/sewer)
-"cAq" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/bunker)
 "cAB" = (
 /obj/structure/sign/poster/prewar/poster90,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
+"cBH" = (
+/mob/living/simple_animal/hostile/handy/protectron/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "cBS" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/dark,
@@ -3033,6 +3269,16 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"cCT" = (
+/obj/structure/simple_door/metal/barred,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bottomcellghoul"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bottomcellghoul"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "cDp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/cola/space_up,
@@ -3062,6 +3308,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
+"cEO" = (
+/obj/structure/table/snooker{
+	dir = 10
+	},
+/obj/item/melee/baseball_bat{
+	pixel_x = -7;
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "cFd" = (
 /obj/structure/table{
 	layer = 2.9
@@ -3127,39 +3383,43 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "cFR" = (
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
-"cFS" = (
-/obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
+/obj/effect/decal/remains/human,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "cGj" = (
 /obj/item/electronics/apc,
 /obj/item/stack/cable_coil,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"cGm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "cGq" = (
 /obj/structure/sign/poster/prewar/poster93,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
-"cGy" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
-"cGV" = (
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/generic,
+"cGL" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowhorizontal"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
+"cHb" = (
+/obj/structure/sign/poster/contraband/pinup_pink{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/area/f13/tunnel)
 "cHw" = (
 /obj/structure/closet/crate/secure/weapon{
 	anchored = 1
@@ -3195,42 +3455,23 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"cIa" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
 "cIi" = (
 /obj/structure/chair/wood/worn{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"cIA" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/tunnel)
 "cIF" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/sewer)
 "cIG" = (
-/obj/structure/table/reinforced,
-/obj/item/book/granter/trait/chemistry,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/water,
+/area/f13/bunker)
 "cIS" = (
 /obj/structure/dresser,
 /obj/machinery/light{
@@ -3254,15 +3495,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"cJZ" = (
-/obj/effect/decal/fakelattice,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "cKI" = (
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt{
@@ -3270,12 +3502,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"cKK" = (
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
+"cLx" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "cLJ" = (
 /obj/structure/closet/crate/secure/weapon{
 	anchored = 1
@@ -3314,11 +3544,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"cLR" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider/ranged/legendary,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "cLS" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -3336,40 +3561,28 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cMT" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	desc = "There is something on the wind. It.. it smells like... crime.";
+	name = "Detective Office";
+	req_one_access_txt = "4"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "cNz" = (
-/mob/living/simple_animal/hostile/abomination{
-	health = 400;
-	name = "Escaped abomination"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/tunnel)
-"cOb" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
-	},
-/area/f13/tunnel)
-"cOk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
+"cOe" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/caves)
 "cOn" = (
-/obj/structure/closet/l3closet/virology,
-/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/tunnel)
-"cOo" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "cPA" = (
 /obj/structure/table/reinforced,
@@ -3384,18 +3597,10 @@
 	},
 /area/f13/tunnel)
 "cQf" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
-"cQn" = (
-/obj/structure/kitchenspike,
-/obj/effect/mob_spawn/human/corpse/raidermelee,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/freezer,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "cQR" = (
 /obj/item/ammo_casing/spent{
@@ -3457,6 +3662,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"cSu" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "cSG" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3485,10 +3696,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"cSU" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+"cSX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "cSY" = (
 /turf/open/water,
 /area/f13/caves)
@@ -3528,6 +3742,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"cUk" = (
+/mob/living/simple_animal/hostile/raider/biker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "cUt" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -3556,23 +3774,23 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"cUR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "cWd" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "cWn" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "cXl" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -3616,23 +3834,21 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"daW" = (
-/obj/machinery/door/airlock/grunge,
-/obj/machinery/door/airlock/grunge,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"dbg" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/bunker)
 "dbZ" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
+/area/f13/tunnel)
+"dcc" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/stack/sheet/cloth/ten,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dcf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3641,12 +3857,37 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"dcq" = (
+/obj/structure/sink{
+	pixel_y = 19
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/followers)
+"dcv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "dcB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"dcK" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "dcO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -3655,18 +3896,24 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "dcV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ddQ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
+"ddY" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/landmark/start/f13/prospector,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "dek" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -3687,6 +3934,13 @@
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"deU" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "deX" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 1
@@ -3695,18 +3949,21 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
+"dfs" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"dfO" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "dgy" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "dgL" = (
 /obj/structure/table/wood/settler,
 /obj/item/gun/ballistic/revolver/caravan_shotgun,
@@ -3743,6 +4000,13 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"dig" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "diL" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	dir = 4;
@@ -3762,10 +4026,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/reactor)
-"djM" = (
-/obj/structure/decoration/warning,
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
 "djR" = (
 /obj/structure/toilet{
 	dir = 4
@@ -3788,13 +4048,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"dkZ" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/tunnel)
 "dlw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker{
@@ -3804,6 +4057,18 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"dlx" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "prospector1open";
+	name = "gate shutters";
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "dlz" = (
 /obj/structure/toilet{
 	pixel_y = 10
@@ -3816,49 +4081,24 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"dmy" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib3-old";
-	pixel_y = 12
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
 "dmH" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/tunnel)
-"dns" = (
-/obj/effect/decal/waste{
-	icon_state = "goo8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/wreck/trash/one_barrel,
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "dnu" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 5
 	},
-/obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 4
 	},
-/obj/item/clothing/suit/radiation,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/followers)
 "dnM" = (
 /obj/machinery/power/smes/engineering,
 /obj/effect/decal/cleanable/dirt,
@@ -3873,48 +4113,33 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"doL" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+"doN" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/area/f13/tunnel)
-"doZ" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 35
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/tunnel)
-"dpx" = (
-/obj/structure/frame/machine,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
+/area/f13/followers)
+"dpt" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "dpz" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
-"dpD" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
+"dpI" = (
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"dpV" = (
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/followers)
 "dqp" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "sentdorm";
@@ -3945,6 +4170,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"dqU" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "drd" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -3961,6 +4192,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"dsr" = (
+/obj/machinery/door/keycard{
+	puzzle_id = "library"
+	},
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "dsB" = (
 /obj/item/trash/cheesie,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -3972,6 +4210,14 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"dsS" = (
+/obj/structure/bonfire,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"dsT" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/f13/ruins,
+/area/f13/tunnel)
 "dtm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -3981,6 +4227,32 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/brotherhood/reactor)
+"dtu" = (
+/obj/machinery/door/airlock/vault{
+	autoclose = "TRUE";
+	layer = 2;
+	name = "Oasis Storage";
+	req_one_access_txt = "25"
+	},
+/obj/machinery/door/poddoor/ert{
+	id = "oasisstorage";
+	layer = 5;
+	name = "Oasis Storage"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
+"dtS" = (
+/obj/structure/sign/poster/contraband/red_rum{
+	pixel_y = -32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"dub" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "duf" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt{
@@ -3988,6 +4260,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"dug" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "dur" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -4012,19 +4294,13 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"dvZ" = (
-/obj/effect/decal/remains/human,
-/obj/effect/gibspawner/human,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+"dwz" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
-/area/f13/tunnel)
-"dwF" = (
-/obj/effect/spawner/lootdrop/f13/deadrodent_or_brainwashdisk,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/tunnel)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "dwY" = (
 /obj/structure/toilet/greyscale{
 	dir = 8
@@ -4085,11 +4361,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"dyn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
 "dyv" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -4108,13 +4379,14 @@
 	},
 /area/f13/sewer)
 "dyQ" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/bottle/FEV_solution,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "dyR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
@@ -4125,33 +4397,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
-"dyS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "dzJ" = (
-/obj/machinery/door/airlock/hatch{
-	locked = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
-"dAb" = (
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"dAK" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/fakelattice,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "dBy" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -4169,21 +4418,32 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
+"dBI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/revolver{
+	pixel_y = 32
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
 "dCf" = (
 /obj/structure/campfire/barrel,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"dDt" = (
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/tunnel)
 "dEa" = (
 /obj/machinery/telecomms/server/presets/den,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dEh" = (
-/obj/item/reagent_containers/syringe/piercing,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "dEm" = (
 /obj/effect/landmark/start/f13/seniorknight,
 /obj/effect/decal/cleanable/dirt,
@@ -4201,17 +4461,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
-"dEt" = (
-/obj/machinery/defibrillator_mount,
-/turf/closed/wall/r_wall/rust,
-/area/f13/bunker)
-"dEy" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "Vault1"
+"dEG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "okay";
+	name = "Door Control"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/tunnel)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "dFh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -4224,10 +4482,32 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/sewer)
+"dFA" = (
+/obj/machinery/button/door{
+	id = "oasisstorage";
+	name = "Oasis Storage Button";
+	pixel_x = 32;
+	req_one_access_txt = "62"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/caves)
 "dFC" = (
-/obj/structure/light_construct,
-/turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/mob/living/simple_animal/hostile/deathclaw/legendary{
+	speed = -1.5
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"dFU" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
 "dGe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/bos{
@@ -4263,6 +4543,20 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"dIr" = (
+/obj/item/flag/oasis,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/tunnel)
+"dIB" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "dID" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light{
@@ -4273,11 +4567,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"dJc" = (
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
 "dJm" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/subway,
@@ -4291,12 +4580,9 @@
 	},
 /area/f13/clinic)
 "dJx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/tunnel)
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dJD" = (
 /obj/machinery/door/window/brigdoor{
 	req_access_txt = "120"
@@ -4314,13 +4600,26 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"dJV" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/bottle/plasma,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+"dJG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"dJQ" = (
+/mob/living/simple_animal/hostile/trog/tunneler,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"dJV" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "dKk" = (
 /obj/item/target,
 /obj/item/target,
@@ -4354,12 +4653,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"dKt" = (
-/obj/machinery/autolathe,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "dKx" = (
 /obj/item/chair,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -4387,6 +4680,24 @@
 /obj/machinery/telecomms/server/presets/science,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"dLD" = (
+/obj/structure/decoration/vent{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "dLF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -4394,19 +4705,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"dLJ" = (
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/tunnel)
 "dLK" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"dLN" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/followers)
+"dLO" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/syringe/piercing,
-/obj/item/reagent_containers/syringe/piercing,
-/obj/item/reagent_containers/syringe/piercing,
+/obj/item/storage/part_replacer,
 /turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+	icon_state = "bluefull"
 	},
 /area/f13/tunnel)
 "dLP" = (
@@ -4414,13 +4728,6 @@
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
-/area/f13/bunker)
-"dMb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "dMj" = (
 /obj/structure/closet/cabinet,
@@ -4449,25 +4756,23 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
+"dMs" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "dML" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/potato,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
 	},
-/area/f13/tunnel)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "dMQ" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/hatchet,
-/obj/item/reagent_containers/glass/bottle/killer/weedkiller,
-/obj/item/reagent_containers/spray/plantbgone,
-/obj/item/plant_analyzer,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "dMW" = (
 /obj/structure/noticeboard{
 	desc = "A large, rusted plaque with a newly crafted nameplate listing the many Star Knight's that walk these halls and may make use of this office.";
@@ -4495,12 +4800,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
-"dNN" = (
-/obj/structure/girder/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/open/water,
-/area/f13/caves)
 "dOk" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -4521,21 +4820,16 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"dOI" = (
-/obj/machinery/photocopier,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"dOF" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/ash,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "dPx" = (
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/f13/tcoms)
-"dPM" = (
-/obj/structure/closet/crate/medical,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "dQc" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/remains/human,
@@ -4545,10 +4839,16 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"dQk" = (
-/obj/effect/decal/cleanable/blood/gibs/body,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
+"dQm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"dQn" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "dQA" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4558,15 +4858,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"dQD" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/frame,
-/obj/item/stack/cable_coil/cut/random,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+"dQV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
 	},
-/area/f13/bunker)
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "dRc" = (
 /obj/machinery/vending/wallmed,
 /turf/closed/wall/r_wall,
@@ -4581,6 +4879,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"dRw" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "dRA" = (
 /obj/machinery/shower{
 	dir = 4
@@ -4593,6 +4897,21 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
+"dRU" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/glass/beaker/plastic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "dRZ" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -4656,11 +4975,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"dSx" = (
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "dSN" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /obj/effect/decal/waste{
@@ -4681,12 +4995,11 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"dSW" = (
-/obj/structure/reagent_dispensers/barrel/old,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
+"dTm" = (
+/obj/structure/simple_door/wood,
+/obj/structure/barricade/wooden/planks,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "dTE" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor4-old"
@@ -4696,14 +5009,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"dTO" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "dTR" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -4727,19 +5032,25 @@
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"dUz" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
-"dUC" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/closed/wall/r_wall/rust,
+"dUq" = (
+/obj/structure/table/wood/fancy,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
+"dUu" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/storage/box/matches,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"dUC" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "dUW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -4815,15 +5126,17 @@
 	},
 /area/f13/tunnel)
 "dWi" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/tunnel)
-"dWJ" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/protectron/nsb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"dWp" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/wall/f13/ruins,
 /area/f13/bunker)
 "dWN" = (
 /obj/effect/decal/cleanable/dirt{
@@ -4856,6 +5169,14 @@
 "dXE" = (
 /turf/closed/wall/rust,
 /area/f13/caves)
+"dYh" = (
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"dYr" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "dYy" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -4863,23 +5184,33 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"dYA" = (
-/obj/item/paper/crumpled/bloody/docsdeathnote{
-	info = "DON'T MAKE OUR MISTAKE"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "dYV" = (
-/obj/structure/closet/crate/secure/loot,
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"dZc" = (
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "topcellghoul"
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bottomcellghoul"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"dZe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/folder/white,
+/obj/item/folder/white,
+/obj/item/folder/white,
+/obj/item/folder/white,
+/obj/item/flashlight/pen,
+/obj/item/flashlight/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dZE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4931,24 +5262,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
-"ebs" = (
-/obj/structure/barricade/sandbags,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/bunker)
-"ecf" = (
-/obj/structure/table,
-/obj/item/clothing/suit/apron/chef,
-/obj/item/clothing/head/chefhat,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
 "ecp" = (
 /obj/structure/table{
 	layer = 2.9
@@ -4969,13 +5282,14 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"ecZ" = (
+"ecX" = (
+/obj/structure/rack,
+/obj/item/ammo_box/a308,
+/obj/item/ammo_box/a308,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
+/obj/item/gun/ballistic/automatic/marksman/sniper,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "ede" = (
 /obj/machinery/shower{
 	pixel_y = 32
@@ -4987,11 +5301,30 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"edm" = (
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/flashlight/lantern,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "edB" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"edK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/wasteplant/wild_fungus,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"edM" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "edO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5004,10 +5337,14 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
-"eec" = (
-/obj/structure/frame/machine,
+"eev" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell/ammo/ec{
+	pixel_y = 7
+	},
+/obj/item/stock_parts/cell/ammo/ec,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "bluerustyfull"
 	},
 /area/f13/bunker)
 "eew" = (
@@ -5028,18 +5365,13 @@
 	},
 /area/f13/brotherhood/leisure)
 "eeG" = (
-/obj/machinery/door/airlock/hatch{
-	locked = 1
-	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "eeT" = (
-/obj/item/reagent_containers/syringe/piercing,
-/turf/closed/wall/r_wall/rust,
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "eeW" = (
 /obj/structure/table{
 	layer = 2.9
@@ -5053,54 +5385,44 @@
 	},
 /area/f13/brotherhood/leisure)
 "eeX" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
-"eeY" = (
-/obj/structure/closet/crate/large,
-/obj/item/multitool,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/structure/table/glass,
+/obj/item/storage/box/medsprays,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "bluerustysolid"
 	},
-/area/f13/bunker)
+/area/f13/followers)
 "efa" = (
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "efl" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
+"efX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "egg" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenfull"
-	},
-/area/f13/tunnel)
-"egP" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/warning,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "ehc" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"ehk" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
-	},
+"ehg" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"ehk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "ehz" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -5120,11 +5442,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
-"ehS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "ehT" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -5141,11 +5458,9 @@
 	},
 /area/f13/brotherhood/operations)
 "ehY" = (
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
-	},
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/handy/protectron/nsb,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "eiN" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -5186,21 +5501,41 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
-"ekE" = (
-/obj/machinery/light{
-	dir = 4
+"ekn" = (
+/obj/structure/sign/warning{
+	pixel_x = 6;
+	pixel_y = -3
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
+/obj/structure/decoration/warning{
+	pixel_x = -5;
+	pixel_y = 7
 	},
+/obj/structure/decoration/warning{
+	pixel_x = -3;
+	pixel_y = -5
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
+"ekx" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Oasis";
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "ekK" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greendirtysolid"
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"elg" = (
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "elU" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13{
@@ -5219,6 +5554,34 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"eml" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
+"emX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"enb" = (
+/obj/structure/rack,
+/obj/item/camera,
+/obj/item/camera_film,
+/obj/item/crafting/abraxo,
+/obj/item/crafting/sensor,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/radio,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "enl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -5229,29 +5592,29 @@
 	},
 /area/f13/brotherhood/medical)
 "eom" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/three_course_meal,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
+/obj/item/storage/trash_stack,
+/obj/structure/wreck/trash/two_tire,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "eoy" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
 "eoC" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
+/obj/effect/decal/waste{
+	icon_state = "goo8"
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
-"eoL" = (
-/mob/living/simple_animal/hostile/handy/protectron,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/one_barrel,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"eoX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = -6
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "epe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5264,33 +5627,27 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"eph" = (
-/obj/effect/decal/fakelattice,
-/obj/item/ammo_casing/shotgun/improvised,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "epH" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
-"epS" = (
-/obj/item/storage/trash_stack,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "epZ" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
+"eqb" = (
+/obj/structure/chair/stool/retro,
+/obj/item/instrument/guitar{
+	anchored = 1;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "eqi" = (
 /obj/effect/decal/cleanable/dirt{
@@ -5327,12 +5684,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"erD" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old"
+"erA" = (
+/obj/structure/dresser,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
+/area/f13/followers)
 "erF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/shower{
@@ -5342,24 +5699,22 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
-"esG" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
+"erJ" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
 	},
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenfull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"esM" = (
-/obj/item/storage/trash_stack,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
+"esC" = (
+/obj/structure/simple_door/metal/barred,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"esG" = (
+/obj/structure/rack,
+/turf/open/floor/plating/f13,
+/area/f13/followers)
 "esP" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -5371,10 +5726,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
-"eth" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "etN" = (
 /obj/structure/table/wood/poker,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
@@ -5388,19 +5739,18 @@
 /turf/open/floor/plating,
 /area/f13/brotherhood/reactor)
 "eug" = (
-/obj/structure/bed,
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"eui" = (
+/obj/structure/table/wood/poker,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/stage_br,
 /area/f13/tunnel)
-"eup" = (
-/obj/structure/closet/crate/freezer/blood/anchored,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
+"euP" = (
+/turf/closed/mineral/random/high_chance,
 /area/f13/bunker)
 "euS" = (
 /obj/effect/decal/cleanable/dirt{
@@ -5417,25 +5767,14 @@
 	},
 /area/f13/brotherhood/mining)
 "euY" = (
-/obj/structure/closet/wardrobe/white/medical,
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/area/f13/tunnel)
-"evP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash/large,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
-"evS" = (
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibtorso"
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
+"evD" = (
+/obj/structure/decoration/smokeold,
+/turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "exq" = (
 /obj/structure/closet,
@@ -5444,12 +5783,6 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/bunker)
-"exF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "exH" = (
 /obj/effect/decal/cleanable/dirt{
@@ -5473,6 +5806,11 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"exV" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "exY" = (
 /obj/structure/table/wood,
 /obj/item/pda,
@@ -5496,11 +5834,9 @@
 	},
 /area/f13/tunnel)
 "ezl" = (
-/obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
-	},
-/area/f13/tunnel)
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ezy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/f13/raidertreads,
@@ -5522,18 +5858,26 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"eAk" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
-	},
-/area/f13/tunnel)
-"eAm" = (
+"eAh" = (
+/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/prewar,
+/obj/item/stack/sheet/prewar,
+/obj/item/stack/sheet/prewar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"eAk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "eAw" = (
 /obj/structure/table,
@@ -5543,10 +5887,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"eAL" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/water,
-/area/f13/caves)
 "eAQ" = (
 /obj/structure/nest/scorpion,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5567,16 +5907,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"eBh" = (
-/obj/structure/reagent_dispensers/barrel/two,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"eBj" = (
-/obj/item/storage/trash_stack,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
+"eBn" = (
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/obj/item/book/granter/trait/trekking,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "eBK" = (
 /obj/machinery/shower{
@@ -5586,28 +5921,25 @@
 	icon_state = "dark"
 	},
 /area/f13/building)
+"eBP" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Oasis Housing";
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "eCr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/f13/tcoms)
-"eCx" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
-"eCA" = (
-/obj/effect/decal/waste,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "eCE" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/part_replacer,
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
-	},
-/area/f13/tunnel)
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "eCK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5692,17 +6024,6 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"eEE" = (
-/obj/structure/frame/computer{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "eEL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5747,6 +6068,10 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"eGX" = (
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "eHh" = (
 /turf/closed/indestructible/opshuttle{
 	icon = 'icons/turf/walls/reinforced_wall.dmi';
@@ -5783,12 +6108,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"eIo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "eIJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/deepfryer,
@@ -5797,16 +6116,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"eIS" = (
-/obj/structure/light_construct,
-/obj/structure/table,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/suit/armor/hos/trenchcoat,
-/obj/item/clothing/head/HoS/beret,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
 "eIU" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/subway,
@@ -5826,20 +6135,22 @@
 /obj/effect/landmark/start/f13/ncrveteranranger,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"eJq" = (
-/obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"eJU" = (
-/obj/structure/kitchenspike,
-/obj/effect/mob_spawn/human/corpse/raidermelee,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
-	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
+"eKx" = (
+/obj/machinery/workbench,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "eKT" = (
 /obj/structure/sign/poster/contraband/have_a_puff{
 	pixel_y = 32
@@ -5848,20 +6159,9 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"eLb" = (
-/obj/structure/light_construct,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
 "eLE" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
-"eLF" = (
-/obj/item/storage/trash_stack,
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "eLI" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -5905,6 +6205,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"eMW" = (
+/obj/structure/table/snooker{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "eMX" = (
 /obj/structure/table/greyscale,
 /obj/item/defibrillator/loaded,
@@ -5917,12 +6223,10 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"eOt" = (
+"eOs" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
 "eOx" = (
 /obj/structure/simple_door/blast{
 	max_integrity = 10000;
@@ -5940,6 +6244,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
+"eOL" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "eOW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -5955,19 +6269,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"ePe" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
-	},
-/area/f13/tunnel)
 "ePk" = (
-/obj/structure/light_construct,
-/obj/structure/bed,
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
-	},
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/handy/securitron/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "eQC" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -5981,11 +6286,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
-"eQZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "eRg" = (
 /obj/structure/falsewall/reinforced,
 /turf/open/floor/f13{
@@ -6018,10 +6318,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/tunnel)
-"eTb" = (
-/mob/living/simple_animal/hostile/handy/protectron/nsb,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "eTv" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -6049,18 +6345,21 @@
 	},
 /area/f13/clinic)
 "eUp" = (
-/obj/structure/timeddoor,
-/obj/structure/timeddoor,
-/turf/closed/wall/r_wall/rust,
+/obj/item/gun/ballistic/automatic/tribalbow{
+	desc = "A simple wooden bow with small pieces of turquiose. This one looks particularly blood-covered. Who the fuck brings a /BOW/ to a /BUNKER/"
+	},
+/obj/effect/mob_spawn/human/corpse,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"eUI" = (
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "eVi" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
-"eVp" = (
-/obj/structure/stacklifter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "eVA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -6070,6 +6369,18 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
+"eVL" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
+"eWp" = (
+/obj/item/clothing/head/helmet/f13/ncr/rangercombat/desert,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "eWN" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -6084,9 +6395,10 @@
 	},
 /area/f13/tunnel)
 "eWV" = (
-/obj/structure/timeddoor,
-/turf/closed/wall/r_wall/rust,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "eXJ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
@@ -6097,17 +6409,20 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
-"eXP" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "eXS" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"eYM" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "eZh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
@@ -6118,6 +6433,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"eZm" = (
+/turf/closed/indestructible/vaultdoor{
+	desc = "A wall made out of metal, really fucking tough metal. Someone built this waaaay in advance.";
+	name = "bunker wall"
+	},
+/area/f13/bunker)
 "eZN" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -6167,20 +6488,12 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "fbC" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/abomhorror/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
-"fbD" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "fbP" = (
 /obj/machinery/computer/security/wooden_tv{
 	network = list("BoS")
@@ -6190,18 +6503,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
-"fbT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"fdA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/chem_master/advanced,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
 "fdN" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/pepper{
@@ -6255,6 +6556,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"fel" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "shopladder"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "feo" = (
 /obj/machinery/telecomms/server/presets/medical,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -6273,12 +6581,26 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/surface)
+"feB" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "feM" = (
 /obj/effect/landmark/start/f13/offduty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"feN" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "prospector3open"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/tunnel)
 "feP" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib1-old"
@@ -6293,6 +6615,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"fff" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe/ammo,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "ffE" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -6300,35 +6627,18 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "ffJ" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/geiger_counter,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "fgy" = (
 /obj/machinery/vending/toyliberationstation,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
-"fgW" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibup1"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/bunker)
 "fhk" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -6342,18 +6652,6 @@
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"fjU" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibtorso"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/bunker)
 "fjW" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -6384,12 +6682,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"fkm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "fkn" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/mre,
@@ -6404,10 +6696,11 @@
 	},
 /area/f13/brotherhood/leisure)
 "fkv" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "platingdmg3"
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "fkz" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -6420,6 +6713,25 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"fkA" = (
+/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"fkE" = (
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
+"fkT" = (
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "fkZ" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/ranged,
@@ -6427,6 +6739,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"flc" = (
+/obj/machinery/door/window,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "flj" = (
 /obj/machinery/chem_master/advanced,
 /turf/open/indestructible/ground/inside/subway,
@@ -6438,11 +6757,9 @@
 	},
 /area/f13/clinic)
 "flP" = (
-/mob/living/simple_animal/pet/dog/eyebot,
-/turf/open/floor/plasteel/f13{
-	icon_state = "platingdmg2"
-	},
-/area/f13/tunnel)
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "flW" = (
 /obj/structure/simple_door/bunker{
 	name = "Gym/Kitchen"
@@ -6460,30 +6777,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "fmf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
-"fmj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/kitchenspike,
-/obj/effect/mob_spawn/human/corpse/raidermelee,
-/obj/effect/decal/cleanable/blood/splats,
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
-"fmB" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/indestructible/ground/inside/subway,
+/obj/item/paper,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "fmT" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -6523,6 +6819,15 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
+"fnQ" = (
+/obj/structure/junk/small/bed2,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "fnZ" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden,
@@ -6534,6 +6839,18 @@
 /obj/structure/flora/junglebush/c,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"fpl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/glasses/sunglasses{
+	anchored = 1;
+	pixel_y = 26
+	},
+/obj/item/clothing/head/fedora/det_hat{
+	anchored = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "fpv" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -6576,25 +6893,20 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"frc" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
 "frf" = (
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
 /area/f13/tunnel)
 "frh" = (
-/obj/structure/showcase/horrific_experiment,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper,
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "hate";
+	name = "Door Control"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "frm" = (
 /obj/structure/bed/mattress,
@@ -6614,12 +6926,46 @@
 "frS" = (
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
+"fsw" = (
+/obj/structure/table/glass,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/book/granter/trait/midsurgery,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "ftt" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"ftu" = (
+/obj/item/clothing/head/hardhat,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"ftz" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"ftD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "ftF" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -6638,11 +6984,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"ftV" = (
-/obj/machinery/vending/medical,
+"ftT" = (
+/obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "floorrusty"
 	},
+/area/f13/followers)
+"ftV" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/machinery/pdapainter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "fuc" = (
 /obj/structure/window/reinforced,
@@ -6655,20 +7008,10 @@
 	},
 /area/f13/brotherhood/operations)
 "fuE" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/geiger_counter,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "fuQ" = (
 /obj/structure/curtain,
 /obj/effect/turf_decal/loading_area/white,
@@ -6680,18 +7023,36 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"fuX" = (
-/obj/machinery/button/door{
-	id = "hell";
-	name = "Door Control"
-	},
-/obj/structure/table/reinforced,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "fvp" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
+/area/f13/tunnel)
+"fvL" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/pillbottles,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
+"fvM" = (
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"fvV" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowbottom"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
+"fwM" = (
+/obj/effect/decal/cleanable/generic,
+/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "fwX" = (
 /obj/machinery/computer/libraryconsole/bookmanagement{
@@ -6758,10 +7119,16 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "fxN" = (
-/mob/living/simple_animal/hostile/raider/ranged,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"fxS" = (
+/obj/structure/table,
+/obj/item/fusion_fuel,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "fze" = (
 /obj/item/flashlight/lamp{
@@ -6788,6 +7155,13 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
+"fzx" = (
+/obj/effect/landmark/start/f13/followersdoctor,
+/obj/structure/chair/stool/f13stool,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
 "fzR" = (
 /obj/structure/table{
 	pixel_y = 6
@@ -6804,23 +7178,13 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/offices1st)
-"fAl" = (
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
-"fAq" = (
-/turf/closed/indestructible/vaultdoor{
-	desc = "A wall made out of metal, really fucking tough metal. Someone built this waaaay in advance.";
-	name = "bunker wall"
-	},
-/area/f13/bunker)
 "fAs" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "platingdmg2"
+/mob/living/simple_animal/hostile/raider/thief,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
 	},
-/area/f13/tunnel)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "fAJ" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/spacevine{
@@ -6829,11 +7193,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fBi" = (
-/obj/effect/decal/cleanable/blood/old,
-/mob/living/simple_animal/hostile/raider/ranged,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "fBQ" = (
 /obj/structure/noticeboard{
@@ -6842,17 +7205,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
-"fBU" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "fCf" = (
 /obj/item/kirbyplants{
 	pixel_y = 14
@@ -6874,6 +7226,56 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"fCp" = (
+/obj/structure/rack,
+/obj/item/advanced_crafting_components/receiver,
+/obj/item/advanced_crafting_components/receiver,
+/obj/item/advanced_crafting_components/receiver,
+/obj/item/advanced_crafting_components/lenses,
+/obj/item/advanced_crafting_components/lenses,
+/obj/item/advanced_crafting_components/lenses,
+/obj/item/advanced_crafting_components/flux,
+/obj/item/advanced_crafting_components/flux,
+/obj/item/advanced_crafting_components/flux,
+/obj/item/advanced_crafting_components/conductors,
+/obj/item/advanced_crafting_components/conductors,
+/obj/item/advanced_crafting_components/conductors,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/alloys,
+/obj/item/advanced_crafting_components/alloys,
+/obj/item/advanced_crafting_components/alloys,
+/obj/item/advanced_crafting_components/alloys,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/conductors,
+/obj/item/advanced_crafting_components/flux,
+/obj/item/advanced_crafting_components/lenses,
+/obj/item/advanced_crafting_components/receiver,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"fDg" = (
+/obj/structure/closet/crate/miningcar,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"fDj" = (
+/obj/machinery/workbench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"fDn" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "house1ladder"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "fDp" = (
 /obj/machinery/libraryscanner{
 	desc = "This device scans books and other documents for entry into the Archives.";
@@ -6891,11 +7293,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"fDI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "fEs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet,
@@ -6908,12 +7305,9 @@
 	},
 /area/f13/brotherhood/operations)
 "fEB" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 9
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "fEJ" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -6923,6 +7317,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"fER" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/f13/bunker)
 "fET" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/effect/decal/cleanable/dirt,
@@ -6941,6 +7341,38 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"fFm" = (
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
+"fFn" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"fGA" = (
+/obj/structure/table,
+/obj/machinery/processor/chopping_block,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
 "fGO" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -6992,6 +7424,14 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
+"fJM" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
 "fJS" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/f13{
@@ -7012,14 +7452,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"fKi" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "fKm" = (
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/machinery/light{
@@ -7028,15 +7460,9 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "fKq" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 5
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"fKv" = (
-/turf/open/floor/plasteel/freezer,
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "fKP" = (
 /obj/structure/chair/wood{
@@ -7067,12 +7493,12 @@
 "fLU" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
-"fMg" = (
-/obj/effect/decal/cleanable/blood/gibs/old,
+"fMa" = (
+/obj/effect/landmark/start/f13/followersvolunteer,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "floorrusty"
 	},
-/area/f13/bunker)
+/area/f13/followers)
 "fME" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -7085,20 +7511,17 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
-"fNr" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/raider/firefighter,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+"fNk" = (
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"fNu" = (
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
-/turf/closed/wall/r_wall/rust,
+"fNr" = (
+/obj/structure/barricade/bars,
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "fNX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7108,12 +7531,33 @@
 /obj/machinery/door/window/northright,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/offices1st)
+"fOJ" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "fOZ" = (
 /obj/machinery/door/airlock/abandoned,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "fPj" = (
-/obj/structure/campfire/barrel,
+/obj/item/storage/trash_stack,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	name = "Repaired Turret";
+	scan_range = 9;
+	throw_range = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"fPn" = (
+/obj/effect/decal/remains/human,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -7126,12 +7570,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"fPB" = (
-/mob/living/simple_animal/hostile/raider/thief,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "fPJ" = (
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -7161,10 +7599,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"fRU" = (
-/mob/living/simple_animal/hostile/handy/protectron/nsb,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
+"fRt" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/tunnel)
 "fSe" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13{
@@ -7201,45 +7642,22 @@
 	},
 /area/f13/brotherhood/offices1st)
 "fTt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/machinery/light/broken{
+	dir = 8
 	},
-/area/f13/bunker)
-"fTA" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/machinery/door/poddoor{
-	id = "malice"
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
-"fTW" = (
-/obj/structure/table/wood,
-/obj/item/clothing/glasses/heat,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
+/mob/living/simple_animal/hostile/handy/protectron/nsb,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"fTB" = (
+/obj/item/instrument/piano_synth,
+/obj/structure/rack,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/tunnel)
 "fUZ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"fVn" = (
-/obj/structure/simple_door/bunker/glass,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/f13{
-	dir = 6;
-	icon_state = "redmark"
-	},
-/area/f13/bunker)
 "fVx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -7252,49 +7670,14 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
-"fWr" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"fWI" = (
-/obj/structure/closet/crate/large,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"fWY" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 10
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"fXa" = (
-/mob/living/simple_animal/hostile/raider/firefighter,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "fXm" = (
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/mob/living/simple_animal/hostile/raider/ranged/boss,
+/obj/structure/table/glass,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "bluerustysolid"
 	},
-/area/f13/bunker)
+/area/f13/followers)
 "fXr" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -7369,22 +7752,28 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "fZO" = (
-/obj/item/flashlight/flare,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
 	},
-/area/f13/bunker)
-"gaf" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/obj/item/gun/ballistic/revolver/m29/alt,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"gaa" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/landmark/start/f13/followersadministrator,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "bluerustysolid"
 	},
-/area/f13/bunker)
-"gbx" = (
-/obj/item/paper,
-/obj/item/paper/crumpled,
+/area/f13/followers)
+"gau" = (
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/area/f13/tunnel)
 "gbA" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Brig";
@@ -7404,10 +7793,10 @@
 	},
 /area/f13/clinic)
 "gbH" = (
-/obj/structure/timeddoor,
-/obj/structure/timeddoor,
-/turf/closed/wall/r_wall/rust,
-/area/f13/bunker)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gcb" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -7415,6 +7804,25 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"gcp" = (
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
+"gct" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"gcC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "gcD" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -7423,18 +7831,27 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
+"gcN" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"gdG" = (
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/followers)
 "gev" = (
-/turf/closed/wall,
-/area/f13/caves)
-"geL" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"gfb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/wreck/trash/one_barrel,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
 "gfz" = (
 /obj/structure/table{
@@ -7452,13 +7869,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"gfP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
+"gfS" = (
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
 	},
-/area/f13/bunker)
+/area/f13/tunnel)
 "ggm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
@@ -7469,6 +7884,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
+"ggp" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
 "ggq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker{
@@ -7535,12 +7958,16 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
-"giA" = (
-/turf/closed/wall/rust,
-/area/f13/bunker)
-"gjk" = (
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
+"giW" = (
+/obj/item/storage/trash_stack,
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
+"gjr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "gjB" = (
@@ -7594,6 +8021,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
+"gkk" = (
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/tunnel)
 "gkm" = (
 /mob/living/simple_animal/hostile/centaur,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -7629,16 +8064,29 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"glQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/supermart,
+/area/f13/tunnel)
 "gmv" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "gmL" = (
-/turf/closed/wall,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/protectron/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "gni" = (
-/turf/closed/mineral/random/high_chance,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"gnR" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "gnY" = (
 /obj/structure/toilet{
 	dir = 4
@@ -7668,6 +8116,27 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"goY" = (
+/mob/living/simple_animal/hostile/ghoul/wyomingghost{
+	desc = "A happily proud Enclave commander, mutated and boiled alive by the forced evolutionary virus. His armor looks to be sunken into his flesh.";
+	faction = list("wastebot");
+	health = 1500;
+	maxHealth = 1500;
+	name = "Commander Dirsk";
+	speak = list("For the Enclave!","Long live America!","Die, mutie!","AAAAAGGH!!","AUGUHGHHH!"));
+	speak_chance = 10;
+	speed = -1;
+	unarmed_attack_speed = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"gpf" = (
+/obj/structure/falsewall,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/tunnel)
 "gpl" = (
 /obj/structure/table{
 	layer = 2.9
@@ -7685,16 +8154,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"gpr" = (
-/obj/machinery/door/poddoor/preopen{
-	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70);
-	id = eairlock
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "bluemark"
-	},
-/area/f13/bunker)
 "gpM" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7712,6 +8171,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"gre" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "gse" = (
 /obj/machinery/shower{
 	dir = 8
@@ -7719,48 +8184,52 @@
 /obj/structure/decoration/vent,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/offices1st)
-"gsM" = (
-/obj/machinery/light/broken,
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
-	faction = list("raider");
-	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
-	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
-	name = "Repaired Turret";
-	scan_range = 9;
-	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
-	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
-	throw_range = 9
+"gsr" = (
+/obj/machinery/chem_master,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/chem_pile{
+	pixel_x = -12;
+	pixel_y = 10
+	},
+/obj/structure/sign/poster/prewar/poster92{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"gsQ" = (
-/obj/item/instrument/piano_synth,
-/obj/structure/rack,
-/turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
+"gsQ" = (
+/obj/item/storage/trash_stack,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"gsT" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/f13/bunker)
 "gta" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"gtH" = (
-/mob/living/simple_animal/hostile/raider/baseball,
+"gtO" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/obj/structure/sign/poster/contraband/punch_shit{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/area/f13/tunnel)
 "gtY" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"gua" = (
-/obj/structure/reagent_dispensers/barrel,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"gui" = (
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "gul" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices2nd)
@@ -7774,12 +8243,26 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
-"gvW" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
+"guL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
 	},
+/obj/item/paper/crumpled/bloody/ruins,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"gvB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/prewar/poster69{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"gvS" = (
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/followers)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -7798,24 +8281,22 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"gwD" = (
-/obj/structure/girder/reinforced,
-/turf/open/water,
-/area/f13/caves)
 "gwE" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"gxe" = (
-/obj/structure/reagent_dispensers/barrel/old,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "gxq" = (
-/obj/item/instrument/accordion,
-/obj/structure/rack,
-/turf/open/floor/plasteel/floorgrime,
+/obj/structure/fluff/paper/stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"gyd" = (
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bottomcellghoul"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "gyf" = (
 /obj/effect/decal/cleanable/oil/slippery,
@@ -7825,6 +8306,12 @@
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gyn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "gyp" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -7836,9 +8323,9 @@
 	},
 /area/f13/brotherhood/offices1st)
 "gyB" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/tunnel)
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gyS" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -7846,19 +8333,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gyZ" = (
-/obj/structure/table,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/machinery/light/small/broken{
-	dir = 4
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/tunnel)
+/obj/item/paper/crumpled,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gza" = (
-/obj/structure/falsewall,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper_bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gzs" = (
 /obj/structure/sink{
 	dir = 8;
@@ -7887,10 +8369,23 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"gzI" = (
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "gzK" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gAz" = (
+/obj/machinery/door/airlock/grunge,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gAN" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -7903,44 +8398,34 @@
 	},
 /area/f13/clinic)
 "gBq" = (
-/turf/closed/wall{
-	icon_state = "fwall_opening"
+/obj/machinery/workbench/advanced,
+/obj/item/storage/part_replacer,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
 	},
-/area/f13/tunnel)
+/area/f13/followers)
 "gCd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
-"gCz" = (
+"gDj" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
-"gEd" = (
+/turf/closed/wall/r_wall/rust,
+/area/f13/tunnel)
+"gED" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/waste{
-	icon_state = "goo10"
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
+/obj/structure/weightlifter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "gEZ" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
-"gFg" = (
-/turf/closed/wall/f13/ruins,
-/area/f13/caves)
 "gFu" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/tunnel)
+/obj/structure/stacklifter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gFv" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -7959,22 +8444,31 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "gFV" = (
-/obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/baseball,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gGa" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"gGS" = (
+"gGm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"gGr" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "gHh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -7991,11 +8485,6 @@
 	},
 /turf/closed/wall,
 /area/f13/tcoms)
-"gIH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/stacklifter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "gJa" = (
 /obj/effect/mine/stun,
 /turf/open/floor/f13{
@@ -8003,11 +8492,11 @@
 	},
 /area/f13/clinic)
 "gJz" = (
-/obj/item/paper_bin/bundlenatural,
-/obj/structure/rack,
-/obj/item/paper_bin/bundlenatural,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/tunnel)
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gKc" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -8015,10 +8504,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"gKv" = (
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "gKJ" = (
 /obj/effect/turf_decal/caution/stand_clear/white,
 /obj/effect/decal/cleanable/dirt,
@@ -8026,6 +8511,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
+"gLP" = (
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "gLS" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt{
@@ -8046,15 +8538,6 @@
 /obj/effect/spawner/lootdrop/f13/ncr_k_ration,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"gMS" = (
-/obj/effect/decal/waste{
-	icon_state = "goo10"
-	},
-/turf/closed/indestructible/fakedoor{
-	desc = "An indestructible door. Hm.";
-	name = "Strong Door"
-	},
-/area/f13/bunker)
 "gMX" = (
 /obj/effect/turf_decal/caution/stand_clear/white,
 /obj/effect/decal/cleanable/dirt,
@@ -8086,53 +8569,30 @@
 /obj/item/clothing/head/helmet/roman/fake,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"gNR" = (
-/obj/structure/junk/small/bed,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "gNZ" = (
-/obj/item/instrument/violin,
-/obj/structure/rack,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/tunnel)
-"gOB" = (
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/obj/effect/turf_decal/stripes/end,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/tunnel)
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gOG" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"gON" = (
-/obj/item/cultivator,
-/mob/living/simple_animal/hostile/handy/protectron/nsb,
+"gPe" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/ranged/legendary,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"gPe" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "radio";
-	level = 1
+"gPi" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/light/small/broken{
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/tunnel)
+/area/f13/followers)
 "gPJ" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden,
@@ -8145,23 +8605,23 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"gQz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "gQO" = (
 /obj/effect/mine/stun,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"gQV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 5
+"gRa" = (
+/mob/living/simple_animal/hostile/deathclaw/legendary{
+	speed = -1.5
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"gRa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/area/f13/caves)
 "gRq" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/breadslice/plain,
@@ -8186,6 +8646,13 @@
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"gSw" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "gSD" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -8224,20 +8691,20 @@
 	},
 /area/f13/brotherhood/rnd)
 "gSQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"gTa" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/closed/mineral/random/low_chance,
+/obj/machinery/button/door{
+	id = "okay";
+	name = "Door Control"
+	},
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "gTv" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_7"
+/obj/effect/decal/waste{
+	icon_state = "goo8"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "gTy" = (
 /obj/structure/noticeboard{
 	desc = "A large, rusted plaque with a newly crafted nameplate displaying the current Head Knight on duty.";
@@ -8258,24 +8725,23 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"gUj" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"gUm" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6"
-	},
-/turf/open/indestructible/ground/inside/mountain,
+"gUC" = (
+/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "gUF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/indestructible/f13/matrix,
 /area/f13/enclave)
+"gUI" = (
+/obj/structure/junk/small/bed2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "gVb" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -8290,20 +8756,26 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
+"gVN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
 "gVV" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "gWc" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/r_wall/rust,
-/area/f13/tunnel)
+/obj/item/storage/trash_stack,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "gWt" = (
-/turf/closed/wall/f13/wood/house,
-/area/f13/tunnel)
-"gWG" = (
-/turf/closed/wall/r_wall,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gWK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -8323,20 +8795,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
-"gXR" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/r_wall,
-/area/f13/tunnel)
-"gYE" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
+"gYA" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"gYR" = (
+/obj/structure/simple_door/bunker/glass,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/f13{
+	dir = 6;
+	icon_state = "redmark"
 	},
-/obj/structure/sign/poster/contraband/punch_shit{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "gYV" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -8354,14 +8824,11 @@
 	},
 /area/f13/brotherhood/operations)
 "gZF" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"gZL" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider/ranged,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
 "hac" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8374,14 +8841,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"hae" = (
-/obj/structure/closet/crate/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "han" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/machinery/light/small/broken{
@@ -8415,30 +8874,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"hba" = (
-/obj/structure/barricade/wooden/planks,
-/turf/closed/wall/f13/wood,
-/area/f13/sewer)
-"hbd" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell/ammo/ec{
-	pixel_y = 7
-	},
-/obj/item/stock_parts/cell/ammo/ec,
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
-	},
-/area/f13/bunker)
-"hbh" = (
-/obj/item/shard{
-	icon_state = "small";
-	pixel_x = -2;
-	pixel_y = -4
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "hbQ" = (
 /obj/structure/table/booth,
 /obj/item/flashlight,
@@ -8507,6 +8942,12 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"hdX" = (
+/turf/closed/indestructible/vaultdoor{
+	desc = "A wall made out of metal, really fucking tough metal. Someone built this waaaay in advance.";
+	name = "bunker wall"
+	},
+/area/f13/caves)
 "heg" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ghoul/reaver,
@@ -8515,13 +8956,14 @@
 	},
 /area/f13/tunnel)
 "hev" = (
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "topcellghoul"
+/obj/structure/simple_door/metal/ventilation,
+/obj/machinery/door/poddoor{
+	id = "pain"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "heI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -8529,34 +8971,36 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"heR" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/stage_tl,
-/area/f13/tunnel)
 "hfb" = (
-/obj/structure/chair/stool,
-/obj/machinery/button/door{
-	id = "bottomcellghoul";
-	name = "Bottom cell shutters";
-	pixel_x = -6;
-	pixel_y = 32
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/obj/machinery/button/door{
-	id = "topcellghoul";
-	name = "Top cell shutters";
-	pixel_x = 6;
-	pixel_y = 32
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/tunnel)
+/area/f13/followers)
 "hfr" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"hfW" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"hgw" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "hgy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -8570,28 +9014,24 @@
 	icon_state = "supermart0"
 	},
 /area/f13/tcoms)
-"hgP" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/tunnel)
-"hhc" = (
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
+"hgD" = (
+/obj/structure/barricade/wooden,
+/obj/structure/curtain{
+	color = "#845f58"
 	},
-/area/f13/bunker)
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "hhe" = (
-/obj/machinery/jukebox,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/stage_tr,
-/area/f13/tunnel)
+/obj/item/paper,
+/obj/item/paper/crumpled,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hhi" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/corner,
+/obj/item/paper_bin/bundlenatural,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hhn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -8599,14 +9039,19 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"hhr" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/followers)
 "hhC" = (
 /obj/item/trash/f13/dog,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"hhI" = (
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "hhQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -8621,6 +9066,20 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"hia" = (
+/mob/living/simple_animal/hostile/enclave/soldier{
+	desc = "A former Enclave soldier, mutated by the forced evolutionary virus and grafted to the interior of his suit.";
+	extra_projectiles = 1;
+	faction = list("wastebot");
+	loot = null;
+	name = "mutated enclave soldier";
+	speak = list("AUUGHGHHH!");
+	speak_emote = list("shouts")
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "hil" = (
 /obj/structure/table/wood/settler,
 /obj/structure/reagent_dispensers/beerkeg,
@@ -8636,6 +9095,20 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"hjL" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
+"hkf" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "hkh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/weightmachine/stacklifter,
@@ -8643,26 +9116,29 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"hkm" = (
+/obj/structure/table,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/clothing/head/chefhat,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "hkn" = (
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"hky" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "hkD" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/tunnel)
-"hlb" = (
-/obj/machinery/workbench,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"hlu" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "hlS" = (
 /obj/structure/chair/left{
 	dir = 8
@@ -8699,6 +9175,11 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"hmZ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/robobrain/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hng" = (
 /obj/structure/bookcase/random/religion,
 /obj/effect/decal/cleanable/dirt,
@@ -8713,11 +9194,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"hoc" = (
-/obj/machinery/light/broken,
-/obj/item/ammo_casing/shotgun/improvised,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "hog" = (
 /obj/item/bedsheet/red,
 /obj/structure/bed/pod,
@@ -8737,13 +9213,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
-"hor" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	pixel_x = -6
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
 "hoH" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/f13/wood,
@@ -8765,9 +9234,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "hpe" = (
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paperplane/origami,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hpp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -8796,23 +9266,39 @@
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
+"hqc" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "mine"
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/caves)
 "hqg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/item/paper/crumpled,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hqt" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/snacks/soylentgreen,
 /obj/item/reagent_containers/food/snacks/soylentgreen,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"hqw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
+"hqB" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "radio";
+	level = 1
+	},
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/tunnel)
 "hqC" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -8857,6 +9343,22 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"hsj" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/shard{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "hsv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -8872,9 +9374,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "hsH" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
+"hsK" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/mob/living/simple_animal/hostile/raider/biker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hsL" = (
 /obj/structure/chair{
 	dir = 4
@@ -8908,28 +9418,6 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"hsY" = (
-/mob/living/simple_animal/hostile/enclave/soldier{
-	aggro_vision_range = 15;
-	armour_penetration = 1;
-	desc = "What visibly appears to be a proud Enclave soldier clad in armor is in actuality a grotesque, FEV-exposed mutant grafted to the interior of his suit, never able to leave. You've gotten a lot farther than you should have...";
-	extra_projectiles = 10;
-	faction = list("wastebot");
-	health = 3000;
-	loot = list(/obj/item/keycard/library);
-	maxHealth = 3000;
-	melee_damage_lower = 100;
-	melee_damage_upper = 100;
-	melee_queue_distance = 10;
-	name = "Captain Arlem";
-	speak = list("Die... mutie!","AAAAUHGHHHH!","DIE!","Perish!","FOR THE ENCLAVE!");
-	speak_chance = 10;
-	speak_emote = list("shouts");
-	speed = -1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "huS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -8938,10 +9426,22 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/f13/tcoms)
+"hvr" = (
+/obj/structure/light_construct,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenfull"
+	},
+/area/f13/tunnel)
 "hvw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/rock,
-/area/f13/caves)
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"hxz" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/followers)
 "hxB" = (
 /obj/structure/table{
 	layer = 2.9
@@ -8957,39 +9457,33 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"hxM" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/inside/mountain,
+"hxP" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall,
 /area/f13/tunnel)
-"hyd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"hyj" = (
-/obj/item/wirecutters/basic,
-/obj/item/screwdriver/crude,
-/obj/structure/table/wood,
-/obj/item/storage/box/handcuffs,
-/obj/item/lock_construct,
-/obj/item/key,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+"hxS" = (
+/obj/structure/table/reinforced,
+/obj/item/folder{
+	pixel_x = -4
 	},
-/obj/item/stack/f13Cash/random/med,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"hyn" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/recharger,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
+"hyj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/blackbox_recorder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hyH" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"hyV" = (
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "hzg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -9003,6 +9497,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"hzG" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "hzV" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 1;
@@ -9018,10 +9520,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/sewer)
-"hAT" = (
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "hBz" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/cable{
@@ -9051,6 +9549,19 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"hBU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"hCb" = (
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hCS" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -9059,10 +9570,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"hCT" = (
-/obj/item/ammo_casing/shotgun/improvised,
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
 "hDw" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
@@ -9071,23 +9578,35 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building)
-"hDP" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/securitron/nsb,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "hDX" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "hEp" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/destructible/tribal_torch/lit,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"hEH" = (
+/obj/item/crowbar,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"hEM" = (
+/obj/structure/table/optable,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"hEv" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
+"hEW" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	name = "microwave"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "hFm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -9122,11 +9641,11 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
-"hGW" = (
+"hGY" = (
+/obj/structure/chair/booth,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/area/f13/tunnel)
 "hHc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/f13foldupchair,
@@ -9136,6 +9655,15 @@
 /obj/item/trash/f13/cram_large,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"hHz" = (
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/followers)
 "hHI" = (
 /obj/structure/closet{
 	storage_capacity = 10
@@ -9154,21 +9682,21 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"hIq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
+"hIo" = (
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"hIq" = (
+/obj/structure/decoration/clock,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "hIy" = (
-/obj/structure/guncase,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/ballistic/shotgun/trench,
-/obj/item/gun/ballistic/shotgun/trench,
-/obj/item/gun/ballistic/shotgun/trench,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/effect/decal/remains/robot,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hJk" = (
 /obj/structure/lattice{
 	layer = 3
@@ -9178,18 +9706,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"hJs" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6";
-	pixel_x = -28
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "hJV" = (
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"hJZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "hKm" = (
 /obj/structure/rack,
@@ -9212,13 +9739,11 @@
 	},
 /area/f13/brotherhood/medical)
 "hKG" = (
-/obj/structure/rack,
-/obj/item/ammo_box/a308,
-/obj/item/ammo_box/a308,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/gun/ballistic/automatic/marksman/sniper,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hKI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -9230,20 +9755,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
-"hKR" = (
-/obj/structure/wreck/trash/five_tires,
-/obj/effect/decal/cleanable/dirt/dust,
+"hLd" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/machinery/door/poddoor{
+	id = "okay"
+	},
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
-"hLd" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"hLh" = (
-/obj/structure/window/reinforced/spawner/east,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "hLo" = (
@@ -9257,10 +9775,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"hLw" = (
-/mob/living/simple_animal/hostile/raider/biker,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
+"hLJ" = (
+/obj/structure/chair/booth,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/pinup_couch{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "hLS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/sign{
@@ -9271,12 +9793,31 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"hMo" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/bunker)
+"hMw" = (
+/obj/machinery/defibrillator_mount,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "hMJ" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"hMQ" = (
+/turf/closed/indestructible/fakedoor{
+	desc = "An indestructible door. Hm.";
+	name = "Strong Door"
+	},
+/area/f13/bunker)
 "hMU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9294,13 +9835,11 @@
 	},
 /area/f13/brotherhood/medical)
 "hNq" = (
-/obj/structure/simple_door/metal/barred,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "topcellghoul"
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
 	},
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "hNS" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -9313,32 +9852,42 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"hOj" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/spacevine{
-	name = "vines"
+"hNX" = (
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
 	},
-/turf/open/water,
-/area/f13/caves)
-"hOR" = (
-/turf/open/floor/wood/f13/stage_bl,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
+"hOz" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hOT" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"hPk" = (
-/obj/structure/junk/small/bed,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "hPn" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
+"hPu" = (
+/obj/machinery/jukebox,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/stage_tr,
+/area/f13/tunnel)
 "hPD" = (
 /obj/machinery/chem_master/advanced,
 /obj/effect/decal/cleanable/dirt,
@@ -9377,6 +9926,12 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"hQs" = (
+/obj/item/paper_bin/bundlenatural,
+/obj/structure/rack,
+/obj/item/paper_bin/bundlenatural,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/tunnel)
 "hQt" = (
 /obj/structure/sink/kitchen{
 	desc = "Strictly for filling up mop buckets.";
@@ -9394,14 +9949,20 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
 "hQG" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/wood/f13/stage_b,
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "hQR" = (
 /mob/living/simple_animal/hostile/giantantqueen,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"hQW" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder/constructed,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "hRy" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -9412,10 +9973,12 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"hRA" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+"hSe" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/followers)
 "hSU" = (
 /obj/structure/decoration/vent{
 	layer = 2
@@ -9475,6 +10038,12 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"hTX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "hUn" = (
 /obj/structure/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt,
@@ -9482,6 +10051,14 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"hUA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
 "hUV" = (
 /obj/machinery/chem_dispenser,
 /obj/effect/decal/cleanable/dirt,
@@ -9493,6 +10070,14 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"hVa" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
 "hVk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9524,13 +10109,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"hWB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor{
-	id = "pain"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "hWJ" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -9539,16 +10117,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "hWZ" = (
-/obj/structure/table/wood/poker,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/stage_br,
-/area/f13/tunnel)
-"hXB" = (
-/obj/item/fishingrod,
-/mob/living/simple_animal/hostile/raider/thief,
-/turf/open/water,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"hXQ" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/followers)
 "hYh" = (
 /obj/structure/chair/sofa/corp/right,
 /obj/effect/decal/cleanable/dirt{
@@ -9557,10 +10137,15 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "hYr" = (
-/obj/structure/simple_door/metal/barred,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/stacklifter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
+"hYE" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hYS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -9584,17 +10169,8 @@
 	},
 /area/f13/brotherhood/rnd)
 "ias" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"iau" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib5-old"
-	},
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/subway,
+/obj/structure/decoration/rag,
+/turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "iav" = (
 /obj/structure/table{
@@ -9609,13 +10185,10 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"iaz" = (
-/obj/structure/chair/f13chair2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
+"iaO" = (
+/obj/structure/simple_door/fakeglass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "iaS" = (
 /obj/machinery/light/small{
@@ -9626,23 +10199,6 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"ibo" = (
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibup1"
-	},
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
-	faction = list("raider");
-	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
-	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
-	name = "Repaired Turret";
-	scan_range = 9;
-	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
-	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
-	throw_range = 9
-	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
 "ibr" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
@@ -9650,29 +10206,21 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"ibv" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
+"ibB" = (
+/obj/structure/chair/wood/modern{
+	dir = 8;
+	icon_state = "wooden_chair_old"
 	},
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "icd" = (
 /obj/item/pickaxe/drill,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "icj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/barred,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"icB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/wreck/trash/one_barrel,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
+/obj/item/wallframe/camera,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "icI" = (
 /obj/structure/table{
@@ -9686,13 +10234,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood/offices1st)
-"icW" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/assaultron,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "ide" = (
 /obj/structure/chair/sofa/corp/corner,
 /obj/effect/decal/cleanable/dirt{
@@ -9700,19 +10241,20 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"idi" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "idK" = (
 /obj/structure/barricade/wooden,
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"ieG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/obj/item/paper/crumpled/bloody/ruins,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+"ieE" = (
+/obj/structure/chair/stool,
+/turf/open/floor/wood/f13/stage_t,
+/area/f13/tunnel)
 "ife" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/clothing_high,
@@ -9720,20 +10262,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"iff" = (
-/obj/machinery/door/keycard{
-	puzzle_id = "library"
+"ifD" = (
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/bunker)
-"ifn" = (
-/obj/item/storage/trash_stack,
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "ifR" = (
 /obj/structure/table{
@@ -9747,14 +10280,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood/offices1st)
-"ifT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "ifW" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -9777,6 +10302,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"ige" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "igo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table{
@@ -9807,25 +10339,22 @@
 /obj/item/flashlight/flare/torch,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"igG" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/decal/fakelattice,
-/obj/machinery/light/small{
-	dir = 4
+"igD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/chem_master/advanced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
 	},
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "igH" = (
-/obj/structure/guncase,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/light/broken{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "igL" = (
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/f13/wood,
@@ -9843,18 +10372,11 @@
 	},
 /area/f13/brotherhood/operations)
 "ihg" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "iiu" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -9879,32 +10401,9 @@
 	},
 /turf/open/floor/plating,
 /area/f13/tcoms)
-"ijb" = (
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibtorso"
-	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
-"ijq" = (
+"ikv" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"ijP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/corpse,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"ikD" = (
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "topcellghoul"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bottomcellghoul"
-	},
-/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ikI" = (
@@ -9915,12 +10414,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"ikX" = (
-/obj/structure/light_construct,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenfull"
-	},
-/area/f13/tunnel)
 "ilb" = (
 /obj/structure/decoration/vent{
 	pixel_x = 16;
@@ -9938,6 +10431,16 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"ili" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old";
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "ill" = (
 /obj/structure/sign/poster/prewar/poster92,
 /turf/closed/wall/r_wall,
@@ -9964,19 +10467,12 @@
 /obj/item/circular_saw,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"ime" = (
-/mob/living/simple_animal/hostile/deathclaw/legendary{
-	speed = -1.5
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "imj" = (
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "topcellghoul"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "imo" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider,
@@ -9984,32 +10480,18 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"imY" = (
-/obj/structure/junk/small/bed,
-/obj/effect/decal/fakelattice,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "inU" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"ioj" = (
-/obj/item/trash/f13/yumyum,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
+"iot" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibtorso"
-	},
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "iox" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -10018,10 +10500,9 @@
 	},
 /area/f13/bunker)
 "ioO" = (
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "ioQ" = (
 /obj/effect/turf_decal/arrows/white,
 /obj/effect/decal/cleanable/dirt,
@@ -10032,13 +10513,24 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"ioV" = (
-/obj/item/storage/trash_stack,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
+"ioR" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
+"ioZ" = (
+/obj/structure/closet/wardrobe/white/medical,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
 	},
-/area/f13/bunker)
+/area/f13/tunnel)
 "ipv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/kitchenspike_frame{
@@ -10051,18 +10543,20 @@
 	},
 /area/f13/brotherhood/offices1st)
 "ipw" = (
-/obj/structure/barricade/bars,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"ipx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/securitron/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/area/f13/bunker)
+"iqa" = (
+/obj/structure/closet/crate/large,
+/obj/item/multitool,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "iqE" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -10097,6 +10591,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"irf" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "irB" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
@@ -10104,16 +10604,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
-	},
-/area/f13/bunker)
-"irY" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/fakelattice,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "ise" = (
@@ -10127,6 +10617,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/brotherhood/operations)
+"isw" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/mutagen,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/granter/trait/pa_wear,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/f13/bunker)
 "isG" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -10144,21 +10643,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
-"isI" = (
-/obj/structure/closet/crate{
-	anchored = 1;
-	can_be_unanchored = 1
-	},
-/obj/item/gun/ballistic/automatic/m1garand/oldglory{
-	desc = "Arguably the most patriotic garand in existence, flag and well-known satisfying ping included, all the while hitting like a truck";
-	name = "M1 Garand"
-	},
-/obj/item/clothing/suit/armor/f13/battlecoat,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/caves)
 "isJ" = (
 /obj/machinery/shower{
 	layer = 2.8;
@@ -10170,6 +10654,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"isT" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "isU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10181,13 +10673,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"itz" = (
-/obj/item/fusion_fuel,
-/obj/item/fusion_fuel,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/clinic)
 "itI" = (
 /obj/structure/table{
 	layer = 2.9
@@ -10205,22 +10690,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood/offices1st)
-"itL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
-	faction = list("raider");
-	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
-	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
-	name = "Repaired Turret";
-	scan_range = 9;
-	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
-	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
-	throw_range = 9
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "itP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -10247,16 +10716,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
-"iuU" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "iuX" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -10285,9 +10744,32 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"ivm" = (
+"ivl" = (
+/obj/structure/table/wood,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/workbench/forge,
+/obj/item/stack/f13Cash/random/med,
+/obj/item/megaphone,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"ivm" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"ivV" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/item/stack/sheet/hay/fifty,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "iwu" = (
@@ -10295,35 +10777,17 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"iwx" = (
-/obj/structure/rack,
+"ixu" = (
+/obj/structure/barricade/wooden/planks,
+/turf/closed/wall/f13/wood,
+/area/f13/sewer)
+"ixO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/prewar,
-/obj/item/stack/sheet/prewar,
-/obj/item/stack/sheet/prewar,
+/obj/structure/sign/poster/contraband/smoke{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"iwL" = (
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/structure/closet/crate/miningcar,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"ixU" = (
-/obj/machinery/door/poddoor{
-	id = "soup"
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/caves)
 "ixX" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /obj/effect/decal/cleanable/dirt,
@@ -10331,6 +10795,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"iym" = (
+/obj/structure/reagent_dispensers/barrel/three{
+	pixel_x = -14
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/caves)
 "iyJ" = (
 /obj/structure/table/wood/fancy/blackred,
 /turf/open/floor/mineral/plastitanium/airless,
@@ -10347,6 +10817,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"izY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/caves)
 "iAm" = (
 /turf/open/floor/mineral/plastitanium,
 /area/f13/brotherhood/rnd)
@@ -10385,51 +10859,75 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/enclave)
+"iBw" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "iCS" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "iDt" = (
-/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"iDv" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
+"iDI" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/ammobox/beanbag,
+/obj/item/storage/fancy/ammobox/beanbag,
+/obj/item/storage/fancy/ammobox/beanbag,
+/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/storage/fancy/ammobox/lethalshot,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "iDP" = (
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/brotherhood/reactor)
+"iEl" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
 "iER" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/plastic/fifty,
-/obj/item/stack/sheet/plastic/fifty,
-/obj/item/stack/sheet/plastic/fifty,
-/obj/item/stack/sheet/plastic/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"iFe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/inside/subway,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
+"iFC" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/tunnel)
+"iFF" = (
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
 "iFL" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"iGR" = (
-/obj/item/chair,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "iGY" = (
 /obj/item/storage/firstaid/regular{
 	pixel_y = 5
@@ -10453,17 +10951,34 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "iHB" = (
-/obj/machinery/autolathe/ammo/unlocked,
-/obj/item/book/granter/crafting_recipe/gunsmith_two,
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
-/obj/item/book/granter/crafting_recipe/gunsmith_one,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
 "iIu" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
 /area/f13/sewer)
+"iIw" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"iID" = (
+/obj/structure/table/glass,
+/obj/machinery/computer/terminal{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/followers)
 "iIQ" = (
 /obj/item/card/id/dogtag{
 	desc = "Never thirsty is the grave of the fallen Brother, for their kin floods the ground with the blood of the blind.";
@@ -10504,11 +11019,11 @@
 	},
 /area/f13/brotherhood/rnd)
 "iKB" = (
-/obj/structure/barricade/bars{
-	layer = 5
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/area/f13/bunker)
 "iKI" = (
 /obj/structure/mirror,
 /turf/closed/wall/rust,
@@ -10543,14 +11058,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
-"iMh" = (
-/obj/effect/decal/cleanable/glass,
-/mob/living/simple_animal/hostile/handy/assaultron,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/bunker)
 "iMs" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/outside/ruins,
@@ -10575,14 +11082,12 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "iNY" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	desc = "There is something on the wind. It.. it smells like... crime.";
-	name = "Detective Office";
-	req_one_access_txt = "4"
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/area/f13/bunker)
 "iOr" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10602,53 +11107,29 @@
 /obj/structure/mirror,
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
-"iPs" = (
-/obj/structure/guncase,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+"iPr" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "iPu" = (
 /obj/machinery/defibrillator_mount/loaded,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
 "iPH" = (
-/obj/structure/rack,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/storage/box/citizenship_permits,
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/machinery/door/poddoor{
+	id = "pain"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"iPO" = (
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "iQt" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -10658,26 +11139,20 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"iQC" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "iRc" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"iRA" = (
-/obj/structure/fluff/oldturret,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/bunker)
 "iRE" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "iRU" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -10728,38 +11203,28 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"iSV" = (
-/obj/effect/decal/fakelattice,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "iTb" = (
 /obj/structure/mopbucket,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"iTk" = (
-/obj/structure/fluff/oldturret,
-/turf/open/floor/f13{
-	dir = 6;
-	icon_state = "bluemark"
-	},
-/area/f13/bunker)
 "iTJ" = (
 /obj/structure/spider/stickyweb,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"iUj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 5
+	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "iUq" = (
 /obj/structure/decoration/vent,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
-"iVc" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "iVi" = (
 /obj/structure/table,
 /obj/item/roller,
@@ -10783,6 +11248,13 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
+"iVM" = (
+/obj/structure/junk/small/bed,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "iWa" = (
 /obj/structure/table/wood/bar,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
@@ -10824,6 +11296,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"iWh" = (
+/obj/structure/curtain,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/tunnel)
+"iWo" = (
+/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/detective,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "iWz" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -10832,18 +11316,22 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "iWE" = (
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bottomcellghoul"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/f13/supermart,
+/area/f13/followers)
+"iWF" = (
+/obj/structure/rack,
+/obj/item/twohanded/sledgehammer,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/caves)
 "iWH" = (
-/obj/structure/sign/poster/ripped{
-	pixel_x = 32
-	},
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "iWR" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -10881,6 +11369,18 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"iXQ" = (
+/obj/structure/timeddoor,
+/turf/closed/wall/r_wall/rust,
+/area/f13/caves)
+"iYa" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/tunnel)
 "iYk" = (
 /obj/structure/table,
 /obj/item/phone,
@@ -10888,13 +11388,17 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"iYF" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+"iYt" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"iYF" = (
+/obj/machinery/autolathe/ammo,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "iYI" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -10913,12 +11417,16 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"iZl" = (
+"iZg" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
+/obj/machinery/light/fo13colored/Aqua{
+	bulb_colour = "#800080";
+	dir = 8;
+	light_color = "#800080";
+	name = "light fixture"
 	},
-/area/f13/bunker)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "iZB" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -10942,12 +11450,23 @@
 /obj/structure/destructible/clockwork/wall_gear,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/mining)
-"jak" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"iZZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"jak" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw/mother{
+	speed = -1.5
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"jaY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/caves)
 "jbA" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
@@ -10966,16 +11485,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
-"jbU" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/gutsy/nsb,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "jcf" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/water,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/caves)
+"jcj" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jcl" = (
 /obj/structure/lattice{
@@ -10989,78 +11505,72 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"jcB" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
-"jdH" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "jdP" = (
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 1;
-	name = "light fixture"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"jec" = (
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "topcellghoul"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jej" = (
-/obj/structure/chair/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/detective,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"jel" = (
-/mob/living/simple_animal/hostile/stalkeryoung,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "jeo" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"jew" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/handy/securitron/nsb,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
+"jeE" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
-"jeE" = (
-/obj/structure/closet/cabinet,
-/obj/item/taperecorder,
-/obj/item/tape,
-/obj/item/tape,
-/obj/item/tape,
-/obj/item/storage/briefcase,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "jeM" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/wood/house,
-/area/f13/tunnel)
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "jfx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
-"jfS" = (
+"jfP" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"jfS" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "jfU" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
@@ -11101,6 +11611,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
+"jgr" = (
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
 "jgL" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -11111,20 +11627,8 @@
 	},
 /area/f13/brotherhood/rnd)
 "jgP" = (
-/obj/structure/simple_door/metal/barred,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bottomcellghoul"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bottomcellghoul"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"jgR" = (
-/mob/living/simple_animal/hostile/raider/thief,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old"
-	},
+/obj/machinery/light/broken,
+/obj/item/ammo_casing/shotgun/improvised,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "jhN" = (
@@ -11155,50 +11659,39 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "jiL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
+/obj/effect/landmark/map_load_mark/dungeons/northsewer,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
+"jkb" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"jkb" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "jkp" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/sewer)
-"jkJ" = (
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/structure/table,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
+"jlb" = (
+/obj/machinery/chem_master,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "jll" = (
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/plasteel/vault/telecomms/mainframe{
 	dir = 8
 	},
 /area/f13/tcoms)
-"jlp" = (
-/obj/machinery/light/small{
-	dir = 1
+"jlt" = (
+/obj/machinery/door/poddoor{
+	id = "pain"
 	},
-/obj/machinery/space_heater,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jlC" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -11209,13 +11702,29 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"jlI" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jmA" = (
-/obj/structure/bed/mattress,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor{
+	id = "pain"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "jmN" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
+"jno" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "jnI" = (
 /obj/structure/table{
 	layer = 2.9
@@ -11227,14 +11736,13 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"jok" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
+"jnW" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_x = -3
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/tunnel)
+/turf/open/floor/plasteel/freezer,
+/area/f13/followers)
 "jpg" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -11242,25 +11750,12 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"jqg" = (
-/mob/living/simple_animal/hostile/handy/assaultron,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
 "jqx" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/tunnel)
-"jqX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/smoke{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jrk" = (
 /obj/structure/chair/sofa/corp{
@@ -11272,60 +11767,31 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "jrm" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/structure/decoration/warning,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "jrn" = (
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
 "jro" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
 "jrA" = (
 /obj/machinery/door/window/eastright,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "jrV" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/machinery/button/door{
+	id = "soup";
+	name = "Door Control"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/caves)
 "jsD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11351,23 +11817,28 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"jtY" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "jug" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"juj" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
+"juo" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "juq" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -11378,33 +11849,14 @@
 	},
 /area/f13/brotherhood/medical)
 "juP" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/ore/blackpowder/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "juU" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -11414,53 +11866,50 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"jvJ" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/plasteel/freezer,
+"jvg" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
 /area/f13/bunker)
-"jwh" = (
+"jvp" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
+"jwm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/item/book/granter/trait/trekking,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"jwp" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/structure/girder/reinforced,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"jwm" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "shopladder"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"jwp" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	max_integrity = 500;
-	name = "Store Backroom";
-	req_one_access_txt = "34"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"jwv" = (
-/obj/structure/frame/machine,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
 "jwA" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"jwF" = (
-/obj/structure/reagent_dispensers/barrel/three,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "jwN" = (
 /obj/machinery/rnd/production/protolathe,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
+"jxG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "soup";
+	name = "Door Control"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jyc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice{
@@ -11480,6 +11929,14 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"jyF" = (
+/obj/machinery/light/fo13colored/Pink{
+	name = "light tube"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "jyZ" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -11523,42 +11980,26 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"jAL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/raider/biker,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/bunker)
 "jAZ" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"jBe" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"jBv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	desc = "A lighting fixture.";
-	dir = 1;
-	light_color = "#008000";
-	name = "light tube"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "jBU" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"jBX" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "jCU" = (
 /obj/structure/lattice{
 	layer = 3
@@ -11568,22 +12009,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"jDW" = (
-/obj/structure/closet/wardrobe/chemistry_white,
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
+"jCW" = (
+/obj/machinery/light/small{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"jEg" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
-"jEt" = (
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
 "jFd" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -11610,39 +12042,29 @@
 	},
 /area/f13/brotherhood/leisure)
 "jFx" = (
-/obj/structure/girder/reinforced,
-/turf/closed/wall/r_wall/rust,
-/area/f13/tunnel)
-"jFB" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jFC" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"jGd" = (
-/obj/structure/kitchenspike,
-/obj/effect/mob_spawn/human/corpse/raidermelee,
-/obj/effect/decal/cleanable/blood/splats,
-/turf/open/floor/plasteel/freezer,
+"jFU" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"jGy" = (
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+"jGt" = (
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "jGQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -11653,18 +12075,29 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/reactor)
-"jHN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
+"jHk" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/tunnel)
-"jHU" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/sentrybot/nsb/riot,
+"jHN" = (
+/obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"jIi" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "jIm" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -11675,6 +12108,13 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/medical)
+"jJb" = (
+/obj/structure/reagent_dispensers/barrel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "jJd" = (
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white/bos,
@@ -11688,14 +12128,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
-"jJA" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "jJB" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/black,
@@ -11706,21 +12138,11 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
-"jJO" = (
-/obj/machinery/hydroponics/constructable,
+"jJT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"jJT" = (
-/obj/structure/table/wood,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/f13Cash/random/med,
-/obj/item/megaphone,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "jJV" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/f13{
@@ -11741,45 +12163,13 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
-"jKq" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"jKx" = (
-/obj/item/shard{
-	icon_state = "medium";
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"jKY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/money_stack,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"jLI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate{
-	anchored = 1;
-	can_be_unanchored = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/item/reagent_containers/food/snacks/f13/deathclawomelette,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"jKu" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"jKM" = (
+/mob/living/simple_animal/hostile/raider/biker,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "jLX" = (
 /obj/effect/spawner/lootdrop/f13/advcrafting,
@@ -11812,6 +12202,10 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"jMN" = (
+/obj/structure/reagent_dispensers/barrel,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "jMR" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -11827,13 +12221,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"jNe" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/tunnel)
 "jNr" = (
 /obj/item/flag/bos,
 /turf/open/floor/circuit/f13_red,
@@ -11853,14 +12240,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "jOe" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	max_integrity = 500;
-	name = "Store Bedroom";
-	req_one_access_txt = "34"
+/mob/living/simple_animal/hostile/raider/tribal,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jOt" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -11874,6 +12259,17 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"jOH" = (
+/obj/structure/closet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "jOU" = (
 /obj/machinery/door/window/eastright{
 	dir = 8
@@ -11888,8 +12284,13 @@
 	},
 /area/f13/brotherhood/rnd)
 "jPC" = (
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/item/wallframe/camera,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "jPN" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -11898,6 +12299,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"jQm" = (
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "jQp" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -11928,11 +12333,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
-"jQK" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/robobrain/nsb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "jQN" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood{
@@ -11943,27 +12343,24 @@
 /obj/machinery/telecomms/bus/preset_four,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"jQU" = (
-/turf/closed/indestructible/vaultdoor{
-	desc = "A wall made out of metal, really fucking tough metal. Someone built this waaaay in advance.";
-	name = "bunker wall"
+"jQV" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/area/f13/caves)
-"jRu" = (
-/obj/structure/destructible/tribal_torch/lit,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
-"jSc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
 "jSf" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
+/area/f13/tunnel)
+"jSq" = (
+/obj/structure/barricade/wooden/planks,
+/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "jSu" = (
 /obj/structure/table/wood/settler,
@@ -11971,15 +12368,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "jSJ" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"jTg" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/f13{
-	icon_state = "redmark"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "jTD" = (
@@ -11997,10 +12389,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"jVf" = (
-/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "jVx" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 1
@@ -12023,30 +12411,11 @@
 	},
 /area/f13/bunker)
 "jWC" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/structure/wreck/trash/five_tires,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"jWG" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/deathclaw/mother{
-	speed = -1.5
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"jXe" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/closed/wall/r_wall,
-/area/f13/tunnel)
-"jXq" = (
-/obj/item/storage/trash_stack,
-/obj/structure/wreck/trash/two_tire,
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "jXu" = (
 /obj/structure/chair/f13foldupchair{
@@ -12055,13 +12424,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
-"jXC" = (
-/obj/machinery/light/broken,
-/obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
 "jYe" = (
 /obj/machinery/door/window/southleft,
 /obj/effect/decal/cleanable/dirt,
@@ -12078,41 +12440,51 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "jYt" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/handcuffs,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowbottom"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
+"jYL" = (
+/obj/effect/decal/fakelattice,
+/obj/item/storage/toolbox/emergency/old,
+/obj/item/storage/toolbox/emergency/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "jYP" = (
 /obj/structure/simple_door/bunker,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/medical)
 "jZf" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "gatehouseladder"
+/obj/effect/decal/fakelattice,
+/obj/structure/wreck/trash/engine,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/area/f13/bunker)
 "jZg" = (
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/medical)
 "jZH" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
-"jZI" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "jZT" = (
 /turf/open/floor/plasteel/floorgrime,
+/area/f13/tunnel)
+"kae" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "kan" = (
 /obj/item/statuebust,
@@ -12155,6 +12527,17 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"kcf" = (
+/obj/structure/timeddoor,
+/obj/structure/timeddoor,
+/turf/closed/wall/r_wall/rust,
+/area/f13/caves)
+"kcm" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/generic,
+/obj/structure/curtain,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "kcD" = (
 /obj/structure/bookcase/manuals/medical,
 /turf/open/floor/carpet/black,
@@ -12201,29 +12584,25 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"kfQ" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/floor/f13/wood,
+"kfy" = (
+/turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
-"kfU" = (
-/obj/structure/table,
-/obj/item/fusion_fuel,
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
+"kfQ" = (
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
 /area/f13/bunker)
+"kfT" = (
+/obj/structure/bed,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
 "kfV" = (
 /obj/structure/simple_door/room,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"kgo" = (
-/mob/living/simple_animal/hostile/raider/thief,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "kgP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -12273,30 +12652,18 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"kiY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/caves)
 "kja" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/microwave,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "kjo" = (
-/mob/living/simple_animal/hostile/handy/gutsy,
+/obj/effect/decal/cleanable/glass,
+/mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"kjz" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor6-old";
-	tag = "icon-floor6-old"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "kjU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -12311,36 +12678,11 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"kjV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "kjW" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
+/obj/machinery/door/airlock/grunge,
+/obj/machinery/door/airlock/grunge,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"kkm" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "kkq" = (
 /obj/item/flashlight/flare/torch,
 /turf/open/floor/f13/wood,
@@ -12351,14 +12693,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "kkU" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "klj" = (
 /obj/structure/sink{
 	pixel_y = 22
@@ -12373,26 +12720,25 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"kne" = (
-/obj/machinery/door/keycard{
-	puzzle_id = "library"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+"klZ" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "kny" = (
 /obj/structure/sign/poster/prewar/poster74,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
-"knU" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell/ammo/ec,
+"kod" = (
+/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/bunker)
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "koC" = (
 /obj/structure/lattice{
 	layer = 3
@@ -12402,10 +12748,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"koJ" = (
-/mob/living/simple_animal/hostile/raider/biker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "kpd" = (
 /obj/structure/lattice{
 	layer = 3
@@ -12416,52 +12758,34 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "kpk" = (
-/obj/structure/rack,
-/obj/item/advanced_crafting_components/receiver,
-/obj/item/advanced_crafting_components/receiver,
-/obj/item/advanced_crafting_components/receiver,
-/obj/item/advanced_crafting_components/lenses,
-/obj/item/advanced_crafting_components/lenses,
-/obj/item/advanced_crafting_components/lenses,
-/obj/item/advanced_crafting_components/flux,
-/obj/item/advanced_crafting_components/flux,
-/obj/item/advanced_crafting_components/flux,
-/obj/item/advanced_crafting_components/conductors,
-/obj/item/advanced_crafting_components/conductors,
-/obj/item/advanced_crafting_components/conductors,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/alloys,
-/obj/item/advanced_crafting_components/alloys,
-/obj/item/advanced_crafting_components/alloys,
-/obj/item/advanced_crafting_components/alloys,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/conductors,
-/obj/item/advanced_crafting_components/flux,
-/obj/item/advanced_crafting_components/lenses,
-/obj/item/advanced_crafting_components/receiver,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
 "kpo" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"kpy" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "kqh" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"kqK" = (
+"kqJ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/caves)
+/obj/item/storage/box/bodybags,
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard/twenty,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "kqS" = (
 /obj/effect/turf_decal/arrows/white,
 /obj/effect/decal/cleanable/dirt,
@@ -12469,27 +12793,30 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"kqY" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"krm" = (
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
 "krt" = (
-/obj/structure/rack,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/item/gun/ballistic/automatic/m1garand/oldglory{
+	desc = "Arguably the most patriotic garand in existence, flag and well-known satisfying ping included, all the while hitting like a truck";
+	name = "M1 Garand"
+	},
 /obj/item/clothing/suit/armor/f13/battlecoat,
-/obj/item/circuitboard/machine/autolathe/ammo,
-/obj/item/circuitboard/machine/autolathe/ammo,
-/obj/item/circuitboard/machine/autolathe/ammo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
+"krJ" = (
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "ksg" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -12497,18 +12824,13 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"ksw" = (
-/obj/structure/table,
-/obj/item/clothing/under/f13/enclave_officer,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+"kss" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
-"ksD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "ksU" = (
 /obj/structure/table{
 	layer = 2.9
@@ -12549,6 +12871,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
+"kuj" = (
+/obj/item/instrument/violin,
+/obj/structure/rack,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/tunnel)
 "kur" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -12571,18 +12898,26 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"kvE" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/r_wall/rust,
-/area/f13/bunker)
 "kvK" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "kvL" = (
-/obj/structure/dresser,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/frame/machine,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
+"kvN" = (
+/obj/structure/sign/poster/prewar/poster89,
+/turf/closed/wall/f13/supermart,
+/area/f13/followers)
 "kvO" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -12597,6 +12932,15 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
+"kwu" = (
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "kwB" = (
 /obj/structure/simple_door/dirtyglass,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -12622,6 +12966,29 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
+"kxW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/tunnel)
+"kxY" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
+"kzt" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "kzO" = (
 /obj/machinery/vending/nukacolavend,
 /obj/machinery/light/small{
@@ -12632,9 +12999,27 @@
 	},
 /area/f13/clinic)
 "kAp" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/water,
+/obj/structure/table,
+/obj/item/healthanalyzer/advanced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"kAs" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Armory";
+	req_one_access_txt = "62"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"kAA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "kAR" = (
 /obj/structure/simple_door/fakeglass,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -12665,12 +13050,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "kBD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Aqua{
-	name = "light fixture"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/area/f13/bunker)
 "kCg" = (
 /obj/structure/table{
 	layer = 2.9
@@ -12686,6 +13071,15 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"kCi" = (
+/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "kCo" = (
 /obj/structure/table/wood,
 /obj/item/crafting/coffee_pot{
@@ -12708,6 +13102,19 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"kCx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/item/toy/plush/mr_buckety,
+/obj/item/reagent_containers/glass/bucket,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "kCz" = (
 /obj/structure/mirelurkegg{
 	anchored = 1
@@ -12723,11 +13130,20 @@
 	},
 /area/f13/tunnel)
 "kDS" = (
-/obj/machinery/light/fo13colored/Aqua{
-	name = "light fixture"
+/obj/item/cultivator,
+/mob/living/simple_animal/hostile/handy/protectron/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"kDV" = (
+/obj/structure/junk/small/bed,
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "kEP" = (
 /obj/structure/lattice{
 	layer = 3
@@ -12744,11 +13160,6 @@
 /obj/structure/sign/poster/prewar/poster83,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
-"kFg" = (
-/obj/structure/bookcase,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "kFo" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/f13/wood{
@@ -12764,6 +13175,14 @@
 	dir = 10
 	},
 /area/f13/tcoms)
+"kFD" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "kFF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/can,
@@ -12771,13 +13190,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"kFX" = (
+/obj/structure/junk/small/bed,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "kGx" = (
 /obj/structure/sign/poster/prewar/poster89,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
-"kHi" = (
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "kHD" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -12799,30 +13220,46 @@
 	icon_state = "housewood2"
 	},
 /area/f13/sewer)
-"kJI" = (
-/obj/machinery/computer/security{
-	dir = 4;
-	network = "vault"
-	},
+"kJa" = (
+/obj/structure/filingcabinet,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "purplefull"
+	},
+/area/f13/followers)
+"kJR" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
-"kJJ" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
 "kJW" = (
 /obj/structure/toilet{
 	pixel_y = 10
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/offices2nd)
+"kKf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/armor/f13/power_armor/t45b/restored,
+/turf/open/floor/f13{
+	dir = 8;
+	icon_state = "bluemark"
+	},
+/area/f13/bunker)
+"kKl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"kLy" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
 "kLA" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/blue,
@@ -12844,6 +13281,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"kNg" = (
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/flashlight/lantern,
+/obj/item/mining_scanner,
+/obj/item/pickaxe/drill,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "kNK" = (
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12869,16 +13315,11 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "kPb" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/item/shovel/spade,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "kPE" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/under/syndicate/brotherhood,
@@ -12891,6 +13332,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
+"kQl" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/followers)
 "kQy" = (
 /obj/structure/closet/cabinet{
 	anchored = 1;
@@ -12904,24 +13351,27 @@
 /obj/item/documents/syndicate/blue,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
+"kQO" = (
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "kRu" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Armory";
-	req_one_access_txt = "62"
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/indestructible/fakedoor{
+	desc = "An indestructible door. Hm.";
+	name = "Strong Door"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/area/f13/bunker)
 "kRE" = (
-/obj/structure/sign/poster/contraband/red_rum{
-	pixel_y = -32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/supermart,
+/area/f13/followers)
 "kSa" = (
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "kSl" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -12929,6 +13379,28 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"kSn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/biker,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"kSD" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old";
+	tag = "icon-gib5-old"
+	},
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"kSK" = (
+/obj/structure/frame/machine,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
 "kTF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
@@ -12937,14 +13409,13 @@
 	},
 /area/f13/tunnel)
 "kTJ" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/area/f13/bunker)
 "kTO" = (
 /obj/machinery/light{
 	dir = 4
@@ -12971,6 +13442,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
+"kUc" = (
+/obj/structure/table,
+/obj/item/clothing/under/f13/enclave_officer,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"kUL" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "kUN" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbroken"
@@ -12981,12 +13465,22 @@
 	},
 /area/f13/tunnel)
 "kVD" = (
-/obj/structure/chair/office{
-	dir = 8
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
 	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"kVL" = (
+/obj/structure/simple_door/metal/barred,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"kVN" = (
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "kVP" = (
 /obj/structure/sink{
 	dir = 8;
@@ -13008,6 +13502,13 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"kWm" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "kWr" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -13029,9 +13530,11 @@
 	},
 /area/f13/brotherhood/offices1st)
 "kWK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/rust,
-/area/f13/tunnel)
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "kXn" = (
 /obj/structure/camera_assembly{
 	dir = 8
@@ -13040,19 +13543,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"kXo" = (
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
-	faction = list("raider");
-	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
-	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
-	name = "Repaired Turret";
-	scan_range = 9;
-	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
-	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
-	throw_range = 9
-	},
-/turf/open/indestructible/ground/inside/subway,
+"kXs" = (
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/cut/random,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "kXA" = (
 /obj/structure/table{
@@ -13080,37 +13575,18 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"kYy" = (
-/obj/structure/closet/crate,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+"kZR" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
-"kZR" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/wood,
-/area/f13/tunnel)
-"lah" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "laO" = (
 /obj/structure/falsewall/rust,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
-"laT" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/item/storage/fancy/candle_box,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "lbk" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -13130,15 +13606,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"lbN" = (
+"lcu" = (
+/obj/effect/landmark/start/f13/followersguard,
 /turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
+	icon_state = "floorrusty"
 	},
-/area/f13/bunker)
-"lcr" = (
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/area/f13/followers)
 "lcE" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -13148,11 +13621,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"lcG" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "ldi" = (
 /obj/structure/sign/poster/prewar/poster84,
 /turf/closed/wall/r_wall,
@@ -13184,13 +13652,18 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices1st)
-"ldZ" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "house1ladder"
+"ldY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/ranged/legendary,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/area/f13/bunker)
+"ldZ" = (
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
+	},
+/area/f13/followers)
 "lea" = (
 /obj/structure/noticeboard{
 	desc = "A large, rusted plaque with a newly crafted nameplate listing the many Paladin's that walk these halls and may make use of this office.";
@@ -13199,12 +13672,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
 "lev" = (
-/obj/structure/noticeboard{
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "leG" = (
 /obj/structure/table{
 	layer = 2.9
@@ -13217,10 +13688,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"leM" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
 "leT" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cloth/ten,
@@ -13229,17 +13696,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
-"lfb" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/item/toy/figure/detective{
-	pixel_x = -4;
-	pixel_y = 11
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "lfw" = (
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"lfN" = (
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lfW" = (
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -13247,13 +13710,12 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"lgn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
+"lgu" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "lgv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/paladin,
@@ -13268,10 +13730,6 @@
 /obj/structure/sign/poster/prewar/poster85,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
-"lhg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
 "lhh" = (
 /obj/item/assembly/signaler{
 	code = 2;
@@ -13286,13 +13744,19 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"lhT" = (
+"lhw" = (
+/obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/mask/gas/enclave,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"lhQ" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/area/f13/bunker)
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/followers)
 "liq" = (
 /obj/machinery/shower{
 	dir = 8
@@ -13303,11 +13767,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
-"liB" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/assaultron,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "liD" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/light{
@@ -13340,6 +13799,29 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"ljj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ljk" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
+"ljs" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
 "ljD" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -13348,14 +13830,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
-"ljX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/suit/armor/f13/power_armor/t45b/restored,
-/turf/open/floor/f13{
-	dir = 8;
-	icon_state = "bluemark"
-	},
-/area/f13/bunker)
 "ljY" = (
 /obj/structure/handrail/g_end{
 	pixel_x = 12;
@@ -13371,6 +13845,10 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"llb" = (
+/obj/structure/girder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "llp" = (
 /obj/structure/curtain{
 	color = "#363636"
@@ -13379,6 +13857,12 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"llv" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/followers)
 "llQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -13387,19 +13871,11 @@
 	},
 /area/f13/brotherhood/operations)
 "llV" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "llW" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -13430,11 +13906,9 @@
 "lnr" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"lnt" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"lnB" = (
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "lnL" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -13442,25 +13916,11 @@
 	},
 /area/f13/tunnel)
 "loc" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"loe" = (
-/mob/living/simple_animal/hostile/handy/gutsy/nsb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "lof" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -13483,20 +13943,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
-"loO" = (
-/obj/structure/frame/machine,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+"loK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/f13/bunker)
-"lpa" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/cobble{
-	desc = "An assortment of broken and battered bricks, stones, rebar, and dust.";
-	name = "rubble"
-	},
-/area/f13/bunker)
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "lpd" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -13507,11 +13960,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"lps" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/mob/living/simple_animal/hostile/raider/legendary,
+"lpu" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/structure/sign/poster/contraband/pinup_bed{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/area/f13/tunnel)
 "lpK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker{
@@ -13523,10 +13979,11 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"lqy" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+"lqk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/workbench/forge,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "lqC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -13542,10 +13999,6 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"lrt" = (
-/mob/living/simple_animal/hostile/deathclaw,
-/turf/open/water,
-/area/f13/caves)
 "lrP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13555,55 +14008,13 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"lsk" = (
-/obj/structure/rack,
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/item/crafting/abraxo,
-/obj/item/crafting/sensor,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/radio,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"lsl" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"lsn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "lsy" = (
 /obj/structure/sign/poster/prewar/poster88,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
-"lsJ" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/obj/machinery/power/apc,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
+"lsS" = (
+/turf/closed/wall,
+/area/f13/caves)
 "lsW" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -13621,15 +14032,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"lue" = (
-/obj/item/storage/trash_stack,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
-"luy" = (
-/obj/item/wrench/crude,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "lvr" = (
 /obj/structure/table/optable/abductor,
 /obj/item/restraints/handcuffs,
@@ -13648,13 +14050,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"lvL" = (
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/obj/machinery/pdapainter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "lvT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -13662,12 +14057,10 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
-"lws" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/bunker)
+"lwc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "lwz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/f13foldupchair,
@@ -13684,16 +14077,17 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
-"lyc" = (
+"lxC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"lxD" = (
+/obj/effect/decal/waste,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "lyh" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13718,23 +14112,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"lzR" = (
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"lzW" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+"lzj" = (
+/obj/effect/landmark/start/f13/prospector,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"lAm" = (
+"lzW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
 /area/f13/caves)
 "lAr" = (
 /obj/item/trash/f13/dog,
@@ -13749,13 +14135,21 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"lAW" = (
+"lAR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/tools{
-	pixel_x = 32
+/obj/item/storage/trash_stack,
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
+"lAW" = (
+/obj/machinery/chem_master/advanced,
+/obj/machinery/chem_master/advanced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "lBb" = (
 /obj/structure/sink/puddle,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13769,12 +14163,16 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"lBR" = (
-/mob/living/simple_animal/hostile/handy/sentrybot,
+"lBq" = (
+/obj/structure/junk/small/bed,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"lBA" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall/rust,
+/area/f13/tunnel)
 "lBX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
@@ -13784,9 +14182,10 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"lCd" = (
-/obj/machinery/smartfridge/bottlerack,
-/turf/open/floor/f13/wood,
+"lBZ" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/tunnel)
 "lCK" = (
 /obj/structure/table{
@@ -13817,10 +14216,6 @@
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
-"lDm" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "lDx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/paladin,
@@ -13847,31 +14242,28 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"lEh" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "followersadminshutters";
+	name = "desk shutters";
+	pixel_x = 6
+	},
+/obj/machinery/button/door{
+	id = "fadmin";
+	name = "Door lockdown button";
+	pixel_x = -5
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "lEl" = (
 /obj/structure/spacevine{
 	name = "vines"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"lED" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/storage/box/matches,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"lGe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/gibs/down,
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
-"lGl" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "lGo" = (
 /obj/structure/table/optable,
 /obj/machinery/iv_drip{
@@ -13882,44 +14274,34 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"lGG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/bunker)
-"lGO" = (
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibtorso"
-	},
+"lGw" = (
+/obj/structure/curtain,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/bunker)
-"lHn" = (
-/obj/structure/decoration/clock,
-/turf/closed/wall/r_wall/rust,
-/area/f13/bunker)
-"lHu" = (
-/obj/structure/table,
+/area/f13/followers)
+"lIq" = (
+/mob/living/simple_animal/hostile/enclave/soldier{
+	aggro_vision_range = 15;
+	armour_penetration = 1;
+	desc = "What visibly appears to be a proud Enclave soldier clad in armor is in actuality a grotesque, FEV-exposed mutant grafted to the interior of his suit, never able to leave. You've gotten a lot farther than you should have...";
+	extra_projectiles = 10;
+	faction = list("wastebot");
+	health = 3000;
+	loot = list(/obj/item/keycard/library);
+	maxHealth = 3000;
+	melee_damage_lower = 100;
+	melee_damage_upper = 100;
+	melee_queue_distance = 10;
+	name = "Captain Arlem";
+	speak = list("Die... mutie!","AAAAUHGHHHH!","DIE!","Perish!","FOR THE ENCLAVE!");
+	speak_chance = 10;
+	speak_emote = list("shouts");
+	speed = -1
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/paper/crumpled/bloody/docsdeathnote{
-	info = "Initial tests of the modified FEV on our subjects is promising, with an increase in strength and indurance and no notable decrease in intelligence. Further testin is require for now, however, and tests with the soldiers can begin soon...."
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"lIw" = (
-/obj/structure/sign/poster/contraband/pinup_topless{
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "lIx" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -13936,14 +14318,6 @@
 /obj/structure/sign/poster/prewar/poster86,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
-"lJa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/handrail/g_central{
-	layer = 2.7;
-	pixel_y = -16
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "lKh" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -13955,28 +14329,19 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"lKF" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+"lKT" = (
+/obj/machinery/light/broken,
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
-"lKT" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"lKW" = (
+"lLt" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/gutsy/nsb,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"lLh" = (
-/obj/structure/reagent_dispensers/barrel/old,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "lLA" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -14023,10 +14388,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"lMI" = (
-/mob/living/simple_animal/hostile/trog/tunneler,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "lMT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -14037,16 +14398,9 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"lOo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
-"lOq" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
+"lNv" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
 	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
@@ -14054,8 +14408,11 @@
 /area/f13/bunker)
 "lOt" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/tunnel)
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "lOJ" = (
 /obj/structure/sign/poster/contraband/pinup_pink{
 	pixel_y = -32
@@ -14083,12 +14440,11 @@
 	},
 /area/f13/tunnel)
 "lPs" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	pixel_x = -6
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/tunnel)
+/area/f13/bunker)
 "lPt" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -14126,6 +14482,10 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/tunnel)
+"lQW" = (
+/obj/structure/sign/poster/prewar/poster92,
+/turf/closed/wall/f13/supermart,
+/area/f13/followers)
 "lRu" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = -32
@@ -14138,21 +14498,24 @@
 /obj/item/seeds/cannabis,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"lUq" = (
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/tunnel)
-"lUI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/mattress,
+"lST" = (
+/obj/machinery/light/fo13colored/Aqua{
+	name = "light fixture"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"lUJ" = (
-/obj/structure/junk/small/bed2,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+"lUq" = (
+/obj/structure/closet/crate/freezer/blood/anchored,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
 	},
-/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"lUI" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
 "lVj" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -14161,16 +14524,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "lVr" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "lVt" = (
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
+"lWy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "lXw" = (
 /obj/machinery/workbench/advanced,
 /obj/effect/turf_decal/stripes/box,
@@ -14209,12 +14575,6 @@
 	icon_state = "r_wall"
 	},
 /area/f13/brotherhood/offices2nd)
-"lYf" = (
-/obj/effect/decal/waste{
-	icon_state = "goo10"
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "lYu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -14231,16 +14591,23 @@
 /turf/open/water,
 /area/f13/tunnel)
 "lYE" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "lYM" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"lYZ" = (
+/obj/machinery/button/crematorium{
+	pixel_y = 19
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/followers)
 "lZb" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/brown,
@@ -14252,6 +14619,10 @@
 /obj/structure/glowshroom/single,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"lZH" = (
+/obj/structure/chair/bench,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "lZJ" = (
 /obj/structure/table{
 	layer = 2.9
@@ -14270,37 +14641,27 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"max" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"maE" = (
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
-	},
-/area/f13/bunker)
 "mba" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 8;
-	name = "light fixture"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"mbC" = (
-/obj/structure/barricade/bars,
-/obj/structure/table,
-/obj/item/book/granter/trait/trekking,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"mbx" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "mbT" = (
 /obj/item/trash/f13/porknbeans,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mbX" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "mcC" = (
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/fancy/candle_box,
@@ -14309,13 +14670,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/medical)
-"mcH" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
+"mcL" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters{
+	id = "followersadminshutters";
+	name = "followers shutters"
 	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
 "mdv" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
@@ -14328,33 +14692,20 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/sewer)
-"mfb" = (
-/mob/living/simple_animal/hostile/handy/sentrybot/nsb,
+"mdK" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/f13/battlecoat,
+/obj/item/circuitboard/machine/autolathe/ammo,
+/obj/item/circuitboard/machine/autolathe/ammo,
+/obj/item/circuitboard/machine/autolathe/ammo,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"mfi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/area/f13/tunnel)
 "mfC" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"mgg" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"mgu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "mgx" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
@@ -14363,11 +14714,6 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"mgQ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "mhc" = (
 /turf/closed/indestructible/opshuttle{
 	icon = 'icons/turf/walls/reinforced_wall.dmi';
@@ -14382,15 +14728,35 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"mia" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"mij" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Prospector Entrance";
+	req_one_access_txt = "48"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "prospector1open"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "miw" = (
-/obj/structure/ore_box,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/item/storage/trash_stack,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "miy" = (
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/fakelattice,
+/obj/item/ammo_casing/shotgun/improvised,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "miI" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -14402,12 +14768,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mjq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/bunker)
 "mjz" = (
 /obj/item/clothing/under/f13/brahmin,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14420,10 +14780,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"mjS" = (
-/mob/living/simple_animal/hostile/handy/securitron/nsb,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "mko" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -14431,6 +14787,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"mkv" = (
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mkC" = (
 /obj/structure/bodycontainer/crematorium{
 	dir = 8
@@ -14452,6 +14812,13 @@
 "mkY" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/sewer)
+"mln" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "mlz" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14478,29 +14845,62 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"mlW" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "mmv" = (
 /obj/machinery/door/airlock/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
+"mmx" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"mmL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"mmN" = (
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"mmO" = (
+/obj/machinery/smartfridge/bottlerack,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"mng" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "mnk" = (
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
 /area/f13/clinic)
-"mot" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13{
+"mnY" = (
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/turf/open/floor/f13{
 	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"mot" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "mpn" = (
@@ -14515,17 +14915,26 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"mpt" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "mpE" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"mqi" = (
-/obj/structure/junk/small/bed2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
+"mpN" = (
+/obj/structure/chair/f13chair2{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "mql" = (
@@ -14538,13 +14947,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"mqF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/chair,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "mqJ" = (
 /obj/effect/landmark/start/f13/seniorscribe,
 /obj/structure/chair/office/dark{
@@ -14579,17 +14981,30 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
+"msE" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "msK" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib5-old"
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"mtA" = (
-/obj/structure/junk/small/bed,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
+"mtN" = (
+/obj/structure/light_construct,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
+"muc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/tunnel)
 "mui" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -14615,11 +15030,29 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"mvy" = (
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Oasis";
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "mvH" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mwN" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
 "mxa" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
@@ -14649,6 +15082,14 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"mxG" = (
+/obj/effect/decal/cleanable/generic,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "cornerladder"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "mxI" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -14670,6 +15111,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"myC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/mask/gas/enclave,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "myP" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -14691,13 +15139,12 @@
 	},
 /area/f13/tunnel)
 "mzR" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "prospectorladder"
+/obj/structure/girder/reinforced,
+/obj/structure/decoration/rag,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "mzX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -14718,12 +15165,12 @@
 	},
 /area/f13/brotherhood/reactor)
 "mAa" = (
-/obj/machinery/light/fo13colored/Aqua{
-	name = "light fixture"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/area/f13/bunker)
 "mAc" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibmid3";
@@ -14732,15 +15179,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"mAf" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/machinery/door/poddoor{
-	id = "hate"
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "mAn" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -14768,11 +15206,12 @@
 	},
 /area/f13/brotherhood/reactor)
 "mBn" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mBu" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -14798,18 +15237,24 @@
 "mDq" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"mDK" = (
+/obj/structure/girder/reinforced,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "mDR" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/clinic)
-"mDZ" = (
-/mob/living/simple_animal/hostile/handy/assaultron,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
+"mEb" = (
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/flashlight/lantern,
+/obj/item/mining_scanner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "mEf" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -14873,36 +15318,27 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"mGf" = (
+"mGl" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
-"mGg" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "mGH" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"mGY" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"mHc" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/ash/large,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
+"mGT" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/plastic/fifty,
+/obj/item/stack/sheet/plastic/fifty,
+/obj/item/stack/sheet/plastic/fifty,
+/obj/item/stack/sheet/plastic/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "mHj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bookcase/manuals/engineering,
@@ -14927,22 +15363,20 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
-"mHM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/toolbox/drone,
-/obj/item/storage/toolbox/drone,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"mHW" = (
-/obj/structure/table,
-/obj/item/gun/energy/laser/plasma/glock,
-/obj/machinery/light/small{
-	dir = 1
-	},
+"mHF" = (
+/obj/machinery/autolathe,
 /turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"mHM" = (
+/obj/machinery/door/poddoor{
+	id = "soup"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "mIj" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -14952,27 +15386,14 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"mIx" = (
-/obj/structure/table,
-/obj/item/storage/backpack/enclave{
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/obj/item/storage/backpack/enclave{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "mII" = (
 /obj/structure/flora/junglebush/c,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"mIW" = (
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "mJG" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14981,27 +15402,10 @@
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"mKg" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "mKh" = (
-/obj/structure/closet/crate/large,
-/obj/structure/closet/crate/large,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"mKm" = (
-/obj/structure/closet/crate/medical,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "mKE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15012,25 +15416,23 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
-"mKS" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/closed/wall/f13/ruins,
-/area/f13/bunker)
 "mKY" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"mLa" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider/biker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "mLh" = (
 /mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"mLL" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "mLN" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -15057,30 +15459,18 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mMd" = (
-/obj/effect/decal/waste{
-	icon_state = "goo8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "mMC" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"mNc" = (
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mNE" = (
 /obj/structure/barricade/bars,
 /turf/open/water,
 /area/f13/tunnel)
+"mNF" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "mOm" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood{
@@ -15107,18 +15497,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/leisure)
-"mPK" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"mQO" = (
-/turf/open/water,
-/area/f13/bunker)
 "mQX" = (
 /obj/effect/spawner/lootdrop/trash,
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
+"mRd" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "mRk" = (
 /obj/effect/landmark/start/f13/ussgt,
 /turf/open/floor/f13{
@@ -15163,18 +15551,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
-"mSj" = (
-/obj/effect/decal/remains/human,
-/obj/effect/gibspawner/human,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
+"mSp" = (
+/obj/structure/curtain,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"mSo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "mSs" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/chemistry,
@@ -15190,10 +15570,6 @@
 /obj/effect/temp_visual/steam_release,
 /turf/open/water,
 /area/f13/caves)
-"mTq" = (
-/obj/structure/campfire,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/tunnel)
 "mTr" = (
 /obj/machinery/door/window/northright,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -15213,20 +15589,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
-"mTN" = (
-/obj/machinery/door/poddoor{
-	name = "bunker door"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "platingdmg3"
-	},
-/area/f13/tunnel)
-"mTO" = (
-/turf/closed/indestructible/fakedoor{
-	desc = "An indestructible door. Hm.";
-	name = "Strong Door"
-	},
-/area/f13/bunker)
 "mUb" = (
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
@@ -15238,35 +15600,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"mUw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	dir = 8
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/tunnel)
-"mUZ" = (
-/obj/effect/landmark/map_load_mark/dungeons/northsewer,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
-"mVa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/tunnel)
-"mVo" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "mVr" = (
-/obj/structure/junk/small/bed2,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
-"mVU" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "mWD" = (
 /obj/structure/cable{
@@ -15277,16 +15615,37 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
+"mWI" = (
+/obj/structure/showcase/horrific_experiment,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/bunker)
 "mWM" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
+"mXF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "mXW" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"mYm" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "mYt" = (
 /obj/machinery/computer/libraryconsole/bookmanagement{
 	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
@@ -15313,29 +15672,11 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
-"mYN" = (
-/obj/item/clothing/head/helmet/f13/power_armor/t45b,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/bunker)
 "mYV" = (
-/obj/machinery/workbench,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
-/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
-/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "mZq" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/machinery/light/small{
@@ -15344,28 +15685,28 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"mZH" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/sentrybot/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mZU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"naY" = (
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/item/stack/sheet/hay/fifty,
-/obj/effect/decal/cleanable/dirt,
+"nav" = (
 /obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"nbx" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 6
-	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"naY" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "nbz" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -15373,52 +15714,24 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/tunnel)
-"nbC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/effect/decal/cleanable/oil/slippery,
+"nbI" = (
+/obj/effect/decal/cleanable/glass,
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
+"ndi" = (
+/mob/living/simple_animal/hostile/deathclaw,
+/turf/open/water,
+/area/f13/caves)
+"ndk" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker)
-"ncx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"ncK" = (
-/obj/machinery/workbench/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"ncQ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/ore_box,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"ndi" = (
-/obj/effect/landmark/start/f13/prospector,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"ndk" = (
-/obj/structure/noticeboard{
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Oasis";
-	req_one_access_txt = "25"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/area/f13/caves)
 "ndn" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -15431,11 +15744,6 @@
 "ndp" = (
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
-"ndr" = (
-/obj/structure/simple_door/wood,
-/obj/structure/barricade/wooden/planks,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "neu" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/outside/water,
@@ -15454,21 +15762,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
-"nfo" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
-"nfv" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "nfz" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -15483,12 +15776,10 @@
 	},
 /area/f13/tunnel)
 "nfM" = (
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nfW" = (
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -15497,10 +15788,25 @@
 	dir = 8
 	},
 /area/f13/tcoms)
-"ngv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing/shotgun/improvised,
-/turf/open/floor/plasteel/freezer,
+"ngc" = (
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/obj/item/storage/trash_stack{
+	layer = 2
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/tunnel)
+"ngM" = (
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/bunker)
 "ngP" = (
 /obj/structure/bed/pod,
@@ -15508,16 +15814,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "nha" = (
-/obj/structure/closet/crate/large,
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"nhq" = (
-/obj/machinery/door/airlock/grunge,
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "nhE" = (
 /turf/open/floor/f13{
@@ -15531,10 +15829,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "nhK" = (
-/obj/structure/closet/crate,
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
+"nhV" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
+"nhY" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "nim" = (
 /obj/structure/bed,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -15561,17 +15866,68 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"njZ" = (
-/obj/machinery/light/fo13colored/Pink{
-	dir = 4;
-	name = "light tube"
-	},
-/obj/structure/wreck/trash/five_tires{
-	layer = 3
-	},
+"niM" = (
+/obj/structure/guncase,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/gun/ballistic/shotgun/trench,
+/obj/item/gun/ballistic/shotgun/trench,
+/obj/item/gun/ballistic/shotgun/trench,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"niP" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"niT" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Oasis Housing";
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"niX" = (
+/obj/machinery/vending/medical{
+	req_access = null
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
+"njs" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"njE" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/f13{
+	dir = 8;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
+"njZ" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"nkf" = (
+/obj/machinery/light/broken,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "nld" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15591,15 +15947,11 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"nmn" = (
-/obj/effect/decal/waste{
-	icon_state = "goo8"
+"nlP" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"nmo" = (
-/obj/structure/glowshroom/single,
-/turf/open/water,
 /area/f13/caves)
 "nmE" = (
 /obj/item/kirbyplants/random,
@@ -15611,35 +15963,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"nmN" = (
-/turf/closed/wall/f13/supermart,
+"nnh" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"nnn" = (
-/obj/structure/fluff/oldturret,
-/turf/open/floor/f13{
-	dir = 8;
-	icon_state = "redmark"
-	},
-/area/f13/bunker)
 "nnx" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "nnz" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "clinicoutsideladder"
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/blood/tracks,
+/mob/living/simple_animal/hostile/raider/legendary,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"nnL" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "nnN" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "boscheckpointreactor";
@@ -15660,25 +15997,6 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"nof" = (
-/mob/living/simple_animal/hostile/raider/ranged/boss,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"nox" = (
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
-	faction = list("raider");
-	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
-	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
-	name = "Repaired Turret";
-	scan_range = 9;
-	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
-	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
-	throw_range = 9
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "noI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15701,6 +16019,21 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"npJ" = (
+/obj/item/paper/crumpled/bloody/docsdeathnote{
+	info = "DON'T MAKE OUR MISTAKE"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"npL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "npR" = (
 /obj/structure/lattice{
 	layer = 3
@@ -15714,9 +16047,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "nqA" = (
-/obj/effect/landmark/start/f13/prospector,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/wrench/power,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "nqE" = (
 /obj/structure/glowshroom/single,
 /obj/structure/campfire/barrel,
@@ -15745,15 +16082,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "nsa" = (
-/obj/structure/sign/poster/contraband/pinup_pink{
-	pixel_y = 32
+/obj/effect/decal/fakelattice,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"nsm" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/unique,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"nss" = (
-/mob/living/simple_animal/hostile/raider/legendary,
-/turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "nsw" = (
 /mob/living/simple_animal/hostile/handy,
@@ -15767,6 +16108,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/brotherhood/reactor)
+"nsP" = (
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/tunnel)
+"nta" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ntS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/vault{
@@ -15779,9 +16128,18 @@
 	},
 /area/f13/brotherhood/reactor)
 "nue" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/machinery/door/poddoor{
+	id = "pain"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "nuy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -15794,6 +16152,18 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
+"nuz" = (
+/obj/structure/table/snooker{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/dice{
+	pixel_x = 13;
+	pixel_y = -7
+	},
+/obj/item/dice,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "nuA" = (
 /obj/structure/lattice/catwalk,
 /turf/open/water,
@@ -15805,15 +16175,6 @@
 	},
 /turf/closed/wall/f13/store,
 /area/f13/ncr)
-"nvn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul,
-/obj/item/pizzabox/meat,
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
 "nvC" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -15836,13 +16197,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"nvT" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/abomhorror/nsb,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "nwf" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt,
@@ -15870,17 +16224,22 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
-"nxH" = (
-/obj/machinery/light/small{
-	dir = 4
+"nwX" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/button/door{
-	id = "prospector1open";
-	name = "gate shutters";
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"nxH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"nxP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/wood/house,
 /area/f13/tunnel)
 "nxT" = (
 /obj/structure/fence/handrail{
@@ -15893,17 +16252,20 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
-"nyb" = (
-/mob/living/simple_animal/hostile/handy/protectron/nsb,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"nyt" = (
-/obj/item/fusion_fuel,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+"nyy" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 5
 	},
-/area/f13/bunker)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/tunnel)
 "nzl" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -15942,6 +16304,14 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
+"nAf" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
 "nAC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15949,10 +16319,6 @@
 /obj/structure/timeddoor,
 /turf/closed/mineral/random/low_chance,
 /area/f13/tunnel)
-"nAM" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
 "nAV" = (
 /obj/machinery/light{
 	dir = 1
@@ -15989,11 +16355,14 @@
 "nBk" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"nBr" = (
+"nBo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/blackbox_recorder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/obj/machinery/light/fo13colored/Pink{
+	dir = 1;
+	name = "light tube"
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/tunnel)
 "nBL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
@@ -16005,15 +16374,21 @@
 	name = "pool water"
 	},
 /area/f13/brotherhood/leisure)
-"nCS" = (
-/obj/machinery/computer/rdconsole{
+"nCt" = (
+/obj/machinery/light/small{
 	dir = 4
 	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"nCD" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"nCU" = (
+/obj/structure/simple_door/metal/barred,
+/turf/open/water,
+/area/f13/tunnel)
 "nDb" = (
 /obj/structure/table/abductor{
 	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
@@ -16021,6 +16396,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
+"nDl" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "followerlabladder"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "nEl" = (
 /obj/structure/simple_door/metal/store,
 /obj/effect/decal/cleanable/dirt{
@@ -16028,16 +16412,11 @@
 	},
 /turf/closed/indestructible/f13/matrix,
 /area/f13/ncr)
-"nEo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash/large,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "nEr" = (
-/obj/item/flag/oasis,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nEt" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16052,16 +16431,9 @@
 /area/f13/brotherhood/mining)
 "nEz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/glasses/sunglasses{
-	anchored = 1;
-	pixel_y = 26
-	},
-/obj/item/clothing/head/fedora/det_hat{
-	anchored = 1;
-	pixel_y = 32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nEC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -16071,14 +16443,9 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"nEH" = (
-/obj/item/storage/trash_stack{
-	layer = 2
-	},
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 1;
-	name = "light fixture"
-	},
+"nFc" = (
+/obj/effect/landmark/start/f13/settler,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "nFr" = (
@@ -16105,9 +16472,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"nGx" = (
-/mob/living/simple_animal/hostile/raider/thief,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"nGb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
 /area/f13/bunker)
 "nGN" = (
 /obj/machinery/light/small{
@@ -16117,12 +16486,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"nHa" = (
-/obj/structure/junk/small/bed2,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "nHN" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -16161,18 +16524,45 @@
 /area/f13/sewer)
 "nIP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/nest/deathclaw,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"nJe" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating/f13,
+/area/f13/followers)
+"nJw" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "nJB" = (
-/obj/machinery/chem_dispenser,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
+"nJO" = (
+/obj/structure/junk/small/bed2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "nJV" = (
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"nKj" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/water,
+/area/f13/tunnel)
 "nKk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fence/handrail{
@@ -16187,30 +16577,25 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
-"nKL" = (
+"nKK" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/toy/figure/detective{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"nKT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/paper,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"nKX" = (
-/obj/item/chair,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/obj/structure/barricade/wooden,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "nKZ" = (
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "nLK" = (
-/obj/machinery/chem_master,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/chem_pile{
-	pixel_x = -12;
-	pixel_y = 10
-	},
-/obj/structure/sign/poster/prewar/poster92{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/tunnel)
 "nLM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16223,6 +16608,10 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
+"nMh" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
 "nMv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -16299,18 +16688,12 @@
 	},
 /area/f13/brotherhood/leisure)
 "nNR" = (
-/obj/machinery/chem_heater,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/simple_door/metal/ventilation,
+/obj/machinery/door/poddoor{
+	id = "hate"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"nOw" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/f13{
-	dir = 6;
-	icon_state = "redmark"
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "nOW" = (
@@ -16349,14 +16732,23 @@
 /obj/structure/foamedmetal,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"nRh" = (
-/obj/effect/decal/remains/human,
+"nQZ" = (
+/obj/structure/junk/small/bed2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"nRD" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
+"nRP" = (
+/obj/machinery/door/airlock/grunge,
+/obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"nRP" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "nSe" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -16395,11 +16787,17 @@
 	},
 /area/f13/brotherhood/rnd)
 "nTt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"nTw" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nTN" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -16413,17 +16811,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/offices2nd)
-"nTY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/deathclaw,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"nUx" = (
-/obj/structure/junk/small/bed2,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "nUF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -16433,6 +16820,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"nVN" = (
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/followers)
 "nVP" = (
 /obj/structure/rack,
 /obj/item/mining_scanner,
@@ -16487,6 +16879,27 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/brotherhood/reactor)
+"nWR" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "prospectorladder"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"nWT" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "nWW" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Proctor's Office";
@@ -16497,11 +16910,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
-"nWY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "nXj" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -16516,6 +16924,16 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"nXJ" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_x = -3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/tunnel)
 "nXN" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/timeddoor,
@@ -16523,6 +16941,17 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
+"nXQ" = (
+/obj/structure/sink{
+	pixel_y = 19
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/tunnel)
 "nXS" = (
 /obj/structure/simple_door/bunker{
 	name = "Head Paladin's Office";
@@ -16585,55 +17014,24 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"nZb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"nZt" = (
-/obj/structure/grille/broken,
-/obj/effect/decal/cleanable/glass,
-/obj/item/shard{
-	icon_state = "medium";
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/obj/item/shard{
-	pixel_x = 9;
-	pixel_y = 4
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/bunker)
-"nZu" = (
-/obj/structure/reagent_dispensers/barrel/three{
-	pixel_x = -14
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
-"nZI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Oasis";
-	req_one_access_txt = "25"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"nZZ" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bottle/mutagen,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/book/granter/trait/pa_wear,
+"nZs" = (
+/mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/f13{
-	icon_state = "bluerustyfull"
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"oaG" = (
-/obj/machinery/mineral/ore_redemption,
+"nZB" = (
+/obj/machinery/chem_heater,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"nZI" = (
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "oaW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -16643,17 +17041,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/reactor)
-"obu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"obT" = (
-/obj/machinery/mineral/ore_redemption,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "obV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/bos{
@@ -16667,27 +17054,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/reactor)
-"ocI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/bunker)
 "odj" = (
 /obj/structure/ore_box,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "odk" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Prospector Entrance";
-	req_one_access_txt = "48"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "prospector1open"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "odq" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -16741,12 +17116,21 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"oev" = (
+/obj/structure/closet/crate/large,
+/obj/structure/closet/crate/large,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "oeA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/cell_charger,
 /obj/structure/table/greyscale,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
+"oeG" = (
+/obj/structure/dresser,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "ofm" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16777,21 +17161,25 @@
 /obj/item/am_shielding_container,
 /turf/open/floor/plating,
 /area/f13/brotherhood/reactor)
-"ogz" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/item/wallframe/camera,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
+"ogU" = (
+/obj/structure/sign/poster/prewar/poster90{
+	pixel_y = 32
 	},
-/area/f13/bunker)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
+"ohk" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "ohv" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "busladder"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/closet/crate/miningcar,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ohO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16801,6 +17189,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"oid" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "ois" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/structure/grille,
@@ -16811,19 +17203,46 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/brotherhood/reactor)
-"oiy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Oasis";
-	req_one_access_txt = "25"
+"oix" = (
+/obj/structure/closet/crate/large,
+/obj/item/circuitboard/machine/protolathe,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"ojq" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/bunker)
+"oiy" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"oiA" = (
+/obj/structure/table,
+/obj/item/storage/backpack/enclave{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/storage/backpack/enclave{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"okh" = (
+/obj/structure/chalkboard,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/followers)
 "okm" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/junglebush/b,
@@ -16847,6 +17266,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/enclave)
+"olw" = (
+/obj/structure/chair/f13chair1{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/followers)
 "olK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16866,6 +17293,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"omh" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Private Bar"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "omk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -16881,29 +17315,25 @@
 	},
 /area/f13/brotherhood/rnd)
 "omq" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/glass/beaker/plastic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "omL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"omU" = (
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"onb" = (
+/obj/machinery/door/poddoor/preopen{
+	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70);
+	id = eairlock
+	},
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "bluemark"
+	},
 /area/f13/bunker)
 "onL" = (
 /obj/structure/cable{
@@ -16914,13 +17344,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"onS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/water,
-/area/f13/caves)
 "onY" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -16962,6 +17385,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"opH" = (
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
+"oqN" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/caves)
 "orc" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
@@ -16970,18 +17405,17 @@
 	},
 /area/f13/tunnel)
 "org" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/chem_pile{
-	pixel_x = -19
-	},
-/obj/structure/chair/office/dark{
+/obj/item/storage/trash_stack,
+/obj/machinery/light/broken{
 	dir = 1
 	},
-/obj/effect/landmark/start/f13/followersadministrator,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/tunnel)
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"oro" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "orp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16992,6 +17426,10 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"orB" = (
+/obj/structure/closet/crate/large,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "orM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -17028,41 +17466,12 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
-"otk" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "otF" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"otJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/girder/reinforced,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"ouh" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier2,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "ouq" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -17072,9 +17481,8 @@
 	},
 /area/f13/enclave)
 "ouz" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/supermart,
-/area/f13/tunnel)
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "ovr" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -17082,12 +17490,32 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"ovF" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
+"ovy" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron{
+	aggro_vision_range = 30;
+	desc = "A prototype assaultron with (visibly) upgraded leg motors and hydraulics. It's painted in Enclave markings.";
+	dir = 4;
+	health = 1500;
+	maxHealth = 1500;
+	name = "PCU-11";
+	speed = -0.5
 	},
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"ovA" = (
+/obj/structure/simple_door/metal/barred,
+/obj/structure/simple_door/metal/barred,
+/turf/open/water,
+/area/f13/tunnel)
+"ovE" = (
+/obj/structure/simple_door/metal/barred,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "topcellghoul"
+	},
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "ovL" = (
 /obj/structure/simple_door/bunker{
 	name = "Washroom/Dorms"
@@ -17100,6 +17528,43 @@
 /obj/structure/flora/junglebush,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"ovY" = (
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
+	},
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/followers)
 "owa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -17123,6 +17588,11 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"owU" = (
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/tunnel)
 "owX" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
@@ -17130,15 +17600,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
-"oxm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/item/book/granter/trait/trekking,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
 "oxw" = (
 /obj/structure/table/wood/fancy/blackred,
 /obj/item/candle{
@@ -17153,6 +17614,13 @@
 	},
 /turf/open/floor/mineral/plastitanium/airless,
 /area/f13/brotherhood/rnd)
+"oxI" = (
+/obj/structure/junk/small/bed2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "oyk" = (
 /obj/structure/table{
 	layer = 2.9
@@ -17164,64 +17632,43 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"oyo" = (
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 8;
-	name = "light fixture"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"oyr" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Private Bar"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "oyG" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"ozp" = (
-/obj/structure/billboard/cola/pristine,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"ozN" = (
-/obj/structure/girder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"oAe" = (
-/obj/machinery/light/small{
-	dir = 4
+"ozm" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
 	},
-/obj/effect/landmark/start/f13/prospector,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"oAm" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
+"ozp" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"ozN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder/reinforced,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "oAt" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"oBa" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
-"oBz" = (
-/obj/structure/junk/small/bed2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "oBJ" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -17250,30 +17697,28 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
+"oCH" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper/crumpled/bloody/docsdeathnote{
+	info = "Initial tests of the modified FEV on our subjects is promising, with an increase in strength and indurance and no notable decrease in intelligence. Further testin is require for now, however, and tests with the soldiers can begin soon...."
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "oDf" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"oDN" = (
-/mob/living/simple_animal/hostile/raider/tribal,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib5-old"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"oDY" = (
-/obj/structure/barricade/wooden,
-/obj/item/pickaxe{
-	anchored = 1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"oEi" = (
+"oEf" = (
+/mob/living/simple_animal/hostile/handy/protectron,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/wasteplant/wild_fungus,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "oEt" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/spacevine{
@@ -17281,11 +17726,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"oEw" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "oEC" = (
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/f13{
@@ -17315,14 +17755,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"oFg" = (
+/turf/closed/wall/f13/supermart,
+/area/f13/followers)
 "oFh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	pixel_x = -6
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "oFi" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/f13{
@@ -17349,12 +17788,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
-"oGk" = (
-/obj/structure/fluff/oldturret,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "oGA" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -17388,13 +17821,9 @@
 	},
 /area/f13/brotherhood/mining)
 "oIo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Pink{
-	dir = 4;
-	name = "light tube"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/item/ammo_casing/shotgun/improvised,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "oIJ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -17416,40 +17845,22 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "oJc" = (
-/obj/machinery/smartfridge/chemistry,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"oKH" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"oLu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor2"
-	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"oJB" = (
+/obj/machinery/light/small,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/bunker)
-"oLG" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
+/area/f13/followers)
+"oJO" = (
+/obj/structure/barricade/bars{
+	layer = 5
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 25
-	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 25
-	},
-/obj/item/storage/box/strange_seeds_10pack,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "oMb" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibleg"
@@ -17488,35 +17899,19 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
-"oOh" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"oOm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/obj/item/fermichem/pHmeter,
-/obj/item/storage/bag/chemistry,
-/obj/item/fermichem/pHmeter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "oOE" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"oOO" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "oOR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/followersdoctor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "oPp" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -17540,13 +17935,7 @@
 /turf/open/floor/carpet/red,
 /area/f13/brotherhood/offices2nd)
 "oQa" = (
-/obj/effect/landmark/start/f13/followersvolunteer,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"oQd" = (
-/obj/machinery/door/poddoor{
-	id = "pain"
-	},
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "oQf" = (
@@ -17568,6 +17957,12 @@
 	},
 /turf/closed/wall/f13/store,
 /area/f13/ncr)
+"oQp" = (
+/obj/item/chair,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "oQP" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13/wood{
@@ -17582,12 +17977,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "oRb" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "133"
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"oRf" = (
+/obj/machinery/autolathe,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/followers)
 "oRZ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -17613,12 +18012,6 @@
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"oSG" = (
-/obj/structure/barricade/bars,
-/obj/structure/table,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "oSZ" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
@@ -17628,18 +18021,20 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"oTR" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore";
-	tag = "icon-gibbearcore"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"oUg" = (
+"oTw" = (
+/obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"oUA" = (
+/obj/structure/sink{
+	pixel_y = 19
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "oUK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -17650,10 +18045,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
-"oUM" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/water,
-/area/f13/bunker)
 "oUO" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13{
@@ -17672,6 +18063,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
+"oVe" = (
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/followers)
 "oVh" = (
 /turf/closed/wall/r_wall/f13composite{
 	icon_state = "rubblepillar"
@@ -17739,12 +18135,17 @@
 	},
 /area/f13/enclave)
 "oXs" = (
-/obj/structure/bodycontainer/morgue{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
+"oXu" = (
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oXD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/wallmed{
@@ -17755,6 +18156,10 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"oYk" = (
+/obj/machinery/light,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "oYG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/dark{
@@ -17775,26 +18180,32 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
-"oZe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "oZF" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Oasis Housing";
-	req_one_access_txt = "25"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old";
+	tag = "icon-gib5-old"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"oZJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "pab" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/revolver{
-	pixel_y = 32
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/splats,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"paD" = (
+/obj/item/fusion_fuel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/area/f13/bunker)
 "paF" = (
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
@@ -17813,6 +18224,16 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
+"paI" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/plastic/five,
+/obj/item/stack/sheet/plastic/five,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "paO" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -17822,11 +18243,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"pbp" = (
-/obj/structure/dresser,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "pbr" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/decal/cleanable/dirt,
@@ -17834,28 +18250,20 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"pbu" = (
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/handy/protectron/nsb,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"pcK" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bottle/mutagen,
-/obj/effect/decal/cleanable/dirt,
+"pcw" = (
+/obj/structure/ore_box,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"pcY" = (
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13{
-	icon_state = "bluerustyfull"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "pdh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/pinup_shower{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/raider/legendary,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "pdz" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -17883,13 +18291,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"pdV" = (
-/mob/living/simple_animal/hostile/handy/protectron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "pez" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -17899,6 +18300,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
+"peF" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "peK" = (
 /obj/structure/fluff/railing{
 	dir = 1
@@ -17908,6 +18313,19 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"peZ" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
+"pfm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "pfv" = (
 /obj/structure/fluff/railing{
 	dir = 5
@@ -17940,17 +18358,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"pho" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/raider/baseball,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"phq" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "phA" = (
 /obj/structure/sign/warning,
 /obj/structure/timeddoor,
@@ -17968,22 +18375,17 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"phP" = (
-/obj/structure/chair/stool/retro,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"pip" = (
-/obj/structure/table/snooker{
-	dir = 6
-	},
+"phL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/dice{
-	pixel_x = 13;
-	pixel_y = -7
-	},
-/obj/item/dice,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/simple_door/metal/barred,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"phP" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/mob/living/simple_animal/hostile/raider/ranged/legendary,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "pis" = (
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
@@ -18010,28 +18412,14 @@
 	},
 /area/f13/brotherhood/mining)
 "pjj" = (
-/obj/structure/table/snooker{
-	dir = 10
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"pkv" = (
-/mob/living/simple_animal/hostile/handy/protectron,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
 	},
+/turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
-"pkH" = (
-/obj/structure/chair/stool/retro,
-/obj/item/instrument/guitar{
-	anchored = 1;
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "pkL" = (
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
@@ -18053,13 +18441,10 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"plF" = (
-/obj/structure/girder,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+"plN" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
 	},
 /area/f13/tunnel)
 "plQ" = (
@@ -18073,10 +18458,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"pmU" = (
-/mob/living/simple_animal/hostile/radscorpion/black,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "pmV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
@@ -18089,6 +18470,10 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"pmZ" = (
+/obj/item/clothing/suit/radiation,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "pnd" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light{
@@ -18098,18 +18483,9 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"pnI" = (
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
 "pnL" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "pnV" = (
 /obj/structure/rack,
@@ -18140,10 +18516,11 @@
 /obj/structure/barricade/wooden/planks,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/tunnel)
-"poJ" = (
-/obj/structure/girder/reinforced,
+"poI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "ppt" = (
@@ -18173,13 +18550,15 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"pqz" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "redmark"
+"pqR" = (
+/obj/structure/sink{
+	pixel_y = 19
 	},
-/area/f13/bunker)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/tunnel)
 "pqV" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -18190,6 +18569,40 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
+"pqY" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/storage/belt/medical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"pra" = (
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/o2,
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
+"prM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"psp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "psA" = (
 /obj/structure/lattice{
 	layer = 3
@@ -18278,12 +18691,25 @@
 	},
 /area/f13/bunker)
 "pvI" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/flashlight/lantern,
-/obj/item/mining_scanner,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/nsb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"pvV" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"pwC" = (
+/obj/structure/table,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "pwH" = (
 /obj/effect/decal/remains/human,
@@ -18292,13 +18718,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"pwR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/bunker)
 "pwY" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -18318,6 +18737,13 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
+"pxX" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	dir = 6;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
 "pym" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -18328,6 +18754,16 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"pyB" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"pzu" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "pzw" = (
 /obj/structure/table{
 	layer = 2.9
@@ -18378,10 +18814,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"pAI" = (
-/obj/item/pickaxe/mini,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
 "pAK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -18403,6 +18835,20 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"pBJ" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/stack/f13Cash/random/med,
+/obj/machinery/light/fo13colored/Aqua{
+	bulb_colour = "#800080";
+	dir = 4;
+	light_color = "#800080";
+	name = "light fixture"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "pCg" = (
 /obj/effect/spawner/lootdrop/f13/armor/random_high,
 /obj/structure/closet,
@@ -18410,13 +18856,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "pCn" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/flashlight/lantern,
-/obj/item/mining_scanner,
-/obj/item/pickaxe/drill,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"pCt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/workbench/forge,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "pDM" = (
 /obj/structure/flora/junglebush,
@@ -18432,6 +18882,19 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
+"pEm" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "followerladder"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
 "pEF" = (
 /obj/item/instrument/harmonica,
 /obj/structure/rack,
@@ -18447,13 +18910,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
-"pFb" = (
+"pEZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/generic,
-/mob/living/simple_animal/hostile/handy/gutsy/nsb,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "pFn" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/decal/cleanable/dirt,
@@ -18461,19 +18926,46 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
-"pGw" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/flashlight/lantern,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"pGc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/caves)
+"pGg" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"pGw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"pGK" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"pGS" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pHv" = (
 /obj/machinery/telecomms/server/presets/enclave,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"pHw" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"pHQ" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "pIg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -18522,6 +19014,30 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"pKf" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/mutagen,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/f13/bunker)
+"pKo" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greendirtysolid"
+	},
+/area/f13/tunnel)
+"pKp" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Bar Backroom";
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "pLl" = (
 /obj/machinery/ore_silo,
 /obj/effect/decal/cleanable/dirt,
@@ -18544,25 +19060,11 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "pMg" = (
-/obj/machinery/button/door{
-	id = "prospector3open";
-	name = "gate shutters";
-	pixel_x = 32
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/turf/open/water,
-/area/f13/tunnel)
-"pMj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/obj/item/toy/plush/mr_buckety,
-/obj/item/reagent_containers/glass/bucket,
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -15
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "pMM" = (
 /obj/structure/table/optable/abductor,
@@ -18573,6 +19075,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"pMU" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "pNi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -18593,39 +19099,11 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"pOm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "pOB" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"pPj" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"pPr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/water,
-/area/f13/bunker)
-"pPs" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor7-old"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "pPS" = (
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/glass/fifty,
@@ -18639,6 +19117,17 @@
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"pQt" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
+	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
+	name = "strange meat"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "pQx" = (
 /obj/item/flag/ncr,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -18696,6 +19185,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"pSE" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
+"pVq" = (
+/obj/structure/curtain,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/tunnel)
 "pVA" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -18713,15 +19216,15 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"pVW" = (
-/obj/structure/closet/crate/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+"pVP" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
 	},
-/area/f13/bunker)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "pWc" = (
 /obj/machinery/light/sign{
 	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
@@ -18783,6 +19286,22 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
+"pXC" = (
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/followers)
+"pXO" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "pYd" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/rust,
@@ -18799,25 +19318,25 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "pYA" = (
-/obj/machinery/mineral/equipment_vendor,
+/mob/living/simple_animal/hostile/handy/sentrybot/nsb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"pYE" = (
-/obj/structure/closet/crate/large,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"pZm" = (
-/obj/structure/girder/reinforced,
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "pZr" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/ruins,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/item/gun/ballistic/automatic/pistol/pistol127/compact,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"pZt" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qaX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/handrail/g_central{
@@ -18826,16 +19345,10 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"qbi" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
+"qbC" = (
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "qbZ" = (
 /obj/structure/rack,
 /obj/item/electropack/shockcollar{
@@ -18851,12 +19364,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"qcb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/mob_spawn/human/corpse/raider/tribal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "qci" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile/house{
@@ -18875,9 +19382,30 @@
 	},
 /area/f13/tunnel)
 "qcp" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/followers)
+"qcq" = (
+/obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"qcN" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qdj" = (
 /obj/structure/table/wood/fancy/black,
@@ -18889,10 +19417,22 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
-"qdZ" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/floor/f13/wood,
+"qdm" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
 /area/f13/tunnel)
+"qdE" = (
+/obj/structure/billboard/cola/pristine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"qdZ" = (
+/obj/structure/table,
+/obj/item/storage/belt/utility/full,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/followers)
 "qeh" = (
 /obj/structure/table{
 	layer = 2.9
@@ -18927,15 +19467,11 @@
 	},
 /area/f13/brotherhood/mining)
 "qez" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "qeH" = (
 /obj/effect/mine/stun,
 /turf/open/floor/f13{
@@ -18962,21 +19498,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
-"qfA" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
-	faction = list("raider");
-	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
-	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
-	name = "Repaired Turret";
-	scan_range = 9;
-	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
-	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
-	throw_range = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "qfB" = (
 /obj/machinery/rnd/production/protolathe,
 /obj/effect/decal/cleanable/dirt,
@@ -18984,6 +19505,14 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"qfC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/obj/item/fermichem/pHmeter,
+/obj/item/storage/bag/chemistry,
+/obj/item/fermichem/pHmeter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "qgC" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -19003,14 +19532,15 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "qgP" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "qhk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/followersscientist,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "qhm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -19030,11 +19560,16 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
-"qiA" = (
-/obj/machinery/door/window,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+"qhB" = (
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/splats,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"qhW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/shotgun/improvised,
+/turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "qiH" = (
 /obj/item/trash/f13/fancylads,
@@ -19044,22 +19579,32 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"qjd" = (
+/obj/structure/chair/f13chair1,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/followers)
+"qjp" = (
+/obj/structure/closet/crate/large,
+/obj/item/storage/box/stockparts/basic,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "qjs" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/decal/fakelattice,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/obj/structure/closet,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/storage/belt/medical,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "qju" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "qjT" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19080,10 +19625,18 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "qmV" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/generic,
-/obj/structure/curtain,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/machinery/chem_heater,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
+"qmY" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "gatehouseladder"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "qmZ" = (
 /obj/structure/bookcase/random/reference,
@@ -19109,6 +19662,11 @@
 /area/f13/tunnel)
 "qoi" = (
 /obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"qoB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qoF" = (
@@ -19153,39 +19711,45 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "qpe" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/floor/plating/tunnel,
-/area/f13/tunnel)
-"qpG" = (
-/obj/structure/closet/cabinet,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"qpI" = (
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 8;
-	name = "light fixture"
+/obj/machinery/button/door{
+	id = "hell";
+	name = "Door Control"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/structure/table/reinforced,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"qpG" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old";
+	tag = "icon-floor6-old"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"qpI" = (
+/obj/machinery/gibber,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "qpX" = (
 /obj/structure/flora/rock/jungle,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "qpY" = (
-/obj/structure/table/snooker{
-	dir = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "qqm" = (
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
+/area/f13/tunnel)
+"qqD" = (
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qqJ" = (
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -19201,12 +19765,6 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
-"qrc" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "qrJ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -19220,13 +19778,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
-"qrK" = (
-/obj/structure/junk/small/bed2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "qsa" = (
 /obj/structure/flora/rock/jungle,
 /obj/structure/spacevine{
@@ -19234,14 +19785,8 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"qsg" = (
-/obj/structure/table/snooker{
-	dir = 9
-	},
-/obj/item/toy/cards/deck{
-	pixel_x = -11;
-	pixel_y = 15
-	},
+"qsb" = (
+/obj/structure/bed/mattress,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qsm" = (
@@ -19252,6 +19797,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"qsr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "qsM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -19295,6 +19848,17 @@
 /turf/open/floor/carpet/black,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
+"qtN" = (
+/obj/item/clothing/head/helmet/f13/power_armor/t45b,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
+"qtQ" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "quB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/statuebust{
@@ -19305,15 +19869,14 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/medical)
-"quL" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
+"quQ" = (
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/prewar/poster79{
+	pixel_y = -32
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "quR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/ore_box,
@@ -19322,10 +19885,10 @@
 	},
 /area/f13/brotherhood/mining)
 "qvI" = (
-/obj/structure/chair/stool/retro,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/followers)
 "qvX" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -19333,30 +19896,26 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"qwy" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "qwP" = (
-/obj/structure/barricade/bars,
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "malice";
+	name = "Door Control"
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/tunnel)
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"qwR" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall/rust,
+/area/f13/caves)
 "qwV" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "prospector3open"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/tunnel)
+/obj/structure/sign/poster/prewar/poster91,
+/turf/closed/wall/f13/supermart,
+/area/f13/followers)
+"qxk" = (
+/obj/item/chair,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "qxo" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/decal/cleanable/dirt,
@@ -19364,40 +19923,23 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
-"qxv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate{
-	anchored = 1;
-	can_be_unanchored = 1
-	},
-/obj/item/autosurgeon,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/item/clothing/head/helmet/f13/power_armor/t45d{
-	color = "#C1C1C1";
-	desc = "(IX) It's an old pre-War power armor helmet. It's pretty hot inside of it. Nice.";
-	item_color = "#C1C1C1"
-	},
-/obj/item/defibrillator/compact/combat/loaded,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "qxO" = (
 /obj/machinery/telecomms/server/presets/ncr,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "qyc" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Oasis";
-	req_one_access_txt = "25"
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"qyj" = (
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "qys" = (
 /obj/structure/chair/comfy/shuttle{
@@ -19413,41 +19955,26 @@
 /area/f13/brotherhood/offices1st)
 "qyC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"qyI" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Town Forge";
-	req_one_access_txt = "25"
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul,
+/obj/item/pizzabox/meat,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"qyL" = (
+/obj/structure/sign/poster/ripped{
+	pixel_x = 32
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qyW" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "133"
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "clinicstorage";
-	name = "storage shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"qzG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/folder/white,
-/obj/item/folder/white,
-/obj/item/folder/white,
-/obj/item/folder/white,
-/obj/item/flashlight/pen,
-/obj/item/flashlight/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "qzI" = (
 /turf/closed/wall/r_wall,
 /area/f13/tcoms)
@@ -19459,16 +19986,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qAK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark{
-	dir = 8
+/mob/living/simple_animal/hostile/handy/protectron/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"qAP" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"qBn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/plating/tunnel,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"qBi" = (
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "qBQ" = (
 /obj/effect/landmark/start/f13/elder,
@@ -19485,18 +20016,33 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"qDc" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "qDo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/deathclaw,
+/turf/open/water,
+/area/f13/caves)
 "qDR" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"qEf" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
 "qEg" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19522,8 +20068,16 @@
 	},
 /area/f13/brotherhood/rnd)
 "qFn" = (
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"qFM" = (
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "qFP" = (
 /obj/machinery/status_display,
@@ -19543,13 +20097,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"qFX" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
 "qGe" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/effect/decal/cleanable/dirt,
@@ -19583,17 +20130,9 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
-"qGS" = (
-/obj/effect/decal/waste,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
 "qHc" = (
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "qHd" = (
 /obj/structure/mopbucket,
@@ -19609,15 +20148,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"qHx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibup1"
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "qHZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -19626,11 +20156,6 @@
 	icon_state = "neutralrusty"
 	},
 /area/f13/tunnel)
-"qIw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "qIB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fence/handrail{
@@ -19643,6 +20168,14 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"qJb" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/ore_box,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "qJc" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -19652,18 +20185,19 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
-"qJL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/bodybags,
-/obj/structure/table,
-/obj/item/stack/sheet/cardboard/twenty,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "qJM" = (
-/obj/machinery/smartfridge/organ,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/machinery/door/poddoor{
+	id = "malice"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "qJQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains{
@@ -19673,11 +20207,23 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"qLf" = (
+"qKE" = (
 /obj/structure/barricade/wooden,
-/obj/structure/curtain,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"qLf" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"qLm" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "qLo" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -19692,15 +20238,6 @@
 "qLD" = (
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"qLE" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/machinery/door/poddoor{
-	id = "pain"
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "qMm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19715,12 +20252,25 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"qMs" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_east_middle"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "qME" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"qMG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "qMO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -19743,6 +20293,12 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"qNh" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "qNn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -19754,6 +20310,11 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
+"qNr" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "qNx" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/f13/wood{
@@ -19770,6 +20331,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"qOc" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qOD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -19797,6 +20362,10 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"qOQ" = (
+/obj/structure/flora/wasteplant/wild_fungus,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qPh" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/f13{
@@ -19830,6 +20399,15 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
+"qPZ" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "qQF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -19885,51 +20463,48 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
-"qRG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+"qSt" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"qSf" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
-"qSZ" = (
-/obj/machinery/door/keycard{
-	puzzle_id = "library"
-	},
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"qSL" = (
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "qTb" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"qTL" = (
+"qTw" = (
+/obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/waste{
-	icon_state = "goo10"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"qTY" = (
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"qUh" = (
+/obj/structure/frame/machine,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"qUn" = (
-/obj/structure/nest/ghoul,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
-/area/f13/sewer)
+/area/f13/bunker)
 "qUw" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "qUx" = (
-/obj/structure/chair/bench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "qUL" = (
 /obj/structure/lattice{
 	density = 1
@@ -19937,6 +20512,12 @@
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"qUO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "qUR" = (
 /obj/structure/lattice{
 	density = 1
@@ -19966,6 +20547,14 @@
 /obj/structure/timeddoor,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"qVk" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "qVt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -19981,9 +20570,13 @@
 	},
 /area/f13/brotherhood/rnd)
 "qVG" = (
-/obj/effect/landmark/start/f13/followersguard,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/securitron/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "qWa" = (
 /obj/structure/fence/handrail_end/non_dense{
 	pixel_x = -16;
@@ -19995,21 +20588,27 @@
 	},
 /area/f13/brotherhood/rnd)
 "qWm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "clinicstorage";
-	name = "shutters button";
-	pixel_x = 32
-	},
-/obj/machinery/vending/medical,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "qWx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
+"qWR" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"qXd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "qXo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -20017,18 +20616,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"qXq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
 "qXr" = (
-/obj/structure/table/wood,
-/obj/item/chair/stool,
-/obj/item/chair/stool,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "qXN" = (
 /obj/structure/barricade/bars,
 /obj/structure/window/fulltile/store,
@@ -20036,6 +20630,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices1st)
+"qYq" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "qYA" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/cigarettes/cigars/havana{
@@ -20047,6 +20646,19 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
+"qYK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"qYL" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "qYS" = (
 /obj/structure/fence/handrail_end/non_dense{
 	pixel_x = -16;
@@ -20056,6 +20668,9 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"qZq" = (
+/turf/closed/wall/f13/ruins,
+/area/f13/caves)
 "qZt" = (
 /obj/structure/lattice{
 	density = 1
@@ -20074,15 +20689,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
-"qZB" = (
-/obj/effect/decal/fakelattice,
-/obj/item/storage/toolbox/emergency/old,
-/obj/item/storage/toolbox/emergency/old,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "qZY" = (
 /obj/machinery/autolathe/ammo,
 /obj/machinery/light/small{
@@ -20107,39 +20713,89 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rbg" = (
-/obj/structure/table/snooker{
-	dir = 6
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"rbo" = (
-/obj/structure/table/snooker{
-	dir = 10
-	},
-/obj/item/melee/baseball_bat{
-	pixel_x = -7;
-	pixel_y = -8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "rbt" = (
-/obj/structure/simple_door/metal/barred,
-/obj/structure/simple_door/metal/barred,
-/turf/open/water,
-/area/f13/tunnel)
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "rbE" = (
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "rca" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "rce" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood,
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rcf" = (
+/obj/item/trash/f13/yumyum,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"rcv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 1;
+	icon_state = "neutralrusty"
+	},
+/area/f13/tunnel)
+"rcL" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housebase"
+	},
+/area/f13/tunnel)
+"rcU" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/tunnel)
+"rdq" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/geiger_counter,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
+"rdE" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/stage_tl,
+/area/f13/tunnel)
+"rer" = (
 /obj/structure/decoration/vent{
 	pixel_x = -7;
 	pixel_y = -3
@@ -20157,53 +20813,13 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/tunnel)
-"rcv" = (
+"reu" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 1;
-	icon_state = "neutralrusty"
-	},
-/area/f13/tunnel)
-"rcL" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housebase"
-	},
-/area/f13/tunnel)
-"rcM" = (
-/obj/structure/junk/small/bed2,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
-"rcU" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/tunnel)
-"rde" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/f13/yumyum,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"rdM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
-"rei" = (
-/mob/living/simple_animal/hostile/stalker,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "rex" = (
 /turf/closed/indestructible/rock,
@@ -20218,13 +20834,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
-"rfo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "rfs" = (
 /obj/machinery/light{
 	dir = 1
@@ -20242,13 +20851,11 @@
 	},
 /area/f13/brotherhood/mining)
 "rfH" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "clinicladder"
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "rgt" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
@@ -20270,23 +20877,14 @@
 /obj/structure/table,
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"rha" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "malice";
-	name = "Door Control"
+"rhv" = (
+/obj/structure/table,
+/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
-"rhn" = (
-/obj/machinery/power/tesla_coil/research{
-	desc = "A modified military-grade tesla coil constantly exchanging energy throughout. It looks to be recently used.";
-	name = "tesla charge inducer"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/bunker)
+/area/f13/tunnel)
 "rhP" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_cannabis,
@@ -20311,6 +20909,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"riI" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
 "riR" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -20326,34 +20930,40 @@
 	},
 /area/f13/brotherhood/mining)
 "riT" = (
-/obj/machinery/light{
+/obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"rjn" = (
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "rjq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 8;
-	name = "light fixture"
+/obj/effect/mob_spawn/human/corpse/raider,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"rjs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/kitchenspike,
-/obj/effect/mob_spawn/human/corpse/raidermelee,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"rjx" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
 "rjz" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "rjG" = (
-/obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/deathclaw/mother{
+	speed = -1.5
+	},
+/turf/open/water,
+/area/f13/caves)
 "rjQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -20362,6 +20972,19 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"rjR" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/followers)
+"rjT" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "rkH" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
@@ -20379,16 +21002,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"rmb" = (
+"rln" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate{
-	anchored = 1;
-	can_be_unanchored = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/item/gun/ballistic/automatic/pistol/pistol127/compact,
+/obj/effect/decal/cleanable/blood,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rmf" = (
@@ -20421,10 +21038,19 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"rog" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"ros" = (
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"roS" = (
+/obj/item/storage/trash_stack{
+	layer = 2
+	},
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 1;
+	name = "light fixture"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "rpI" = (
 /obj/structure/chair/right,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -20433,17 +21059,42 @@
 	},
 /area/f13/tunnel)
 "rqc" = (
-/obj/structure/table/snooker{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "rqF" = (
-/obj/structure/table/snooker{
-	dir = 9
+/obj/machinery/light/small{
+	dir = 1
 	},
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/tunnel)
+"rrc" = (
+/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/ore/blackpowder/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rrh" = (
@@ -20454,17 +21105,15 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "rrm" = (
-/obj/structure/chair/stool/retro,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/prewar/poster79{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "rrq" = (
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rrE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -20474,14 +21123,22 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"rrQ" = (
-/mob/living/simple_animal/hostile/handy/protectron/nsb,
+"rsa" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"rsf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/mob_spawn/human/corpse/raider/tribal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"rsf" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "rsj" = (
 /obj/structure/table{
 	layer = 2.9
@@ -20504,6 +21161,11 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"rsB" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/sentrybot/nsb/riot,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rsM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
@@ -20520,6 +21182,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/rnd)
+"rsQ" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rtf" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -20535,21 +21201,24 @@
 	icon_state = "rubblepillar"
 	},
 /area/f13/tunnel)
+"rtO" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rtX" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "run" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/handy/securitron/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rux" = (
-/obj/structure/curtain,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/girder/reinforced,
+/turf/open/water,
+/area/f13/caves)
 "ruX" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -20577,6 +21246,19 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"rvA" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"rvI" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/f13/supermart,
+/area/f13/followers)
+"rwb" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rwf" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue{
@@ -20604,11 +21286,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"rwI" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
 "rwQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
@@ -20617,10 +21294,22 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"rxd" = (
+/obj/structure/table/wood,
+/obj/item/clothing/glasses/heat,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "rxi" = (
 /obj/machinery/computer/rdconsole,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
+"rxo" = (
+/obj/structure/chair/stool/retro,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "rxG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20634,6 +21323,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"ryk" = (
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "ryy" = (
 /obj/structure/lattice{
 	density = 1
@@ -20700,6 +21395,14 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
+"rAn" = (
+/obj/effect/decal/waste,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "rAo" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -20707,44 +21410,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"rAs" = (
-/obj/structure/closet,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "rAt" = (
 /turf/open/floor/circuit/f13_red,
 /area/f13/brotherhood/rnd)
 "rAx" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/tunnel)
-"rBa" = (
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"rBn" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rBS" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/timeddoor,
@@ -20759,49 +21431,16 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
-"rBX" = (
-/mob/living/simple_animal/hostile/handy/gutsy,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "rCv" = (
-/obj/item/defibrillator/loaded,
-/obj/item/storage/box/syringes,
-/obj/item/cane,
-/obj/item/soap,
-/obj/effect/turf_decal/box/white,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/defibrillator/loaded,
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/gloves,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"rCV" = (
-/obj/structure/closet/crate,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rDc" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"rDn" = (
-/obj/item/clothing/head/radiation,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "rDr" = (
 /obj/machinery/light{
 	dir = 1
@@ -20827,6 +21466,10 @@
 /obj/structure/glowshroom/single,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"rEp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/tunnel)
 "rFc" = (
 /obj/structure/lattice{
 	density = 1
@@ -20860,6 +21503,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"rFQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/human/corpse,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rFR" = (
 /obj/machinery/light{
 	dir = 4
@@ -20868,40 +21518,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"rGn" = (
-/obj/structure/closet/crate/large,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/unique,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/armor/tier2,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"rHL" = (
-/obj/item/storage/firstaid/ancient,
-/obj/item/storage/firstaid/ancient,
-/obj/item/storage/firstaid/ancient,
-/obj/effect/turf_decal/box/white,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/silver_sulf,
-/obj/item/reagent_containers/medspray/silver_sulf,
-/obj/item/reagent_containers/medspray/styptic,
-/obj/item/reagent_containers/medspray/styptic,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/storage/pill_bottle/chem_tin/fixer,
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/storage/pill_bottle/mannitol,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+"rGw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rHV" = (
 /obj/structure/table{
 	layer = 2.9
@@ -20922,13 +21543,6 @@
 /obj/machinery/newscaster,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
-"rIA" = (
-/obj/structure/reagent_dispensers/barrel/explosive,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "rIL" = (
 /obj/structure/table/greyscale,
 /obj/item/book/granter/trait/lowsurgery,
@@ -21011,6 +21625,16 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"rKp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/paper/crumpled/bloody/docsdeathnote{
+	info = "it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns "
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "rKx" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
@@ -21093,12 +21717,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
-"rMc" = (
-/obj/structure/destructible/tribal_torch/lit,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "rMk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -21108,15 +21726,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"rMp" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/box/white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"rMG" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "rNi" = (
 /obj/structure/window/reinforced/spawner{
 	color = "#777777";
@@ -21140,14 +21749,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"rNs" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider/baseball,
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "rOb" = (
 /obj/structure/flora/junglebush/b,
 /turf/closed/mineral/random/low_chance,
@@ -21169,20 +21770,6 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"rOO" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"rOZ" = (
-/obj/structure/barricade/bars,
-/obj/structure/barricade/bars,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "rPi" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -21216,6 +21803,13 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"rQe" = (
+/obj/item/stack/cable_coil/random/five,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "rQA" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13{
@@ -21230,6 +21824,21 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/sewer)
+"rQY" = (
+/obj/item/wirecutters/basic,
+/obj/item/screwdriver/crude,
+/obj/structure/table/wood,
+/obj/item/storage/box/handcuffs,
+/obj/item/lock_construct,
+/obj/item/key,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/stack/f13Cash/random/med,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "rRQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -21240,16 +21849,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"rRT" = (
-/mob/living/simple_animal/hostile/raider/firefighter,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
-	},
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "rSw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -21262,12 +21861,9 @@
 	},
 /area/f13/caves)
 "rTh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/prewar/poster69{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/structure/decoration/warning,
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "rTI" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -21314,18 +21910,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"rWl" = (
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
+"rWP" = (
+/obj/structure/chair/office{
+	dir = 8
 	},
-/area/f13/bunker)
-"rWG" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "rWY" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
@@ -21337,9 +21928,9 @@
 	},
 /area/f13/tunnel)
 "rXg" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/mob/living/simple_animal/hostile/stalker,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/tunnel)
 "rXl" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/rock/pile/largejungle,
@@ -21354,9 +21945,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rXS" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood,
+/obj/item/trash/f13/yumyum,
+/obj/effect/mob_spawn/human/corpse/raider,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"rZq" = (
+/obj/structure/table/snooker{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rZw" = (
 /mob/living/simple_animal/hostile/radroach,
@@ -21368,10 +21970,12 @@
 /area/f13/tunnel)
 "rZZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/chair/f13chair2,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "sam" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -21400,23 +22004,25 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/tunnel)
+"sba" = (
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/followers)
 "sbj" = (
 /obj/structure/flora/junglebush/large,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"sbl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/chair,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
+"sbZ" = (
+/obj/machinery/door/poddoor{
+	name = "bunker door"
 	},
-/area/f13/bunker)
-"sbY" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
 	},
-/area/f13/bunker)
+/area/f13/tunnel)
 "scG" = (
 /obj/structure/spider/stickyweb,
 /mob/living/simple_animal/hostile/poison/giant_spider,
@@ -21428,21 +22034,21 @@
 /area/f13/brotherhood/offices2nd)
 "sdI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/chair/f13chair2,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "sdJ" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
 /area/f13/caves)
-"sdN" = (
-/obj/effect/decal/remains/human{
-	name = "Remains of a ranger"
-	},
-/obj/item/clothing/head/helmet/f13/ncr/rangercombat/desert,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "sef" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/rock/jungle,
@@ -21482,11 +22088,10 @@
 	},
 /area/f13/bunker)
 "sfm" = (
-/obj/structure/sign/poster/contraband/pinup_funk{
-	pixel_y = -32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "sfu" = (
 /obj/machinery/light{
 	dir = 8
@@ -21506,9 +22111,11 @@
 	},
 /area/f13/tunnel)
 "sfI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/supermart,
-/area/f13/tunnel)
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "sgd" = (
 /obj/effect/decal/cleanable/blood/innards,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -21527,16 +22134,20 @@
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"sgv" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "sgI" = (
 /obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"sgL" = (
-/obj/structure/barricade/bars,
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "shc" = (
 /obj/structure/simple_door/bunker{
 	name = "Star Paladin Office";
@@ -21553,11 +22164,9 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "shF" = (
-/obj/structure/curtain{
-	open = 0
-	},
+/obj/structure/chair/f13chair2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "shO" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/junglebush/b,
@@ -21565,8 +22174,18 @@
 /area/f13/caves)
 "sic" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood,
-/area/f13/tunnel)
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/item/reagent_containers/food/snacks/f13/deathclawomelette,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "sie" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -21583,19 +22202,43 @@
 	},
 /area/f13/clinic)
 "siK" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "cornerladder"
+/obj/machinery/door/airlock/grunge,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/machinery/door/poddoor{
+	id = "hell"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"siP" = (
+/obj/structure/table,
+/obj/item/pen,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/followers)
+"sjg" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	max_integrity = 500;
+	name = "Store Backroom";
+	req_one_access_txt = "34"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"siP" = (
+"sji" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
-	name = "Bar Backroom";
+	name = "Oasis Housing";
 	req_one_access_txt = "25"
 	},
-/turf/open/floor/f13/wood,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Oasis Housing";
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "sjA" = (
 /obj/structure/flora/junglebush,
@@ -21607,9 +22250,12 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "ska" = (
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/caves)
 "skG" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
@@ -21666,10 +22312,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "smm" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/water,
+/area/f13/caves)
 "smq" = (
 /obj/structure/table{
 	layer = 2.9
@@ -21682,42 +22329,56 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"smu" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	name = "microwave"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
 "smy" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
-"sne" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+"smG" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "snf" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
-"snF" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+"snr" = (
+/obj/structure/closet/crate/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
+"snG" = (
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/stripes/end,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/tunnel)
 "snP" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"sop" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "sor" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -21741,15 +22402,6 @@
 /obj/effect/decal/cleanable/blood/innards,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"srd" = (
-/mob/living/simple_animal/hostile/handy/sentrybot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
-"srz" = (
-/mob/living/simple_animal/hostile/ghoul/glowing,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "srD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -21765,6 +22417,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ssQ" = (
+/obj/effect/mob_spawn/human/corpse,
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "stt" = (
 /obj/structure/sink{
 	dir = 4;
@@ -21787,23 +22444,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
-"suB" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"suJ" = (
-/obj/item/trash/f13/yumyum,
-/obj/effect/mob_spawn/human/corpse/raider,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "suZ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/cups,
@@ -21811,13 +22451,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"svD" = (
-/obj/structure/table,
-/obj/item/healthanalyzer/advanced,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
 "svI" = (
 /obj/machinery/door/airlock/abandoned{
 	req_one_access_txt = "134"
@@ -21826,13 +22459,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
-"swh" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "swY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21842,20 +22468,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
-"swZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/paper/corner,
-/obj/item/paper_bin/bundlenatural,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"sxm" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
-/obj/item/reagent_containers/food/snacks/meat/slab/human,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul,
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
 "sxA" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier9,
@@ -21872,13 +22484,6 @@
 /obj/item/reagent_containers/syringe/medx,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"syJ" = (
-/obj/machinery/chem_master/advanced,
-/obj/machinery/chem_master/advanced,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
 "szW" = (
@@ -21902,14 +22507,8 @@
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sAl" = (
-/mob/living/simple_animal/hostile/handy/nsb,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
 "sBm" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
+/mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "sBu" = (
@@ -21934,13 +22533,8 @@
 	},
 /area/f13/brotherhood/leisure)
 "sCZ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/water,
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "sDo" = (
 /obj/structure/table/booth,
@@ -21958,18 +22552,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"sEL" = (
-/obj/structure/chair/f13chair2{
-	dir = 4
+"sFf" = (
+/obj/structure/junk/small/bed2,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
-"sFr" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider/baseball,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "sGx" = (
 /obj/structure/table/reinforced,
@@ -21984,14 +22571,14 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
-"sHb" = (
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/water,
+"sGP" = (
+/obj/structure/barricade/wooden,
+/obj/structure/curtain,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"sHo" = (
+/mob/living/simple_animal/hostile/stalkeryoung,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "sHv" = (
 /obj/item/radio/intercom{
@@ -22000,19 +22587,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
+"sHN" = (
+/obj/structure/sign/poster/contraband/pinup_funk{
+	pixel_y = -32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"sIk" = (
+/obj/machinery/power/tesla_coil/research{
+	desc = "A modified military-grade tesla coil constantly exchanging energy throughout. It looks to be recently used.";
+	name = "tesla charge inducer"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "sIp" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"sIq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/raider/thief,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
 "sIN" = (
 /obj/effect/decal/cleanable/cobweb,
 /mob/living/simple_animal/hostile/poison/giant_spider,
@@ -22047,6 +22643,23 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/reactor)
+"sJK" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowleft";
+	layer = 2
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
+"sLq" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "sLx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -22063,18 +22676,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"sLS" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/bunker)
 "sMc" = (
-/obj/machinery/autolathe,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "sMr" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/structure/reagent_dispensers/fueltank,
@@ -22082,14 +22687,20 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"sMy" = (
+"sMK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/obj/item/flag/oasis,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/tunnel)
+"sMQ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/f13/yumyum,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"sNu" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "sNB" = (
 /obj/structure/chair/comfy/shuttle{
@@ -22109,17 +22720,24 @@
 	icon_state = "whiterustysolid"
 	},
 /area/f13/tunnel)
-"sNT" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 5;
-	tag = "icon-tracks (NORTHEAST)"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+"sNW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "sNX" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"sNZ" = (
+/obj/machinery/computer/security{
+	dir = 4;
+	network = "vault"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "sOi" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/light{
@@ -22141,21 +22759,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
-"sOB" = (
-/mob/living/simple_animal/hostile/enclave/soldier{
-	desc = "A former Enclave soldier, mutated by the forced evolutionary virus and grafted to the interior of his suit.";
-	extra_projectiles = 1;
-	faction = list("wastebot");
-	loot = null;
-	name = "mutated enclave soldier";
-	speak = list("AUUGHGHHH!");
-	speak_emote = list("shouts")
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "sON" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -22165,28 +22768,16 @@
 	},
 /area/f13/tunnel)
 "sPK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/machinery/light/broken,
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "sPY" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sRw" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"sRL" = (
-/obj/structure/girder/reinforced,
-/obj/structure/decoration/rag,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "sSP" = (
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
@@ -22210,12 +22801,18 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"sUl" = (
+"sTz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"sUl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/f13/yumyum,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "sUs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -22226,23 +22823,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"sVw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"sVN" = (
-/obj/machinery/door/airlock/grunge,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"sVV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/raider/ranged/legendary,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
 "sWp" = (
 /obj/structure/table{
 	layer = 2.9
@@ -22256,13 +22836,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"sWM" = (
-/obj/structure/barricade/bars,
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "sWT" = (
 /obj/structure/table/reinforced,
 /obj/item/pen/fountain{
@@ -22309,30 +22882,33 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "sXV" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
+"sZB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"sYw" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/east,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
 "sZJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
+/mob/living/simple_animal/hostile/deathclaw{
+	speed = -2
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"tau" = (
+/turf/open/water,
+/area/f13/caves)
+"tak" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "taI" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -22340,27 +22916,38 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"tbE" = (
+"tbc" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"tcC" = (
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 8;
-	light_color = "#800080";
-	name = "light fixture"
+"tbr" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"tcT" = (
-/obj/effect/decal/fakelattice,
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"tbE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"tbI" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"tcC" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plating/f13,
+/area/f13/followers)
+"tcN" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tda" = (
 /obj/structure/toilet{
 	dir = 8
@@ -22371,19 +22958,15 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"tdC" = (
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"tdY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/turf/open/floor/f13/wood,
+"tdP" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"tei" = (
-/obj/machinery/door/window,
+"tdU" = (
+/obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "bluerustyfull"
 	},
 /area/f13/bunker)
 "tem" = (
@@ -22418,15 +23001,20 @@
 	},
 /area/f13/clinic)
 "teW" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/nest/deathclaw,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"tff" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"tfi" = (
-/obj/machinery/autolathe/ammo,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/bunker)
 "tfw" = (
 /obj/structure/barricade/sandbags,
@@ -22434,10 +23022,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"tfZ" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
+"tfB" = (
+/obj/machinery/button/door{
+	id = "hell";
+	name = "Door Control"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/caves)
 "tgC" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13{
@@ -22457,12 +23048,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"thH" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "tiS" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -22473,11 +23058,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"tjd" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "tjt" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/handrail/g_central{
@@ -22492,27 +23072,25 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tjA" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
+/obj/structure/table/wood/settler,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "tjI" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"tkz" = (
-/obj/structure/closet/crate/large,
-/obj/item/circuitboard/machine/protolathe,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/obj/machinery/light/small{
-	dir = 4
+"tkG" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"tkQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/pinup_shower{
+	pixel_x = -32
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "tkS" = (
 /obj/machinery/door/airlock/hatch{
 	name = "NCR War Room";
@@ -22530,10 +23108,17 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
-"tlH" = (
-/obj/item/clothing/suit/radiation,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+"tlL" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/followers)
 "tlS" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/small{
@@ -22549,11 +23134,10 @@
 	},
 /area/f13/brotherhood/rnd)
 "tmM" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/water,
+/obj/machinery/light/small,
+/obj/structure/table/wood/settler,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "tmO" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -22571,13 +23155,31 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"tni" = (
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/caves)
 "tnp" = (
 /turf/closed/wall/f13/wood,
 /area/f13/sewer)
-"toA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe/ammo,
+"tny" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
 /turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"toj" = (
+/obj/structure/barricade/wooden,
+/obj/item/pickaxe{
+	anchored = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"toA" = (
+/obj/machinery/workbench/advanced,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/item/book/granter/crafting_recipe/gunsmith_two,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "toP" = (
 /obj/structure/rack,
@@ -22601,29 +23203,33 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"tqF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/kitchenspike,
-/obj/effect/mob_spawn/human/corpse/raidermelee,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor7-old"
+"tpl" = (
+/obj/structure/closet{
+	name = "implants locker"
 	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
+/obj/item/organ/cyberimp/chest/nutriment,
+/obj/item/organ/cyberimp/chest/nutriment,
+/obj/item/organ/cyberimp/chest/nutriment,
+/obj/item/organ/cyberimp/chest/nutriment/plus,
+/obj/item/organ/cyberimp/eyes/hud/medical,
+/obj/item/organ/cyberimp/eyes/hud/medical,
+/obj/item/organ/cyberimp/eyes/hud/medical,
+/obj/item/organ/cyberimp/eyes/hud/medical,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "tqH" = (
-/obj/structure/wreck/trash/five_tires{
-	pixel_x = 3;
-	pixel_y = -13
-	},
-/obj/item/flag/oasis,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tqZ" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_north_middle"
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tse" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -22638,6 +23244,42 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
+"tsn" = (
+/obj/structure/wreck/trash/five_tires{
+	pixel_x = 3;
+	pixel_y = -13
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"tsK" = (
+/obj/structure/rack,
+/obj/item/storage/box/masks,
+/obj/item/storage/box/gloves,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
+"ttg" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"ttl" = (
+/obj/item/defibrillator/loaded,
+/obj/item/storage/box/syringes,
+/obj/item/cane,
+/obj/item/soap,
+/obj/effect/turf_decal/box/white,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/defibrillator/loaded,
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/gloves,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "ttp" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -22656,17 +23298,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"ttJ" = (
-/obj/machinery/door/poddoor/preopen{
-	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70);
-	id = eairlock
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "bluemark"
-	},
-/area/f13/bunker)
 "ttW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -22693,6 +23324,15 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"tvj" = (
+/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/tunnel)
 "tvl" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood{
@@ -22705,6 +23345,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"tvI" = (
+/obj/structure/timeddoor,
+/obj/structure/timeddoor,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "tvZ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
@@ -22712,6 +23357,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
+"twi" = (
+/obj/structure/closet/crate/miningcar,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "twj" = (
 /obj/item/instrument/trombone,
 /obj/structure/rack,
@@ -22723,16 +23373,26 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"twG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
 "txg" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
+"txW" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Business"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"tyw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/money_stack,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "tyR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -22744,6 +23404,21 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"tzm" = (
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"tzH" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5;
+	tag = "icon-tracks (NORTHEAST)"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tzJ" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/rust,
@@ -22754,37 +23429,26 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/tunnel)
-"tAd" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/machinery/door/poddoor{
-	id = "okay"
+"tAe" = (
+/obj/structure/barricade/bars,
+/obj/structure/table/wood,
+/obj/structure/curtain{
+	color = "#845f58"
 	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
-"tAr" = (
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/backpack/duffelbag/med,
-/obj/item/clothing/accessory/medal/ribbon/medical_doctor{
-	desc = "A faded award from long ago";
-	name = "faded medical award"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"tAO" = (
-/obj/item/storage/trash_stack,
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
-	faction = list("raider");
-	name = "Repaired Turret";
-	scan_range = 9;
-	throw_range = 9
+"tAC" = (
+/obj/machinery/door/morgue,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"tBL" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = -6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "tBZ" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -22794,32 +23458,29 @@
 "tCe" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/f13/brotherhood/rnd)
-"tCo" = (
-/obj/structure/fluff/paper/stack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"tCC" = (
-/obj/structure/closet/crate{
-	anchored = 1;
-	can_be_unanchored = 1
+"tCt" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
-/obj/item/clothing/suit/armor/f13/power_armor/t45d/gunslinger,
-/obj/item/clothing/head/helmet/f13/power_armor/t45d/gunslinger,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "tDc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"tDj" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
 "tDl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/book/manual/wiki/cit/chemistry,
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/circuitry,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tDo" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/lootdrop/trash,
@@ -22828,47 +23489,32 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"tDv" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "redmark"
-	},
-/area/f13/bunker)
-"tDW" = (
+"tDU" = (
+/obj/machinery/mineral/ore_redemption,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_north_middle"
-	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"tDW" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old";
+	tag = "icon-gib2-old"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tEm" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"tEo" = (
-/obj/structure/fluff/oldturret,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "tEu" = (
-/obj/machinery/button/door{
-	id = "oasisstorage";
-	name = "Oasis Storage Button";
-	pixel_x = 32;
-	req_one_access_txt = "62"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore";
+	tag = "icon-gibbearcore"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"tEv" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tEG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -22876,17 +23522,27 @@
 	},
 /area/f13/brotherhood/offices1st)
 "tEH" = (
-/obj/structure/rack,
-/obj/item/twohanded/sledgehammer,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/structure/closet/crate/miningcar,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tEW" = (
-/obj/machinery/photocopier,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/warning,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"tFc" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
+"tFD" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "tFF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -22904,31 +23560,22 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"tFT" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "tGe" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"tGP" = (
-/obj/structure/closet/crate/large,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"tGU" = (
-/obj/item/storage/trash_stack,
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
+"tHa" = (
+/turf/open/floor/wood/f13/stage_bl,
+/area/f13/tunnel)
 "tHb" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -22940,21 +23587,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"tHF" = (
-/obj/structure/table,
-/obj/item/kitchen/knife/butcher,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/tunnel)
-"tHM" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/deathclaw/mother{
-	speed = -1.5
-	},
-/turf/open/water,
-/area/f13/caves)
 "tID" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -22965,22 +23597,28 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"tIG" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/f13/yumyum,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "tII" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/water,
+/area/f13/caves)
+"tJe" = (
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/followers)
 "tJD" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/warning{
+	pixel_x = -3;
+	pixel_y = -5
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tJE" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/machinery/light{
@@ -23007,6 +23645,18 @@
 /obj/effect/landmark/start/f13/ncrcaptain,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"tKQ" = (
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
+"tKU" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/followers)
 "tLd" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor4-old"
@@ -23015,13 +23665,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"tMn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "tMw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -23047,20 +23690,25 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
-"tNc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/paper/crumpled/bloody/docsdeathnote{
-	info = "it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns "
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "tNq" = (
 /obj/machinery/telecomms/server/presets/bos,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"tNw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/tools{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"tNA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/handrail/g_central{
+	layer = 2.7;
+	pixel_y = -16
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "tOi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23088,6 +23736,16 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
+"tOP" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
+"tOU" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tOY" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -23096,10 +23754,18 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"tPQ" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowhorizontal"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "tPY" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/glowshroom/single,
+/turf/open/water,
+/area/f13/caves)
 "tQw" = (
 /obj/structure/table,
 /obj/item/storage/fancy/ammobox/slugshot,
@@ -23112,12 +23778,23 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"tRH" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+"tRe" = (
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "124"
 	},
-/area/f13/bunker)
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/followers)
+"tRl" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/light/fo13colored/Pink{
+	dir = 1;
+	name = "light tube"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "tRS" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13{
@@ -23151,9 +23828,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "tTm" = (
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/warning,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tTt" = (
 /obj/machinery/light{
 	dir = 1
@@ -23163,13 +23841,13 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"tUi" = (
+"tTD" = (
+/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/port_gen/pacman/super,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "tUk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/chips,
@@ -23177,39 +23855,52 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"tUG" = (
+/obj/machinery/power/tesla_coil/research{
+	desc = "A modified military-grade tesla coil constantly exchanging energy throughout. It looks to be recently used.";
+	name = "tesla charge inducer"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "tUT" = (
-/obj/machinery/light/small,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/item/fusion_fuel,
+/obj/item/fusion_fuel,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/clinic)
+"tVb" = (
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "topcellghoul"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "tVu" = (
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"tWP" = (
-/obj/structure/simple_door/bunker,
+"tVV" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "fadmin";
+	name = "Follower Admin shutters"
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "124"
+	},
 /turf/open/floor/f13{
-	dir = 6;
-	icon_state = "redmark"
+	icon_state = "bluerustysolid"
 	},
-/area/f13/bunker)
-"tWZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "pain";
-	name = "Door Control"
-	},
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
+/area/f13/followers)
+"tWw" = (
+/turf/closed/wall/f13/store,
+/area/f13/followers)
 "tXh" = (
 /obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
-"tXj" = (
-/obj/structure/closet/radiation,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "tXq" = (
@@ -23235,6 +23926,11 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
+"tYf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/booth,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "tYj" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt{
@@ -23248,9 +23944,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "tZf" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/tunnel)
 "tZg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -23259,9 +23960,9 @@
 	},
 /area/f13/bunker)
 "tZq" = (
-/obj/structure/curtain,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/tunnel)
 "tZE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23270,11 +23971,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
-	},
-/area/f13/tunnel)
-"tZO" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenfull"
 	},
 /area/f13/tunnel)
 "tZW" = (
@@ -23293,43 +23989,70 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"ubj" = (
-/obj/item/crowbar,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+"uaR" = (
+/obj/structure/table/snooker{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "ubN" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"ubO" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "ubW" = (
-/obj/machinery/workbench,
+/obj/structure/toilet,
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/tunnel)
+"ucK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/dresser,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "ucS" = (
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"udr" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
-"udH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/workbench/forge,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"uee" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/deathclaw{
-	speed = -2
+"udK" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = -4
 	},
-/turf/open/water,
-/area/f13/caves)
-"uei" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/water,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
+"uey" = (
+/obj/structure/chair/stool,
+/obj/machinery/button/door{
+	id = "bottomcellghoul";
+	name = "Bottom cell shutters";
+	pixel_x = -6;
+	pixel_y = 32
+	},
+/obj/machinery/button/door{
+	id = "topcellghoul";
+	name = "Top cell shutters";
+	pixel_x = 6;
+	pixel_y = 32
+	},
+/turf/open/floor/wood/f13/stage_t,
+/area/f13/tunnel)
+"ueP" = (
+/obj/structure/girder,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "ueZ" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -23338,12 +24061,26 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "ufo" = (
-/obj/structure/closet/crate/large,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/tunnel)
 "ufQ" = (
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/tunnel)
 "ufR" = (
 /obj/structure/rack,
@@ -23360,12 +24097,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"ugu" = (
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "ugU" = (
 /obj/structure/bookcase/random/adult,
 /obj/machinery/light{
@@ -23376,69 +24107,66 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"uhn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "uhE" = (
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"uhG" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "uhW" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"uif" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/tunnel)
 "uig" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
-"uio" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"uis" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"uiz" = (
-/obj/structure/chair/f13chair2,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/tunnel)
-"uiT" = (
-/obj/machinery/computer/secure_data{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "uiV" = (
 /obj/structure/nest/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"uiW" = (
-/obj/structure/reagent_dispensers/barrel/two,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"ujL" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
-/turf/open/indestructible/ground/inside/subway,
+"ujm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
+"ujn" = (
+/obj/machinery/door/window,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/bunker)
+"ujx" = (
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
+"ukd" = (
+/obj/item/instrument/accordion,
+/obj/structure/rack,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/tunnel)
 "ukv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table{
@@ -23449,6 +24177,18 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"ukI" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/curtain,
+/obj/item/reagent_containers/syringe,
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/tunnel)
 "ulr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/terminal{
@@ -23478,50 +24218,75 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/tunnel)
-"umG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/settler,
-/turf/open/floor/f13/wood,
+"ulE" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/tunnel)
-"unJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/lit,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"umw" = (
+/obj/structure/light_construct,
+/obj/structure/table,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/clothing/suit/armor/hos/trenchcoat,
+/obj/item/clothing/head/HoS/beret,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
+"umG" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/tunnel)
+"umQ" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/bunker)
 "unV" = (
-/obj/machinery/door/airlock/vault{
-	autoclose = "TRUE";
-	layer = 2;
-	name = "Oasis Storage";
-	req_one_access_txt = "25"
-	},
-/obj/machinery/door/poddoor/ert{
-	id = "oasisstorage";
-	layer = 5;
-	name = "Oasis Storage"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"uoo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Bar Backroom";
-	req_one_access_txt = "25"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"uop" = (
 /turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
+	icon_state = "floorgrime"
 	},
-/area/f13/bunker)
+/area/f13/tunnel)
+"uoj" = (
+/obj/structure/reagent_dispensers/barrel,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"uoo" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "uoq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
+/area/f13/tunnel)
+"uov" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/followers)
+"uoy" = (
+/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "uoI" = (
 /obj/effect/decal/cleanable/dirt{
@@ -23534,14 +24299,16 @@
 "uoO" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"uoR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper/crumpled,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+"upp" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
+	},
+/area/f13/followers)
 "upC" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "uqk" = (
 /obj/item/flashlight,
@@ -23594,43 +24361,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/leisure)
-"urt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden/strong,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
-"urI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
 "urM" = (
-/obj/effect/landmark/start/f13/settler,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "urZ" = (
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 8;
-	light_color = "#800080";
-	name = "light fixture"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"usv" = (
-/obj/effect/decal/cleanable/glass,
-/obj/item/shard{
-	icon_state = "small";
-	pixel_x = -6;
-	pixel_y = 3
-	},
+/obj/structure/simple_door/bunker/glass,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "bluerustysolid"
 	},
-/area/f13/bunker)
+/area/f13/followers)
 "usN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -23638,14 +24380,8 @@
 	},
 /area/f13/brotherhood/rnd)
 "utr" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/plastic/five,
-/obj/item/stack/sheet/plastic/five,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "utz" = (
 /obj/structure/sink/kitchen,
@@ -23659,11 +24395,36 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
+"uub" = (
+/obj/item/reagent_containers/syringe/piercing,
+/turf/open/floor/plasteel/f13,
+/area/f13/tunnel)
+"uuf" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"uug" = (
+/obj/structure/showcase/horrific_experiment{
+	icon_state = "pod_0"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
 "uuo" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/ammo,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/tunnel)
+"uux" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bonfire,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "uuN" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -23676,11 +24437,9 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"uvV" = (
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
+"uvW" = (
+/turf/closed/wall/f13/supermart,
+/area/f13/tunnel)
 "uwd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/vent{
@@ -23693,16 +24452,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "uwt" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/showcase/horrific_experiment,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
 "uwA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23741,67 +24497,57 @@
 	},
 /area/f13/brotherhood/medical)
 "uyz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/storage/box/syringes,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "uyQ" = (
-/obj/item/clothing/head/hardhat,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/table/reinforced,
+/obj/item/storage/box/beakers,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
 "uzc" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"uzr" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
-"uzO" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/machinery/light/broken{
+/obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
+"uzf" = (
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"uAb" = (
-/obj/structure/barricade/wooden,
-/obj/machinery/light/fo13colored/Pink{
-	dir = 1;
-	name = "light tube"
+"uzO" = (
+/obj/structure/showcase/horrific_experiment,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
 	},
-/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"uAb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/tunnel)
 "uAc" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/mining)
-"uAs" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/handy/gutsy/nsb,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
+"uBk" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
-"uAK" = (
-/obj/structure/bed,
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
-	},
-/area/f13/tunnel)
-"uBN" = (
-/obj/structure/closet/wardrobe/virology_white,
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
-	},
-/area/f13/tunnel)
 "uBO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -23834,14 +24580,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"uCN" = (
-/obj/machinery/door/airlock/grunge,
+"uDV" = (
+/obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"uDS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/dresser,
-/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "uEb" = (
 /obj/machinery/telecomms/processor/preset_two,
@@ -23861,6 +24602,10 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"uEs" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/water,
+/area/f13/tunnel)
 "uEu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -23878,11 +24623,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "uFj" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/tunnel)
 "uFm" = (
 /obj/structure/rack,
@@ -23902,23 +24645,33 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"uFB" = (
+/obj/structure/closet/crate/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "uFQ" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"uFR" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
+"uFW" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/f13/wood/house,
+/area/f13/tunnel)
+"uGd" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"uGl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/waste,
-/mob/living/simple_animal/hostile/abomhorror/nsb,
-/turf/open/floor/plasteel/f13{
+/turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
@@ -23931,14 +24684,13 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
-"uHb" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/gutsy/nsb,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "uHt" = (
-/obj/structure/nest/ghoul,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/tunnel)
 "uHT" = (
 /obj/machinery/vending/cola/red,
@@ -23970,76 +24722,58 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"uJt" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
-"uJx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibtorso"
-	},
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "uJD" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/tunnel)
-"uKg" = (
-/obj/effect/decal/cleanable/blood/gibs/body,
-/obj/effect/decal/cleanable/blood/gibs/body,
-/mob/living/simple_animal/hostile/raider/ranged/legendary,
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
-"uKj" = (
-/obj/effect/decal/cleanable/glass,
-/obj/item/shard{
-	icon_state = "medium";
-	pixel_x = -4
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"uKB" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
+"uKs" = (
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"uKE" = (
-/mob/living/simple_animal/hostile/raider/firefighter,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
+"uKB" = (
+/obj/effect/decal/remains/human,
+/obj/effect/gibspawner/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "uKP" = (
-/obj/effect/decal/waste,
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/item/storage/box/stockparts/deluxe,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "uKU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood/house,
-/area/f13/tunnel)
-"uKW" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"uLn" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Oasis Housing";
-	req_one_access_txt = "25"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/tunnel)
+"uLn" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/closet/crate/secure/loot,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "uLp" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -24057,32 +24791,27 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/tunnel)
-"uMe" = (
-/obj/structure/frame/machine,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "uMi" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "mine"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
-/area/f13/caves)
-"uMm" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bottle/mutagen,
-/obj/machinery/light/small{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/tunnel)
+"uMj" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
+	},
 /turf/open/floor/f13{
-	icon_state = "bluerustyfull"
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "uMu" = (
@@ -24094,18 +24823,19 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
-"uMz" = (
-/obj/effect/decal/cleanable/robot_debris/old,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
-	},
-/area/f13/tunnel)
 "uMA" = (
-/obj/structure/table/booth,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "uMD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24119,39 +24849,47 @@
 	},
 /area/f13/tunnel)
 "uNS" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "uOE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
+"uOV" = (
+/obj/structure/nest/ghoul,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/tunnel)
 "uPu" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
 "uPv" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "uQO" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = -3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/tunnel)
+/turf/open/floor/plating/f13,
+/area/f13/followers)
 "uRG" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -24160,34 +24898,44 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
-"uRW" = (
-/obj/structure/reagent_dispensers/barrel/two,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"uRY" = (
-/obj/structure/sink{
-	pixel_y = 19
+"uRL" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
 	},
 /area/f13/tunnel)
-"uSi" = (
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"uRT" = (
+/turf/closed/indestructible/fakeglass,
 /area/f13/bunker)
+"uRY" = (
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
 "uSI" = (
 /obj/structure/chair/wood,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"uST" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
+"uTw" = (
+/obj/item/stack/cable_coil/cut/random,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "uTy" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light/small{
@@ -24211,28 +24959,52 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"uUO" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/sentrybot/nsb,
+"uUN" = (
+/obj/structure/chair/bench,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/area/f13/tunnel)
 "uVp" = (
 /obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"uVr" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "uVN" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"uWl" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/turf/open/floor/f13/wood,
+"uVY" = (
+/obj/machinery/power/rtg,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	icon_state = "fwindow"
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	icon_state = "fwindow"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/tunnel)
 "uWC" = (
 /obj/structure/cable{
@@ -24243,33 +25015,41 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
-"uWH" = (
-/obj/structure/flora/wasteplant/wild_fungus,
+"uWW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
+"uXs" = (
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
+"uXM" = (
+/obj/item/clothing/head/radiation,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"uXs" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/effect/decal/cleanable/dirt,
+"uYc" = (
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"uYD" = (
-/obj/effect/decal/fakelattice,
-/mob/living/simple_animal/hostile/handy/gutsy/nsb,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
+"uYQ" = (
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "uZy" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+/mob/living/simple_animal/hostile/handy/robobrain{
+	name = "Conscripted Engineer"
 	},
-/area/f13/caves)
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "uZG" = (
 /obj/structure/rack,
 /obj/item/shield/riot/bullet_proof,
@@ -24291,18 +25071,28 @@
 	},
 /area/f13/brotherhood/operations)
 "vaf" = (
-/obj/structure/table/booth,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
-"vag" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "vat" = (
-/obj/effect/decal/cleanable/generic,
-/turf/closed/wall/f13/wood,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/inducer,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "vaH" = (
 /obj/structure/rack,
@@ -24321,13 +25111,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
-"vbI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "vbV" = (
 /obj/structure/handrail/g_central{
 	dir = 4;
@@ -24338,17 +25121,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"vbY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/tunnel)
-"vcc" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider/firefighter,
+"vcz" = (
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/area/f13/tunnel)
 "vcL" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -24362,15 +25138,30 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"vdI" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "ven" = (
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/window/eastleft,
+/obj/item/stack/sheet/plasteel/twenty,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/tunnel)
 "veq" = (
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/window/westright,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/tunnel)
 "veO" = (
@@ -24398,15 +25189,14 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
-"vfh" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_north"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "vfi" = (
-/obj/structure/table/booth,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 35
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
 "vfj" = (
 /obj/structure/handrail/g_central{
@@ -24424,34 +25214,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/offices2nd)
 "vfL" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "vgo" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/stack/f13Cash/random/med,
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 4;
-	light_color = "#800080";
-	name = "light fixture"
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"vgS" = (
-/obj/structure/decoration/hatch{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/barricade/bars{
-	layer = 5
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/water,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "vgW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24462,9 +25239,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"vgZ" = (
-/obj/structure/junk/small/bed,
-/turf/open/floor/plating/tunnel,
+"vhH" = (
+/obj/machinery/door/keycard{
+	puzzle_id = "library"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/bunker)
 "vhO" = (
 /obj/structure/table/wood/settler,
@@ -24476,27 +25257,13 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
-"vii" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"viw" = (
-/obj/item/storage/trash_stack,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
+"vik" = (
+/obj/structure/chair/stool/f13stool,
+/obj/effect/landmark/start/f13/followersvolunteer,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/bunker)
-"viS" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/gutsy/nsb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"vja" = (
-/obj/effect/mob_spawn/human/corpse,
-/obj/effect/decal/cleanable/blood,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/followers)
 "vkb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dresser,
@@ -24521,40 +25288,51 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/sewer)
-"vkD" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"vkL" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"vlo" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+"vkB" = (
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "bluerustyfull"
 	},
 /area/f13/bunker)
+"vkD" = (
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13,
+/area/f13/tunnel)
+"vkL" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
 "vmm" = (
-/obj/structure/simple_door/metal/barred,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/obj/structure/showcase/horrific_experiment,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
 "vnJ" = (
 /obj/item/instrument/glockenspiel,
 /obj/structure/rack,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"vnW" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+"vnR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Aqua{
+	name = "light fixture"
+	},
 /turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"vnW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/tunnel)
 "vnY" = (
 /obj/structure/rack,
@@ -24572,6 +25350,14 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"vos" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "clinicladder"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "vov" = (
 /obj/machinery/workbench,
 /turf/open/floor/f13{
@@ -24582,30 +25368,35 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"vpb" = (
-/obj/structure/reagent_dispensers/barrel,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"vpz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
-	},
+"vpe" = (
+/obj/machinery/workbench,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"vpz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "vqb" = (
-/obj/machinery/shower{
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/tunnel)
+"vqf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "reddirtyfull"
 	},
-/area/f13/tunnel)
-"vqj" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+/area/f13/bunker)
 "vqo" = (
 /obj/structure/simple_door/bunker{
 	name = "Star Knight Office";
@@ -24617,12 +25408,54 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
-"vra" = (
-/obj/structure/mirror{
-	pixel_x = 32
-	},
+"vqt" = (
+/obj/structure/rack,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/storage/box/citizenship_permits,
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"vqz" = (
+/obj/structure/reagent_dispensers/barrel/explosive,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"vra" = (
+/obj/machinery/door/airlock/hatch{
+	locked = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
 /area/f13/tunnel)
 "vrD" = (
@@ -24631,20 +25464,16 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
+"vsu" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/tunnel)
 "vsC" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"vsG" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/raider/tribal,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "vsI" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water,
@@ -24669,14 +25498,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "vuf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 8;
-	light_color = "#800080";
-	name = "light fixture"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "vuj" = (
 /obj/machinery/light/small{
@@ -24723,14 +25553,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"vxb" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "vxm" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -24750,31 +25572,31 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"vyt" = (
-/obj/structure/barricade/wooden/strong,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
+"vyb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "vyN" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "vzL" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_middle"
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "vzR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
+/obj/item/computer_hardware/recharger/APC,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
-"vAp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/photocopier,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "vAM" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -24782,31 +25604,22 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"vBf" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+"vBh" = (
+/obj/structure/fluff/oldturret,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	dir = 6;
+	icon_state = "bluemark"
 	},
-/area/f13/bunker)
-"vBz" = (
-/turf/closed/indestructible/fakeglass,
 /area/f13/bunker)
 "vBA" = (
-/obj/structure/closet/cabinet,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/window/eastleft,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/tunnel)
-"vBG" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "vBO" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
@@ -24841,18 +25654,26 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"vDl" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+"vCM" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
+"vCT" = (
+/obj/structure/table/snooker{
+	dir = 9
+	},
+/obj/item/toy/cards/deck{
+	pixel_x = -11;
+	pixel_y = 15
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"vDq" = (
-/obj/structure/sink{
-	pixel_y = 19
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+"vDl" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
 /area/f13/tunnel)
 "vDC" = (
@@ -24867,9 +25688,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"vEc" = (
-/obj/item/paper/crumpled,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"vDW" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/bunker)
 "vEd" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -24899,6 +25722,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"vEW" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/frame,
+/obj/item/stack/cable_coil/cut/random,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "vFa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -24916,6 +25748,13 @@
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"vGI" = (
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
 "vGT" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -24923,6 +25762,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
+"vHI" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "vHN" = (
 /obj/structure/chair{
 	dir = 4
@@ -24940,17 +25785,16 @@
 	icon_state = "grass2"
 	},
 /area/f13/clinic)
-"vIr" = (
+"vJg" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/abomhorror/nsb,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
+/obj/machinery/button/door{
+	id = "clinicstorage";
+	name = "shutters button";
+	pixel_x = 32
 	},
-/area/f13/bunker)
-"vJw" = (
-/obj/structure/reagent_dispensers/barrel/four,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/machinery/vending/medical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "vJC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
@@ -24963,9 +25807,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "vKh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/flashlight/lamp,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "vKm" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -24980,11 +25831,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/brotherhood/offices2nd)
-"vLy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
+"vLg" = (
+/obj/structure/table/reinforced,
+/obj/item/book/granter/trait/chemistry,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
+"vLr" = (
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "vLO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -24994,11 +25851,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"vMc" = (
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/caves)
 "vMm" = (
 /obj/structure/simple_door/bunker,
 /obj/effect/decal/cleanable/dirt,
@@ -25013,6 +25865,15 @@
 	name = "pool water"
 	},
 /area/f13/brotherhood/leisure)
+"vMO" = (
+/mob/living/simple_animal/hostile/abomination{
+	health = 400;
+	name = "Escaped abomination"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
 "vNw" = (
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood{
@@ -25032,12 +25893,16 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vPm" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greendirtysolid"
-	},
+"vOu" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
 /area/f13/tunnel)
+"vOA" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
 "vPn" = (
 /obj/structure/table/greyscale,
 /turf/open/floor/f13{
@@ -25068,24 +25933,19 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"vPH" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/machinery/door/poddoor{
-	id = "pain"
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
-"vPN" = (
-/obj/structure/nest/deathclaw,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "vQn" = (
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/closet/l3closet/virology,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
+"vQq" = (
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
 "vQx" = (
 /obj/item/reagent_containers/food/snacks/grown/poppy{
 	pixel_x = 4;
@@ -25105,6 +25965,12 @@
 	},
 /turf/open/floor/mineral/plastitanium/airless,
 /area/f13/brotherhood/rnd)
+"vQK" = (
+/obj/structure/junk/small/bed2,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "vQU" = (
 /obj/machinery/iv_drip{
 	pixel_x = 13;
@@ -25119,42 +25985,41 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"vRe" = (
-/obj/structure/chair/f13chair2{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"vSd" = (
-/obj/structure/closet/crate/miningcar,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"vSC" = (
-/obj/item/stack/cable_coil/random/five,
+"vRE" = (
+/obj/structure/guncase,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"vSd" = (
+/obj/effect/decal/remains/human,
+/obj/effect/gibspawner/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
-/area/f13/bunker)
-"vSD" = (
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/caves)
-"vTd" = (
-/obj/item/stack/cable_coil/cut/random,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/area/f13/tunnel)
+"vTa" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
+"vTA" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/indestructible/cobble{
+	desc = "An assortment of broken and battered bricks, stones, rebar, and dust.";
+	name = "rubble"
 	},
 /area/f13/bunker)
 "vTH" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/followers)
 "vTY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains{
@@ -25164,17 +26029,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"vUs" = (
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"vUz" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood,
-/obj/item/reagent_containers/food/snacks/meat/slab/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "vUM" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25185,8 +26039,13 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "vVz" = (
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
 "vVE" = (
 /obj/effect/decal/remains/human,
@@ -25196,9 +26055,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vWg" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
 "vWj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25209,28 +26069,45 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"vWr" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "vWN" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vWZ" = (
-/obj/structure/girder,
-/obj/structure/barricade/wooden/planks,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
 "vXh" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "vXF" = (
-/obj/structure/chair/booth,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/pinup_couch{
-	pixel_y = 32
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "vXU" = (
 /obj/structure/window/fulltile/house{
@@ -25254,17 +26131,12 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
 "vYC" = (
-/obj/structure/chair/booth,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"vYJ" = (
-/obj/machinery/button/door{
-	id = "okay";
-	name = "Door Control"
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
+/area/f13/tunnel)
 "vZj" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -25303,11 +26175,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vZW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_east_south"
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "wac" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25315,13 +26192,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"waj" = (
-/obj/machinery/button/door{
-	id = "hell";
-	name = "Door Control"
-	},
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/caves)
 "waU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25331,26 +26201,61 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"wbf" = (
+/obj/structure/table/glass,
+/obj/item/folder{
+	pixel_x = -4
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/followers)
 "wbh" = (
 /obj/item/reagent_containers/pill/patch/turbo,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wbi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "wbp" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"wcm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+"wbO" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Town Forge";
+	req_one_access_txt = "25"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"wcm" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/item/clothing/suit/radiation,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/tunnel)
 "wcF" = (
-/obj/structure/dresser,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "wdF" = (
 /obj/structure/chair/wood{
@@ -25359,14 +26264,6 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
-/area/f13/tunnel)
-"wdT" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/structure/sign/poster/contraband/pinup_bed{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "weF" = (
 /obj/item/clothing/under/f13/bosformsilver_m,
@@ -25386,36 +26283,35 @@
 "weW" = (
 /turf/open/water,
 /area/f13/tunnel)
-"wfe" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "bluefull"
-	},
-/area/f13/tunnel)
-"wfn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paperplane/origami,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"wfE" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
+"wfh" = (
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 35
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/tunnel)
+"wfE" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
 	},
 /area/f13/tunnel)
 "wfG" = (
-/obj/structure/barricade/bars{
-	layer = 5
+/obj/effect/decal/remains/human,
+/obj/effect/gibspawner/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
 	},
-/obj/structure/decoration/hatch{
-	dir = 4
-	},
-/turf/open/water,
 /area/f13/tunnel)
 "wgg" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -25429,82 +26325,70 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"wgT" = (
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "whp" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"wiq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "soup";
-	name = "Door Control"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "wiz" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"wjU" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+"wiG" = (
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/area/f13/tunnel)
-"wjW" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "wkx" = (
 /turf/closed/mineral/random/low_chance{
 	mineralAmt = 6;
 	mineralChance = 10
 	},
 /area/f13/caves)
+"wkB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "wkN" = (
-/obj/structure/decoration/warning{
-	pixel_y = -2
+/obj/effect/spawner/lootdrop/f13/deadrodent_or_brainwashdisk,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
 	},
-/obj/structure/sign/warning{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
-"wkZ" = (
-/obj/effect/decal/cleanable/glass,
-/mob/living/simple_animal/hostile/handy/protectron,
+"wkW" = (
+/obj/structure/girder,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "greenrustyfull"
 	},
-/area/f13/bunker)
-"wle" = (
-/obj/machinery/light/small,
-/obj/structure/table/wood/settler,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"wmf" = (
+"wlv" = (
+/obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/wallframe/camera,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"wmI" = (
-/mob/living/simple_animal/hostile/handy/gutsy,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"wmH" = (
+/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "wmT" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -25514,19 +26398,25 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"wnT" = (
-/obj/structure/chair/f13chair2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"wol" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper,
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "hate";
-	name = "Door Control"
+"wnB" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wnG" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
+"wnJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
 "wom" = (
 /obj/structure/disposalpipe/trunk{
@@ -25534,19 +26424,6 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "dark"
-	},
-/area/f13/bunker)
-"wox" = (
-/obj/machinery/mech_bay_recharge_port,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"wpi" = (
-/obj/effect/decal/fakelattice,
-/obj/structure/wreck/trash/engine,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
 "wpj" = (
@@ -25557,29 +26434,54 @@
 	},
 /area/f13/enclave)
 "wpJ" = (
-/obj/structure/handrail/g_central{
-	pixel_y = -16
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/bottle/FEV_solution,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
 	},
-/turf/open/water,
 /area/f13/tunnel)
-"wql" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
+"wpU" = (
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"wqi" = (
+/obj/machinery/door/airlock/hatch{
+	locked = 1
 	},
-/area/f13/bunker)
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
+"wqp" = (
+/mob/living/simple_animal/pet/dog/eyebot,
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg2"
+	},
+/area/f13/tunnel)
+"wqw" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/closed/wall/r_wall,
+/area/f13/tunnel)
 "wqW" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
 "wrg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 8;
-	light_color = "#800080";
-	name = "light fixture"
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
+"wry" = (
+/obj/item/reagent_containers/syringe/piercing,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "wrJ" = (
 /turf/open/floor/f13/wood,
@@ -25589,39 +26491,29 @@
 /obj/item/stock_parts/cell/ammo/ec,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
-"wsv" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "wsK" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/light_construct,
+/turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
-"wtj" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "wtp" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
+"wtI" = (
+/obj/machinery/light/fo13colored/Aqua{
+	name = "light fixture"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "wuf" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wum" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old";
-	tag = "icon-gib2-old"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "wus" = (
-/obj/structure/chair/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "wut" = (
 /obj/structure/rack,
@@ -25630,8 +26522,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "wuM" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/f13/wood,
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
+"wuY" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/bottle/plasma,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
 "wvi" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -25639,6 +26541,12 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
+"wwt" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
+	},
+/area/f13/followers)
 "wwE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/mineral/random/high_chance,
@@ -25647,24 +26555,29 @@
 /obj/item/flashlight/flare/torch,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"wyc" = (
-/obj/structure/curtain,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+"wwV" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/water,
 /area/f13/tunnel)
-"wyL" = (
-/obj/item/chair,
+"wxP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flashlight/lamp,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"wyl" = (
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
+"wAd" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluedirtyfull"
-	},
-/area/f13/bunker)
-"wzs" = (
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/tunnel)
-"wzt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
 "wAe" = (
@@ -25684,11 +26597,18 @@
 /obj/structure/wreck/trash/engine,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"wAX" = (
+"wBu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"wCM" = (
+/obj/structure/table/glass,
+/obj/item/pda,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "wDm" = (
 /obj/structure/lattice{
 	layer = 2
@@ -25707,12 +26627,22 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"wDO" = (
-/obj/structure/sink{
-	pixel_y = 19
-	},
+"wDB" = (
+/obj/structure/bookcase,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"wDK" = (
+/turf/closed/wall/rust,
+/area/f13/bunker)
+"wDO" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/syringe/piercing,
+/obj/item/reagent_containers/syringe/piercing,
+/obj/item/reagent_containers/syringe/piercing,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
 "wDR" = (
 /obj/item/clothing/suit/armor/f13/combatrusted,
@@ -25741,19 +26671,11 @@
 	},
 /area/f13/brotherhood/medical)
 "wFx" = (
-/obj/structure/sign/warning{
-	pixel_x = 6;
-	pixel_y = -3
+/obj/machinery/hydroponics/constructable,
+/obj/item/seeds/potato,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
-/obj/structure/decoration/warning{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/structure/decoration/warning{
-	pixel_x = -3;
-	pixel_y = -5
-	},
-/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "wFL" = (
 /obj/structure/chair{
@@ -25763,58 +26685,23 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"wGy" = (
-/obj/structure/barricade/bars,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "wHf" = (
-/obj/structure/barricade/bars,
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/structure/closet/crate/hydroponics,
+/obj/item/hatchet,
+/obj/item/reagent_containers/glass/bottle/killer/weedkiller,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"wHt" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "wHB" = (
-/obj/structure/barricade/bars,
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"wHP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/handy/securitron/nsb,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
-"wHV" = (
-/obj/structure/barricade/bars,
-/obj/structure/table/wood,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"wIb" = (
-/obj/structure/wreck/trash/three_barrels,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "wIM" = (
 /obj/structure/handrail/g_central{
@@ -25823,17 +26710,6 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/tunnel)
-"wJk" = (
-/mob/living/simple_animal/hostile/handy/securitron/nsb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"wJm" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "wJQ" = (
 /obj/machinery/door/airlock/grunge{
@@ -25866,19 +26742,6 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"wLp" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/machinery/door/poddoor{
-	id = "pain"
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "wLM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -25895,12 +26758,11 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"wMa" = (
-/obj/machinery/light/broken,
-/obj/structure/table,
-/obj/item/storage/toolbox/emergency/old,
+"wMo" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/area/f13/tunnel)
 "wMr" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -25908,27 +26770,31 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "wMy" = (
-/obj/effect/decal/waste{
-	icon_state = "goo10"
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/obj/machinery/power/apc,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
-"wMX" = (
-/obj/item/storage/trash_stack,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
-"wND" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
+"wNC" = (
+/obj/structure/closet/cabinet,
+/obj/item/taperecorder,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/storage/briefcase,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "wNG" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -25937,16 +26803,11 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
-"wNN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "wOg" = (
-/obj/structure/barricade/wooden/planks,
-/turf/closed/wall/f13/wood,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "wOp" = (
 /obj/structure/cable{
@@ -25957,29 +26818,39 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"wPo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/meat/slab/human,
-/mob/living/simple_animal/hostile/deathclaw/legendary{
-	speed = -1.5
+"wOt" = (
+/turf/closed/wall/r_wall,
+/area/f13/tunnel)
+"wOv" = (
+/obj/structure/frame/computer{
+	dir = 4
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"wOH" = (
+/obj/machinery/door/keycard{
+	puzzle_id = "library"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "wQb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wQm" = (
-/obj/machinery/power/tesla_coil/research{
-	desc = "A modified military-grade tesla coil constantly exchanging energy throughout. It looks to be recently used.";
-	name = "tesla charge inducer"
+"wQl" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_7"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/bunker)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "wQB" = (
 /obj/structure/chair{
 	dir = 4
@@ -25989,9 +26860,11 @@
 	},
 /area/f13/clinic)
 "wQC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
+/obj/structure/closet/crate/secure/loot,
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
 "wQS" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
@@ -25999,31 +26872,48 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"wRb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper_bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"wRj" = (
-/obj/structure/handrail/g_central{
-	pixel_y = -16
+"wSh" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "busladder"
 	},
-/obj/item/storage/trash_stack{
-	layer = 2
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"wSj" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"wSv" = (
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/brute,
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/ancient,
+/obj/item/storage/firstaid/ancient,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
+"wSy" = (
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
+"wTk" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
 	},
 /turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+	icon_state = "reddirtyfull"
 	},
-/area/f13/tunnel)
-"wSg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"wTz" = (
+/obj/structure/table/snooker{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "wTF" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = null;
@@ -26040,27 +26930,34 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
-"wUi" = (
-/obj/structure/wreck/trash/four_barrels,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"wUo" = (
-/obj/machinery/light/fo13colored/Pink{
-	name = "light tube"
+"wTK" = (
+/turf/closed/wall{
+	icon_state = "fwall_opening"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"wUi" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
 "wUv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"wUy" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wUB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
+/obj/machinery/door/airlock/hatch{
+	locked = 1
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
 "wVl" = (
 /turf/open/floor/f13/wood{
@@ -26073,6 +26970,26 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"wWc" = (
+/obj/item/reagent_containers/syringe/piercing,
+/turf/closed/wall/r_wall/rust,
+/area/f13/tunnel)
+"wWi" = (
+/obj/structure/bed,
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
+"wWE" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbear1";
+	tag = "icon-gibbear1"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wWF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -26085,9 +27002,20 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"wXk" = (
+/obj/machinery/computer/rdconsole{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "wXG" = (
-/obj/structure/decoration/warning,
-/turf/closed/wall/rust,
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
 "wYl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26128,23 +27056,29 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xbg" = (
-/mob/living/simple_animal/hostile/ghoul/wyomingghost{
-	desc = "A happily proud Enclave commander, mutated and boiled alive by the forced evolutionary virus. His armor looks to be sunken into his flesh.";
-	faction = list("wastebot");
-	health = 1500;
-	maxHealth = 1500;
-	name = "Commander Dirsk";
-	speak = list("For the Enclave!","Long live America!","Die, mutie!","AAAAAGGH!!","AUGUHGHHH!"));
-	speak_chance = 10;
-	speed = -1;
-	unarmed_attack_speed = 2
-	},
+"xaV" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"xba" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/bunker)
+/area/f13/tunnel)
+"xby" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
+"xbP" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "xcm" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -26162,10 +27096,13 @@
 /turf/open/water,
 /area/f13/caves)
 "xcH" = (
-/obj/structure/closet/crate/miningcar,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "xdi" = (
 /obj/structure/chair/bench,
 /obj/effect/landmark/start/f13/raider,
@@ -26173,12 +27110,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"xdM" = (
-/obj/effect/decal/cleanable/blood/tracks{
+"xdA" = (
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "xdS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -26216,9 +27155,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "xfu" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "xgi" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -26229,18 +27172,10 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"xgx" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbear1";
-	tag = "icon-gibbear1"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"xgQ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/closed/mineral/random/high_chance,
+"xgw" = (
+/mob/living/simple_animal/hostile/handy/sentrybot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
 "xgY" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -26262,17 +27197,35 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"xhf" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
+"xhg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/chem_pile{
+	pixel_x = -19
+	},
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/tunnel)
 "xhA" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "xhF" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib5-old";
-	tag = "icon-gib5-old"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/followers)
 "xig" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowrustyfull"
@@ -26312,6 +27265,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"xkd" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenfull"
+	},
+/area/f13/tunnel)
 "xkh" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood{
@@ -26336,6 +27294,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"xlp" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "xlL" = (
 /obj/machinery/door/window/eastright,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -26343,6 +27306,22 @@
 "xmk" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
+"xml" = (
+/obj/structure/closet/crate/large,
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"xmE" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "xmQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/fancy/black,
@@ -26373,6 +27352,19 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
+"xnw" = (
+/obj/structure/nest/ghoul,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/sewer)
+"xod" = (
+/obj/machinery/light/fo13colored/Pink{
+	dir = 1;
+	name = "light tube"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "xop" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -26388,12 +27380,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"xpJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/shovel/spade,
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+"xpN" = (
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/followers)
 "xqa" = (
 /obj/machinery/light{
 	dir = 1
@@ -26412,17 +27404,27 @@
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"xqJ" = (
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"xrf" = (
+/obj/structure/decoration/warning,
+/turf/closed/wall/rust,
+/area/f13/tunnel)
 "xrz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"xsc" = (
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+"xrE" = (
+/obj/machinery/button/door{
+	id = "prospector3open";
+	name = "gate shutters";
+	pixel_x = 32
 	},
+/turf/open/water,
 /area/f13/tunnel)
 "xsL" = (
 /mob/living/simple_animal/hostile/radroach,
@@ -26430,22 +27432,29 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"xuH" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"xuW" = (
-/mob/living/simple_animal/hostile/enclave/soldier{
-	desc = "A former Enclave soldier, mutated by the forced evolutionary virus and grafted to the interior of his suit.";
-	extra_projectiles = 1;
-	faction = list("wastebot");
-	loot = null;
-	name = "mutated enclave soldier";
-	speak = list("AUUGHGHHH!");
-	speak_emote = list("shouts")
+"xsM" = (
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"xtH" = (
+/obj/structure/ore_box,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"xuK" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "xvg" = (
@@ -26457,6 +27466,12 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
+"xvS" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenfull"
+	},
+/area/f13/tunnel)
 "xxn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -26469,34 +27484,27 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"xxT" = (
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"xxV" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
 "xyk" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"xyx" = (
-/obj/effect/decal/fakelattice,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
-"xyR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"xyU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "xyW" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -26509,6 +27517,16 @@
 "xyX" = (
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"xzh" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
+"xzq" = (
+/obj/effect/landmark/start/f13/settler,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "xzX" = (
 /obj/item/storage/trash_stack,
@@ -26535,40 +27553,51 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
-"xAy" = (
-/obj/structure/barricade/sandbags,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
+"xAw" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
 	},
-/area/f13/bunker)
+/area/f13/tunnel)
+"xAO" = (
+/obj/structure/reagent_dispensers/barrel/four,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xCd" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"xCv" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
 "xCN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"xEM" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/assaultron{
-	aggro_vision_range = 30;
-	desc = "A prototype assaultron with (visibly) upgraded leg motors and hydraulics. It's painted in Enclave markings.";
-	dir = 4;
-	health = 1500;
-	maxHealth = 1500;
-	name = "PCU-11";
-	speed = -0.5
+"xDr" = (
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"xFI" = (
-/mob/living/simple_animal/hostile/raider/ranged,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/area/f13/followers)
+"xEd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/tunnel)
+"xEg" = (
+/obj/structure/chair/f13chair2,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "xFN" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -26590,26 +27619,28 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"xGO" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 10
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "xGV" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"xHg" = (
+/obj/machinery/autolathe/ammo/unlocked,
+/obj/item/book/granter/crafting_recipe/gunsmith_two,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/item/book/granter/crafting_recipe/gunsmith_one,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "xHs" = (
 /obj/item/circuitboard/machine/gibber,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whiterustysolid"
 	},
 /area/f13/tunnel)
-"xHv" = (
-/obj/structure/decoration/rag,
-/turf/closed/wall/r_wall/rust,
-/area/f13/bunker)
+"xHZ" = (
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "xIk" = (
 /obj/item/paper_bin{
 	pixel_y = 6
@@ -26622,6 +27653,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
+"xIy" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "xIF" = (
 /turf/open/floor/f13{
 	icon_state = "purplefull"
@@ -26634,26 +27669,55 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"xLN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
-	faction = list("raider");
-	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
-	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
-	name = "Repaired Turret";
-	scan_range = 9;
-	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
-	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
-	throw_range = 9
+"xJU" = (
+/obj/structure/toilet{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"xKg" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"xKn" = (
+/obj/structure/chair/wood/modern{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"xLd" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/ten,
+/obj/item/stack/sheet/glass/ten,
+/obj/item/stack/sheet/glass/ten,
+/obj/item/stack/rods/twentyfive,
+/turf/open/floor/plating/f13,
+/area/f13/followers)
 "xMx" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"xMB" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/followers)
+"xMK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"xNc" = (
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "xNs" = (
 /obj/machinery/conveyor/auto{
 	dir = 1
@@ -26677,32 +27741,19 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
-"xNP" = (
-/obj/structure/reagent_dispensers/barrel,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+"xOj" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greendirtysolid"
 	},
-/area/f13/bunker)
-"xOE" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/nsb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"xOJ" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/area/f13/tunnel)
+"xPz" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greendirtysolid"
 	},
-/area/f13/bunker)
-"xPs" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
+/area/f13/tunnel)
 "xPN" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -26747,21 +27798,18 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"xSb" = (
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
 "xSi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"xSA" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/decoration/rag,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
 "xSY" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -26774,43 +27822,88 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
-"xUb" = (
-/obj/structure/closet/crate{
-	anchored = 1;
-	can_be_unanchored = 1
+"xTE" = (
+/obj/item/storage/firstaid/ancient,
+/obj/item/storage/firstaid/ancient,
+/obj/item/storage/firstaid/ancient,
+/obj/effect/turf_decal/box/white,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/silver_sulf,
+/obj/item/reagent_containers/medspray/silver_sulf,
+/obj/item/reagent_containers/medspray/styptic,
+/obj/item/reagent_containers/medspray/styptic,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/storage/pill_bottle/chem_tin/fixer,
+/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/storage/pill_bottle/mannitol,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"xTN" = (
+/obj/structure/barricade/bars{
+	layer = 5
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/obj/item/gun/ballistic/revolver/m29/alt,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"xUX" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/west,
-/obj/item/shard{
-	pixel_x = 8;
-	pixel_y = 5
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/turf/open/water,
+/area/f13/tunnel)
+"xTR" = (
+/obj/effect/decal/cleanable/robot_debris/old,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
+"xUu" = (
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/tunnel)
+"xVf" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowleft";
+	layer = 2
 	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/bunker)
+/area/f13/followers)
+"xVt" = (
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "xVz" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"xVR" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greendirtysolid"
-	},
-/area/f13/tunnel)
 "xVW" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
+"xWG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Oasis";
+	req_one_access_txt = "25"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "xXc" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
@@ -26828,6 +27921,21 @@
 	icon_state = "neutralrusty"
 	},
 /area/f13/tunnel)
+"xYz" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/three_course_meal,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
+"xYV" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "xZd" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -26838,6 +27946,18 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"yaG" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg2"
+	},
+/area/f13/tunnel)
+"yaH" = (
+/obj/structure/flora/tree/jungle{
+	pixel_x = -33;
+	pixel_y = -3
+	},
+/turf/open/water,
 /area/f13/tunnel)
 "yaO" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -26856,17 +27976,32 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/f13/tcoms)
+"ycj" = (
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "ycl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"ydr" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib3-old"
+"ycG" = (
+/obj/structure/table,
+/obj/item/fusion_fuel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
 	},
-/turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"ydV" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "yej" = (
 /obj/machinery/door/window/northleft,
 /obj/effect/decal/cleanable/dirt,
@@ -26881,35 +28016,21 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"yeT" = (
-/obj/machinery/door/airlock/grunge,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/machinery/door/poddoor{
-	id = "hell"
+"yeZ" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
-"yfd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
+/area/f13/tunnel)
 "yfe" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"yfm" = (
-/obj/item/storage/trash_stack,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/wrench/power,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
+"yfi" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "yfz" = (
@@ -26918,10 +28039,24 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"yfL" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/followers)
 "ygg" = (
 /obj/item/flashlight,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"ygp" = (
+/obj/structure/bookcase/manuals/medical,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "ygu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -26929,6 +28064,26 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"ygC" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenfull"
+	},
+/area/f13/tunnel)
+"ygT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "yhd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26941,20 +28096,8 @@
 "yhT" = (
 /turf/closed/indestructible/opshuttle,
 /area/f13/caves)
-"yjB" = (
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"ykL" = (
-/mob/living/simple_animal/hostile/raider/ranged/boss,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"ylz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
+"ylT" = (
+/turf/closed/wall,
 /area/f13/bunker)
 
 (1,1,1) = {"
@@ -27800,7 +28943,7 @@ uoO
 uoO
 eoy
 uoO
-uoO
+buV
 eoy
 uoO
 uoO
@@ -28057,7 +29200,7 @@ uoO
 uoO
 eoy
 uoO
-pAI
+nBk
 eoy
 uoO
 uoO
@@ -28252,7 +29395,7 @@ hDw
 hDw
 adO
 hDw
-qpe
+aBI
 kxd
 uoO
 uoO
@@ -28415,9 +29558,9 @@ eLE
 eLE
 eLE
 eLE
-fAq
-fAq
-fAq
+eZm
+eZm
+eZm
 eLE
 eLE
 eLE
@@ -28670,13 +29813,13 @@ uoO
 eLE
 eLE
 eLE
-fAq
-fAq
-fAq
-tEo
-fAq
-fAq
-fAq
+eZm
+eZm
+eZm
+beu
+eZm
+eZm
+eZm
 eLE
 eLE
 eLE
@@ -28926,15 +30069,15 @@ uoO
 uoO
 eLE
 eLE
-fAq
-fAq
-vlo
+eZm
+eZm
+nJw
 eBg
 eBg
 pkL
-vlo
-fAq
-fAq
+nJw
+eZm
+eZm
 eLE
 eLE
 uoO
@@ -29183,15 +30326,15 @@ uoO
 uoO
 eLE
 rex
-fAq
+eZm
 pkL
 pAK
 eBg
 eBg
-phq
-fTt
-fTt
-fAq
+fPn
+gcC
+gcC
+eZm
 rex
 eLE
 eLE
@@ -29439,17 +30582,17 @@ uoO
 uoO
 uoO
 eLE
-fAq
-fAq
-tRH
-fTt
-mGY
-eJq
-mlW
-fTt
+eZm
+eZm
+csk
+gcC
+ubO
+uzf
+bGp
+gcC
 pkL
-fAq
-fAq
+eZm
+eZm
 eLE
 eLE
 uoO
@@ -29564,7 +30707,7 @@ uoO
 uoO
 uoO
 kxd
-dEy
+hDw
 hDw
 kxd
 uoO
@@ -29696,17 +30839,17 @@ uoO
 uoO
 eLE
 eLE
-fAq
-oGk
-mNc
+eZm
+vDW
+iKB
 pAK
-blF
-mYN
-qiA
-fTt
+fkT
+qtN
+ujn
+gcC
 eBg
-tEo
-fAq
+beu
+eZm
 eLE
 eLE
 uoO
@@ -29953,17 +31096,17 @@ uoO
 uoO
 eLE
 eLE
-fAq
-fAq
-rWl
-aNQ
-uhG
-hLh
-sYw
-nyt
+eZm
+eZm
+mng
+ozp
+bYr
+ryk
+umQ
+paD
 pkL
-fAq
-fAq
+eZm
+eZm
 eLE
 eLE
 uoO
@@ -30211,15 +31354,15 @@ uoO
 uoO
 eLE
 eLE
-fAq
-kHi
-kHi
-sVw
-rWl
+eZm
+boc
+boc
+kKl
+mng
 pAK
 pAK
 eBg
-fAq
+eZm
 eLE
 eLE
 eLE
@@ -30468,15 +31611,15 @@ uoO
 uoO
 eLE
 eLE
-fAq
-fAq
-irY
-kHi
-tdC
-bxQ
-igG
-fAq
-fAq
+eZm
+eZm
+sgv
+boc
+ros
+mNF
+tFD
+eZm
+eZm
 eLE
 eLE
 uoO
@@ -30726,13 +31869,13 @@ eLE
 eLE
 eLE
 eLE
-fAq
-fAq
-vBz
-kne
-vBz
-fAq
-fAq
+eZm
+eZm
+uRT
+vhH
+uRT
+eZm
+eZm
 eLE
 eLE
 eLE
@@ -30781,7 +31924,7 @@ xVz
 aoj
 xVz
 xVz
-sne
+tcN
 xVz
 xVz
 uoO
@@ -30984,11 +32127,11 @@ eLE
 eLE
 eLE
 eLE
-fAq
+eZm
 pkL
 eBg
-jKq
-fAq
+qDc
+eZm
 eLE
 eLE
 eLE
@@ -31033,7 +32176,7 @@ aoj
 uoO
 uoO
 xVz
-lah
+gYA
 xVz
 xVz
 xVz
@@ -31241,11 +32384,11 @@ eLE
 eLE
 eLE
 eLE
-fAq
+eZm
 eBg
 eBg
-sOB
-fAq
+cdo
+eZm
 eLE
 eLE
 eLE
@@ -31284,14 +32427,14 @@ uoO
 aoj
 aoj
 aoj
-jPC
+uXs
 aoj
 aoj
 uoO
 uoO
 xVz
 xVz
-pmU
+sBm
 xVz
 xVz
 aoj
@@ -31498,11 +32641,11 @@ eLE
 eLE
 eLE
 eLE
-fAq
-cxU
+eZm
+qBi
 pAK
 pkL
-fAq
+eZm
 eLE
 eLE
 eLE
@@ -31548,7 +32691,7 @@ xVz
 xVz
 xVz
 xVz
-ouh
+eUI
 xVz
 aoj
 aoj
@@ -31750,21 +32893,21 @@ uoO
 uoO
 uoO
 eLE
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
 pkL
-sOB
+cdo
 pkL
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
 eLE
 eLE
 eLE
@@ -31806,7 +32949,7 @@ xVz
 xVz
 xVz
 xVz
-uWH
+qOQ
 uoO
 aoj
 uoO
@@ -32007,21 +33150,21 @@ aoj
 uoO
 eLE
 eLE
-fAq
-nHa
-nUx
-imY
-vgZ
-fAq
-wHt
+eZm
+aTh
+sFf
+kDV
+bHt
+eZm
+bnv
 pkL
-ifT
-fAq
-mqi
-lUJ
-mVr
-gNR
-fAq
+dcv
+eZm
+oxI
+gUI
+vQK
+lBq
+eZm
 eLE
 eLE
 eLE
@@ -32264,21 +33407,21 @@ aoj
 uoO
 eLE
 eLE
-fAq
-iVc
+eZm
+hkf
 pkL
-clP
-kHi
-fAq
+jno
+boc
+eZm
 eBg
-iGR
+oQp
 eBg
-fAq
-aNQ
-oOO
+eZm
+ozp
+niP
 pAK
 pAK
-fAq
+eZm
 eLE
 eLE
 eLE
@@ -32320,7 +33463,7 @@ uoO
 uoO
 uoO
 xVz
-pmU
+sBm
 uoO
 uoO
 uoO
@@ -32521,21 +33664,21 @@ aoj
 uoO
 eLE
 eLE
-fAq
+eZm
 eBg
-wmI
+ige
 pkL
-obu
-tWP
+hTX
+pxX
 eBg
 eBg
 pkL
-tDv
-eoL
-eoL
-fTt
-lhT
-fAq
+tDj
+nZs
+nZs
+gcC
+myC
+eZm
 eLE
 eLE
 eLE
@@ -32561,7 +33704,7 @@ uoO
 xVz
 xVz
 xVz
-buV
+iDt
 xVz
 uoO
 uoO
@@ -32588,7 +33731,7 @@ uoO
 uoO
 uoO
 xVz
-buV
+iDt
 xVz
 xVz
 uoO
@@ -32778,21 +33921,21 @@ uoO
 uoO
 eLE
 eLE
-fAq
-urI
-wmI
-eoL
-kYy
-fAq
-lBR
+eZm
+mGl
+ige
+nZs
+qcq
+eZm
+bMV
 eBg
-vRe
-fAq
-uis
-eoL
-dyS
-rCV
-fAq
+mpN
+eZm
+fOJ
+nZs
+ioO
+qPZ
+eZm
 eLE
 eLE
 eLE
@@ -32841,8 +33984,8 @@ uoO
 uoO
 uoO
 uoO
-xVz
-xVz
+qDR
+qDR
 xVz
 xVz
 xVz
@@ -33035,21 +34178,21 @@ uoO
 uoO
 eLE
 eLE
-fAq
-qrK
-mtA
-rcM
-nHa
-fAq
+eZm
+nJO
+kFX
+fnQ
+aTh
+eZm
 pAK
-oLu
-vRe
-fAq
-nHa
-iuU
-oBz
-hPk
-fAq
+tak
+mpN
+eZm
+aTh
+wlv
+nQZ
+iVM
+eZm
 eLE
 eLE
 eLE
@@ -33099,7 +34242,7 @@ uoO
 uoO
 uoO
 xVz
-xVz
+qDR
 xVz
 xVz
 xVz
@@ -33182,13 +34325,13 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 eLE
 eLE
 eLE
@@ -33292,21 +34435,21 @@ uoO
 uoO
 eLE
 eLE
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
-mKg
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
+bNe
 pkL
-lKF
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
+ngM
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
 eLE
 eLE
 uoO
@@ -33342,7 +34485,7 @@ uoO
 uoO
 uoO
 uoO
-jPC
+uXs
 uoO
 uoO
 uoO
@@ -33547,19 +34690,19 @@ uoO
 uoO
 uoO
 uoO
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
-dbg
-fAq
-fAq
-fAq
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
+tOP
+eZm
+eZm
+eZm
 rex
 rex
 rex
@@ -33593,7 +34736,7 @@ uoO
 uoO
 uoO
 xVz
-buV
+iDt
 xVz
 xVz
 xVz
@@ -33765,7 +34908,7 @@ eUk
 bcN
 rQA
 bcN
-itz
+tUT
 dZF
 eLE
 uoO
@@ -33804,43 +34947,43 @@ uoO
 uoO
 uoO
 uoO
-fAq
-uiT
-kJI
-eEE
-fAq
-fAq
-fAq
-iRA
-vlo
+eZm
+gzI
+sNZ
+wOv
+eZm
+eZm
+eZm
+uST
+nJw
 pkL
-xPs
-loO
-fAq
-fAq
-fAq
-fAq
-fAq
-mKS
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-azs
+jBX
+kSK
+eZm
+eZm
+eZm
+eZm
+eZm
+dWp
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+ask
 xVz
 xVz
 uoO
@@ -33854,6 +34997,7 @@ xVz
 xVz
 xVz
 xVz
+qDR
 xVz
 xVz
 xVz
@@ -33864,8 +35008,7 @@ xVz
 xVz
 xVz
 xVz
-xVz
-vQn
+mkv
 xVz
 xVz
 xVz
@@ -34061,42 +35204,42 @@ uoO
 uoO
 uoO
 aoj
-fAq
+eZm
 pkL
-yfd
+dJG
 pAK
 eBg
-evS
-fAq
-pkv
+isT
+eZm
+dfs
 eBg
-azz
-tRH
-fTt
-fAq
-nnn
-eoL
-dYA
-tRH
-mKS
-azs
-azs
-swh
-azs
-azs
-azs
-azs
-azs
-azs
-azs
-uio
-azs
-azs
-azs
-azs
-azs
-azs
-swh
+lxC
+csk
+gcC
+eZm
+njE
+nZs
+npJ
+csk
+dWp
+ask
+ask
+dwz
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ekK
+ask
+ask
+ask
+ask
+ask
+ask
+dwz
 xVz
 xVz
 xVz
@@ -34131,8 +35274,8 @@ xVz
 xVz
 xVz
 xVz
-tUT
-jPC
+oXu
+uXs
 uoO
 uoO
 uoO
@@ -34318,41 +35461,41 @@ aoj
 uoO
 uoO
 uoO
-fAq
+eZm
 pkL
-xbg
+goY
 pkL
-azz
+lxC
 pAK
-fVn
+gYR
 pAK
 eBg
-mDZ
+aWS
 pAK
-cOo
-nOw
+hky
+cqB
 pkL
 eBg
-eoL
-lBR
-lpa
-azs
-azs
-azs
-azs
-azs
-uio
-azs
-azs
-azs
-azs
-azs
-azs
-azs
-azs
-azs
-azs
-azs
+nZs
+bMV
+vTA
+ask
+ask
+ask
+ask
+ask
+ekK
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
 xVz
 xVz
 xVz
@@ -34372,7 +35515,7 @@ xVz
 xVz
 xVz
 xVz
-buV
+iDt
 xVz
 xVz
 uoO
@@ -34575,42 +35718,42 @@ uoO
 uoO
 uoO
 uoO
-fAq
-rAs
+eZm
+jOH
 pkL
 pAK
 pAK
-mqF
-fAq
-gGS
+gjr
+eZm
+psp
 pkL
-kjo
+aZi
 eBg
-qHx
-fAq
-loO
-eoL
-pPj
+ygT
+eZm
+kSK
+nZs
+elg
 pkL
-lpa
-ubj
-azs
-nKX
-azs
-azs
-azs
-azs
-azs
-azs
-azs
-azs
-azs
-azs
-azs
-azs
-azs
-azs
-bWq
+vTA
+hEH
+ask
+qxk
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+njs
 xVz
 xVz
 xVz
@@ -34832,41 +35975,41 @@ uoO
 uoO
 aoj
 uoO
-fAq
-tNc
-ksw
-mIx
-fAq
-fAq
-fAq
-iRA
-sMy
+eZm
+rKp
+kUc
+oiA
+eZm
+eZm
+eZm
+uST
+vqf
 pkL
-sMy
-iRA
-fAq
-fAq
-fAq
-fAq
-fAq
-mKS
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
-gFg
+vqf
+uST
+eZm
+eZm
+eZm
+eZm
+eZm
+dWp
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
+qZq
 xVz
 xVz
 xVz
@@ -35089,19 +36232,19 @@ uoO
 uoO
 uoO
 uoO
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
-pqz
-fAq
-fAq
-fAq
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
+hjL
+eZm
+eZm
+eZm
 rex
 rex
 rex
@@ -35155,7 +36298,7 @@ uoO
 uoO
 uoO
 uoO
-xVz
+qDR
 xVz
 xVz
 xVz
@@ -35348,21 +36491,21 @@ uoO
 uoO
 eLE
 eLE
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
-xyx
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
+xsM
 eBg
-vlo
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
+nJw
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
 eLE
 eLE
 uoO
@@ -35414,7 +36557,7 @@ uoO
 uoO
 xVz
 xVz
-jPC
+uXs
 uoO
 uoO
 xVz
@@ -35605,21 +36748,21 @@ uoO
 uoO
 eLE
 eLE
-fAq
-uMe
-nCS
-qbi
-qwy
-fAq
-ojq
-bxQ
-eoL
-fAq
-pYE
-fWI
-xNP
-dSW
-fAq
+eZm
+xNc
+wXk
+bbB
+bIH
+eZm
+bKB
+mNF
+nZs
+eZm
+dcK
+xuK
+jJb
+tbr
+eZm
 eLE
 eLE
 eLE
@@ -35862,21 +37005,21 @@ uoO
 uoO
 eLE
 eLE
-fAq
-sbY
-suB
-icW
+eZm
+yfi
+kFD
+kWm
 pkL
-fAq
-kHi
-rWl
-lGO
-fAq
-dPM
-eoL
-ecZ
-rIA
-fAq
+eZm
+boc
+mng
+uuf
+eZm
+aqs
+nZs
+kAA
+vqz
+eZm
 eLE
 eLE
 eLE
@@ -36119,21 +37262,21 @@ uoO
 uoO
 uoO
 eLE
-fAq
+eZm
 eBg
-eoL
+nZs
 pAK
 pAK
-tWP
-mNc
-tdC
+pxX
+iKB
+ros
 eBg
-jTg
+arD
 pAK
-hae
-lOq
-ecZ
-fAq
+uFB
+hgw
+kAA
+eZm
 eLE
 eLE
 eLE
@@ -36155,8 +37298,8 @@ uoO
 uoO
 xVz
 xVz
-tUT
-jPC
+oXu
+uXs
 uoO
 uoO
 uoO
@@ -36180,8 +37323,8 @@ uoO
 uoO
 uoO
 uoO
-jPC
-qrc
+uXs
+tDl
 xVz
 xVz
 uoO
@@ -36376,21 +37519,21 @@ uoO
 uoO
 uoO
 eLE
-fAq
+eZm
 pkL
-icW
-fTt
-vSC
-fAq
+kWm
+gcC
+rQe
+eZm
 pkL
-eoL
+nZs
 pkL
-fAq
-hJs
-pdV
-fTt
-pVW
-fAq
+eZm
+uMj
+oEf
+gcC
+snr
+eZm
 eLE
 eLE
 eLE
@@ -36633,34 +37776,34 @@ uoO
 uoO
 uoO
 eLE
-fAq
-hlb
-dKt
-tkz
-acY
-fAq
-vBf
+eZm
+fDj
+mHF
+oix
+qjp
+eZm
+pXO
 eBg
-lGl
-fAq
-eeY
-tGP
-rGn
-bGf
-fAq
+pMU
+eZm
+iqa
+uGd
+nsm
+qXd
+eZm
 eLE
 eLE
 eLE
 eLE
 eLE
 eLE
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
 eLE
 uoO
 uoO
@@ -36890,34 +38033,34 @@ uoO
 uoO
 uoO
 eLE
-fAq
-fAq
-fAq
-fAq
-fAq
-fAq
+eZm
+eZm
+eZm
+eZm
+eZm
+eZm
 pkL
 pkL
-lcG
-fAq
-fAq
-fAq
-qSZ
-fAq
-fAq
+rvA
+eZm
+eZm
+eZm
+dsr
+eZm
+eZm
 eLE
 eLE
 eLE
 eLE
 eLE
 eLE
-fAq
-iTk
-hbd
-gjk
-chC
-dpx
-fAq
+eZm
+vBh
+eev
+qNr
+eWV
+dRw
+eZm
 eLE
 eLE
 uoO
@@ -36945,7 +38088,7 @@ aoj
 aoj
 aoj
 aoj
-jPC
+uXs
 uoO
 xVz
 xVz
@@ -36999,7 +38142,7 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -37152,29 +38295,29 @@ eLE
 eLE
 eLE
 eLE
-fAq
-xuW
+eZm
+hia
 pkL
-mNc
-fAq
+iKB
+eZm
 eLE
-lYf
-lDm
-pnI
-eLE
-eLE
+tbI
+ato
+tni
 eLE
 eLE
 eLE
 eLE
 eLE
-fAq
-uMm
-maE
-iZl
-gfP
-kfU
-fAq
+eLE
+eLE
+eZm
+pKf
+vkB
+sZB
+gGm
+fxS
+eZm
 eLE
 eLE
 uoO
@@ -37206,7 +38349,7 @@ wKH
 xVz
 xVz
 xVz
-vSd
+twi
 uoO
 uoO
 uoO
@@ -37260,8 +38403,8 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -37409,29 +38552,29 @@ eLE
 eLE
 eLE
 eLE
-fAq
+eZm
 pkL
-eoL
+nZs
 eBg
-fAq
+eZm
 eLE
-vJw
-hyd
-lDm
-gxe
-wND
+xAO
+emX
+ato
+pGK
+oqN
 eLE
-fAq
-fAq
-fAq
-fAq
-fAq
-maE
-sbl
-hsY
-kjV
-nZZ
-fAq
+eZm
+eZm
+eZm
+eZm
+eZm
+vkB
+xMK
+lIq
+wnJ
+isw
+eZm
 eLE
 eLE
 uoO
@@ -37510,14 +38653,14 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -37666,29 +38809,29 @@ eLE
 eLE
 eLE
 eLE
-fAq
+eZm
 pkL
 pkL
-oOh
-fAq
+qNh
+eZm
 eLE
 eLE
-azs
-hyd
-lDm
-lDm
+ask
+emX
+ato
+ato
 xVz
-fAq
-wQm
-sLS
-rhn
-vBz
-maE
-xEM
-lGG
-aBk
-lHu
-fAq
+eZm
+sIk
+iDv
+tUG
+uRT
+vkB
+ovy
+cUR
+gSw
+oCH
+eZm
 eLE
 eLE
 uoO
@@ -37716,9 +38859,9 @@ uoO
 uoO
 xVz
 xVz
-bRX
-xfu
-pmU
+qOc
+bwA
+sBm
 xVz
 xVz
 xVz
@@ -37767,14 +38910,14 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -37922,30 +39065,30 @@ eLE
 eLE
 eLE
 eLE
-fAq
-fAq
-vBz
-sOB
-nZt
-fAq
-fAq
+eZm
+eZm
+uRT
+cdo
+hsj
+eZm
+eZm
 eLE
 eLE
-pnI
-nmn
-lDm
-azs
-hEv
-ocI
-ljX
-ocI
-iff
-maE
-lGG
-ocI
-ebs
-xAy
-fAq
+tni
+qAP
+ato
+ask
+xqJ
+nGb
+kKf
+nGb
+wOH
+vkB
+cUR
+nGb
+bDq
+gsT
+eZm
 eLE
 eLE
 uoO
@@ -37978,7 +39121,7 @@ xVz
 xVz
 xVz
 xVz
-xhF
+kSD
 xVz
 uoO
 uoO
@@ -38024,14 +39167,14 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -38178,31 +39321,31 @@ uoO
 uoO
 eLE
 eLE
-fAq
-fAq
-vlo
+eZm
+eZm
+nJw
 pkL
 eBg
 pkL
-cJZ
-fAq
-fAq
+kwu
+eZm
+eZm
 eLE
 eLE
 eLE
-vpb
-eBh
-fAq
-rhn
-cxy
-wQm
-vBz
-xAy
-xAy
-maE
-maE
-knU
-fAq
+uoj
+rsQ
+eZm
+tUG
+xmE
+sIk
+uRT
+gsT
+gsT
+vkB
+vkB
+hzG
+eZm
 eLE
 eLE
 uoO
@@ -38217,11 +39360,11 @@ uoO
 uoO
 uoO
 xVz
-buV
+iDt
 xVz
 uoO
 uoO
-jPC
+uXs
 uoO
 uoO
 uoO
@@ -38231,7 +39374,7 @@ xVz
 xVz
 mlz
 xVz
-xgx
+wWE
 eAQ
 pOB
 xVz
@@ -38281,14 +39424,14 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -38435,31 +39578,31 @@ uoO
 uoO
 eLE
 eLE
-fAq
-jBe
-jKx
+eZm
+bIJ
+jGt
 pkL
-xOJ
+pcY
 pkL
-tdC
-cAq
-fAq
+ros
+kJR
+eZm
 eLE
 eLE
 eLE
 eLE
 eLE
-fAq
-fAq
-fAq
-fAq
-fAq
-bFU
-maE
-xAy
-wyL
-pcK
-fAq
+eZm
+eZm
+eZm
+eZm
+eZm
+ycG
+vkB
+gsT
+awq
+awf
+eZm
 eLE
 eLE
 uoO
@@ -38489,7 +39632,7 @@ xVz
 xVz
 xVz
 xVz
-xfu
+bwA
 xVz
 xVz
 xVz
@@ -38540,14 +39683,14 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -38691,17 +39834,17 @@ uoO
 uoO
 uoO
 eLE
-fAq
-fAq
+eZm
+eZm
 pkL
 pkL
-xOJ
-uKj
-xUX
-hhc
-bxQ
-fAq
-fAq
+pcY
+udK
+cgr
+vHI
+mNF
+eZm
+eZm
 eLE
 eLE
 eLE
@@ -38710,13 +39853,13 @@ eLE
 eLE
 eLE
 eLE
-fAq
-mHW
-btV
-ocI
-ocI
-bdL
-fAq
+eZm
+czr
+tdU
+nGb
+nGb
+wAd
+eZm
 eLE
 eLE
 uoO
@@ -38724,7 +39867,7 @@ uoO
 xVz
 xVz
 xVz
-buV
+iDt
 xVz
 xVz
 xVz
@@ -38748,7 +39891,7 @@ xVz
 xVz
 xVz
 xVz
-pmU
+sBm
 xVz
 xVz
 uoO
@@ -38800,11 +39943,11 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -38948,17 +40091,17 @@ uoO
 uoO
 uoO
 eLE
-fAq
-tEo
-hbh
-xOJ
-wkZ
-iMh
-tei
+eZm
+beu
+mnY
+pcY
+kjo
+nbI
+flc
 pkL
-eXP
-aJX
-fAq
+exV
+kXs
+eZm
 eLE
 eLE
 eLE
@@ -38967,13 +40110,13 @@ eLE
 eLE
 eLE
 eLE
-fAq
-lbN
-maE
-ocI
-ebs
-xAy
-fAq
+eZm
+fkE
+vkB
+nGb
+bDq
+gsT
+eZm
 eLE
 eLE
 uoO
@@ -38993,17 +40136,17 @@ xVz
 xVz
 xVz
 xVz
-jPC
+uXs
 uoO
 uoO
 uoO
 uoO
-jPC
+uXs
 uoO
 uoO
-xcH
+fDg
 xVz
-kjz
+qpG
 xVz
 xVz
 xVz
@@ -39060,8 +40203,8 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -39205,17 +40348,17 @@ uoO
 uoO
 uoO
 eLE
-fAq
-fAq
+eZm
+eZm
 eBg
 eBg
-usv
-hLh
-dQD
-vxb
-bxQ
-fAq
-fAq
+awF
+ryk
+vEW
+qVk
+mNF
+eZm
+eZm
 eLE
 eLE
 eLE
@@ -39224,13 +40367,13 @@ eLE
 eLE
 eLE
 eLE
-fAq
-gpr
-gpr
-ttJ
-ttJ
-gpr
-fAq
+eZm
+onb
+onb
+bMf
+bMf
+onb
+eZm
 eLE
 eLE
 uoO
@@ -39241,7 +40384,7 @@ uoO
 xVz
 xVz
 xVz
-xVz
+qDR
 xVz
 xVz
 xVz
@@ -39317,16 +40460,16 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
 uoO
 uoO
 eLE
 uoO
 gpM
 lnr
-rKx
 lnr
+hQG
 uoO
 uoO
 uoO
@@ -39463,7 +40606,7 @@ uoO
 uoO
 eLE
 eLE
-fAq
+eZm
 pkL
 pkL
 pkL
@@ -39471,9 +40614,9 @@ pkL
 pkL
 eBg
 pkL
-hEv
-azs
-rDn
+xqJ
+ask
+uXM
 eLE
 eLE
 eLE
@@ -39481,13 +40624,13 @@ eLE
 eLE
 eLE
 eLE
-fAq
-lbN
-maE
-ocI
-mGf
-lws
-fAq
+eZm
+fkE
+vkB
+nGb
+fER
+peZ
+eZm
 eLE
 uoO
 uoO
@@ -39518,7 +40661,7 @@ uoO
 uoO
 uoO
 xVz
-xgQ
+dqU
 aoj
 aoj
 aoj
@@ -39574,8 +40717,8 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -39720,31 +40863,31 @@ uoO
 uoO
 eLE
 eLE
-fAq
-fAq
-pPj
+eZm
+eZm
+elg
 eBg
 pkL
-vTd
-rBX
-fAq
-fAq
-nZu
-azs
-gxe
+uTw
+aZR
+eZm
+eZm
+iym
+ask
+pGK
 eLE
 eLE
 eLE
 eLE
 eLE
 eLE
-fAq
-gpr
-gpr
-ttJ
-ttJ
-gpr
-fAq
+eZm
+onb
+onb
+bMf
+bMf
+onb
+eZm
 eLE
 uoO
 uoO
@@ -39761,7 +40904,7 @@ uoO
 uoO
 uoO
 uoO
-jPC
+uXs
 uoO
 uoO
 aoj
@@ -39786,7 +40929,7 @@ uoO
 uoO
 uoO
 xVz
-buV
+iDt
 uoO
 uoO
 uoO
@@ -39832,7 +40975,7 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
 uoO
 uoO
 eLE
@@ -39978,28 +41121,28 @@ uoO
 uoO
 eLE
 rex
-fAq
-fAq
-fAq
-eec
-fAq
-fAq
-fAq
+eZm
+eZm
+eZm
+qUh
+eZm
+eZm
+eZm
 xVz
-lDm
-lDm
-pnI
-azs
-wND
+ato
+ato
+tni
+ask
+oqN
 eLE
 eLE
 eLE
-pnI
-lDm
-pnI
-azs
-eCA
-pnI
+tni
+ato
+tni
+ask
+lxD
+tni
 xVz
 eLE
 eLE
@@ -40089,7 +41232,7 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -40237,26 +41380,26 @@ eLE
 eLE
 eLE
 eLE
-jQU
-jQU
-jQU
+hdX
+hdX
+hdX
 eLE
-vpb
-tlH
-qTL
-lDm
-pnI
-azs
-azs
-vpb
-uRW
-kqY
-lDm
-hyd
-nmn
+uoj
+pmZ
+cSX
+ato
+tni
+ask
+ask
+uoj
+nta
+arQ
+ato
+emX
+qAP
 xVz
-vJw
-azs
+xAO
+ask
 eLE
 eLE
 uoO
@@ -40293,7 +41436,7 @@ aoj
 aoj
 aoj
 uoO
-lqy
+jKu
 xVz
 aoj
 uoO
@@ -40500,18 +41643,18 @@ eLE
 eLE
 eLE
 eLE
-vpb
-lLh
-lDm
-liB
-srd
-azs
-lDm
-twG
-lDm
-azs
-uiW
-pnI
+uoj
+cOe
+ato
+xlp
+xgw
+ask
+ato
+izY
+ato
+ask
+jIi
+tni
 eLE
 eLE
 eLE
@@ -40759,14 +41902,14 @@ eLE
 eLE
 eLE
 eLE
-axC
-jwF
+nTw
+wUy
 xVz
-srd
-azs
-uFR
-gua
-pnI
+xgw
+ask
+iBw
+jMN
+tni
 eLE
 eLE
 eLE
@@ -41036,8 +42179,8 @@ uoO
 uoO
 uoO
 uoO
-jPC
-qrc
+uXs
+tDl
 xVz
 xVz
 xVz
@@ -41579,7 +42722,7 @@ uoO
 uoO
 uoO
 uoO
-jPC
+uXs
 uoO
 xVz
 xVz
@@ -41803,9 +42946,9 @@ uoO
 uoO
 uoO
 uoO
-jPC
-lsl
-azs
+uXs
+nlP
+ask
 xVz
 xVz
 xVz
@@ -42060,9 +43203,9 @@ uoO
 uoO
 uoO
 uoO
-azs
-azs
-azs
+ask
+ask
+ask
 xVz
 xVz
 xVz
@@ -42316,8 +43459,8 @@ uoO
 uoO
 uoO
 uoO
-azs
-azs
+ask
+ask
 xVz
 xVz
 xVz
@@ -42357,7 +43500,7 @@ xVz
 xVz
 xVz
 xVz
-jPC
+uXs
 uoO
 uoO
 uoO
@@ -42573,8 +43716,8 @@ uoO
 uoO
 uoO
 uoO
-azs
-azs
+ask
+ask
 xVz
 xVz
 xVz
@@ -42589,7 +43732,7 @@ uoO
 uoO
 xVz
 xVz
-buV
+iDt
 xVz
 xVz
 xVz
@@ -42830,11 +43973,11 @@ uoO
 uoO
 uoO
 uoO
-azs
-azs
-azs
+ask
+ask
+ask
 xVz
-vQn
+mkv
 xVz
 xVz
 xVz
@@ -43087,9 +44230,9 @@ uoO
 uoO
 uoO
 uoO
-azs
-azs
-azs
+ask
+ask
+ask
 xVz
 xVz
 xVz
@@ -43119,7 +44262,7 @@ uoO
 uoO
 uoO
 uoO
-buV
+iDt
 xVz
 xVz
 xVz
@@ -43345,8 +44488,8 @@ uoO
 uoO
 uoO
 uoO
-azs
-azs
+ask
+ask
 xVz
 xVz
 xVz
@@ -43365,7 +44508,7 @@ xVz
 uoO
 uoO
 uoO
-jPC
+uXs
 uoO
 uoO
 uoO
@@ -43380,7 +44523,7 @@ uoO
 xVz
 xVz
 xVz
-vQn
+mkv
 xVz
 xVz
 xVz
@@ -43608,8 +44751,8 @@ xVz
 xVz
 xVz
 xVz
-tUT
-jPC
+oXu
+uXs
 uoO
 uoO
 uoO
@@ -44104,12 +45247,14 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -44120,10 +45265,8 @@ uoO
 xVz
 xVz
 xVz
-xVz
-xVz
-xVz
-xVz
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -44361,26 +45504,26 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-jPC
-qrc
 xVz
 xVz
 xVz
 xVz
-xVz
-xVz
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -44629,15 +45772,15 @@ uoO
 uoO
 uoO
 uoO
+uoO
 xVz
 xVz
 xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-ckx
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -44748,7 +45891,7 @@ uoO
 uoO
 uoO
 uoO
-mUZ
+jiL
 uoO
 uoO
 uoO
@@ -44869,8 +46012,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -44889,23 +46032,9 @@ uoO
 xVz
 xVz
 xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 aoj
 aoj
 uoO
@@ -44915,9 +46044,23 @@ uoO
 uoO
 uoO
 uoO
-xVz
-xVz
-xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -44971,11 +46114,11 @@ uoO
 uoO
 uoO
 eLE
-blc
-blc
-blc
-blc
-blc
+abi
+abi
+abi
+abi
+abi
 eLE
 uoO
 uoO
@@ -45126,30 +46269,22 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
+oXu
+uXs
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 xVz
 xVz
 xVz
@@ -45159,20 +46294,28 @@ uoO
 uoO
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-xVz
-xVz
-xVz
-xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -45228,11 +46371,11 @@ uoO
 uoO
 uoO
 eLE
-blc
-jiL
-eOt
-tUi
-blc
+abi
+acT
+aCf
+bSL
+abi
 eLE
 uoO
 uoO
@@ -45383,20 +46526,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -45405,10 +46536,13 @@ uoO
 uoO
 xVz
 xVz
+mlz
 uoO
 uoO
-xVz
-xVz
+uoO
+uoO
+uoO
+mlz
 xVz
 xVz
 uoO
@@ -45426,9 +46560,18 @@ uoO
 uoO
 uoO
 uoO
-xVz
-xVz
-xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -45485,11 +46628,11 @@ uoO
 uoO
 uoO
 eLE
-blc
-mot
-uGl
-oLG
-blc
+abi
+adx
+aCq
+bWk
+abi
 eLE
 uoO
 uoO
@@ -45639,31 +46782,22 @@ uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
 xVz
 xVz
 xVz
@@ -45682,16 +46816,25 @@ uoO
 uoO
 uoO
 uoO
-xVz
-xVz
-xVz
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -45742,11 +46885,11 @@ uoO
 uoO
 uoO
 eLE
-blc
-mot
-eOt
-tWZ
-blc
+abi
+adx
+aCf
+bWl
+abi
 eLE
 uoO
 uoO
@@ -45895,49 +47038,22 @@ uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+mlz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 xVz
-tUT
-jPC
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 xVz
 xVz
 xVz
@@ -45945,10 +47061,37 @@ xVz
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -45999,11 +47142,11 @@ uoO
 uoO
 uoO
 eLE
-blc
-mot
-eOt
-mot
-blc
+abi
+adx
+aCf
+adx
+abi
 eLE
 uoO
 uoO
@@ -46152,33 +47295,23 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+eAQ
+xVz
+xVz
+xVz
+xVz
+xVz
 xVz
 xVz
 uoO
@@ -46187,17 +47320,27 @@ uoO
 uoO
 uoO
 uoO
-xVz
-xVz
-mlz
 uoO
 uoO
 uoO
 uoO
 uoO
-mlz
-xVz
-xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -46256,11 +47399,11 @@ uoO
 uoO
 uoO
 eLE
-blc
-pnL
-uop
-aKV
-blc
+abi
+adY
+aCu
+cid
+abi
 eLE
 eLE
 eLE
@@ -46402,43 +47545,15 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-xVz
 xVz
 xVz
 uoO
+uoO
+uoO
+hQE
+uoO
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -46448,12 +47563,40 @@ xVz
 xVz
 xVz
 xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+qDR
 uoO
-xVz
-xVz
-xVz
-xVz
-xVz
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -46513,22 +47656,22 @@ uoO
 uoO
 uoO
 eLE
-blc
-qxv
-vIr
-gvW
-blc
-blc
-blc
-blc
-vYJ
-blc
-blc
-blc
-blc
-blc
-blc
-blc
+abi
+aeS
+aGv
+crg
+abi
+abi
+abi
+abi
+gSQ
+abi
+abi
+abi
+abi
+abi
+abi
+abi
 eLE
 uoO
 uoO
@@ -46543,7 +47686,7 @@ uoO
 xVz
 xVz
 xVz
-pmU
+sBm
 xVz
 uoO
 uoO
@@ -46659,60 +47802,60 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 xVz
 xVz
-xVz
+oXu
+hQE
+uoO
+wKH
 xVz
 xVz
 uoO
+uXs
 uoO
-mlz
-xVz
-xVz
-xVz
-xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+iDt
 xVz
 xVz
 uoO
 xVz
 xVz
 xVz
-xVz
-xVz
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+eLE
+eLE
+uoO
+uoO
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -46770,22 +47913,22 @@ uoO
 uoO
 uoO
 eLE
-blc
-qHc
-uop
-vIr
-blc
-jXq
-chC
-gEd
-mMd
-tAd
-qGS
-eAm
-iaz
-iaz
-rdM
-blc
+abi
+afj
+aCu
+aGv
+abi
+eom
+eWV
+gct
+gTv
+hLd
+ifD
+imj
+jug
+jug
+lAR
+abi
 eLE
 uoO
 uoO
@@ -46914,29 +48057,17 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+hQE
+tDl
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+qOc
+oXu
+hQE
 uoO
 uoO
 uoO
@@ -46951,22 +48082,6 @@ uoO
 xVz
 xVz
 xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-eAQ
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
 uoO
 uoO
 uoO
@@ -46975,7 +48090,35 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+eLE
+eLE
+eLE
+uoO
+uoO
+eLE
+eLE
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -47027,22 +48170,22 @@ uoO
 uoO
 uoO
 eLE
-blc
-uzO
-eOt
-gUj
-jdH
-dns
-nvT
-icB
-wMX
-blc
-fdA
-gCz
-quL
-eAm
-syJ
-blc
+abi
+ahe
+aCf
+cxu
+dJV
+eoC
+fbC
+gev
+gWc
+abi
+igD
+jdP
+juP
+imj
+lAW
+abi
 eLE
 uoO
 uoO
@@ -47136,14 +48279,14 @@ uoO
 uoO
 eLE
 jmN
-bSS
-bSS
-bud
-bSS
-mSj
+unV
+unV
+uVr
+unV
+vSd
 jmN
-dML
-dML
+wFx
+wFx
 jmN
 eLE
 uoO
@@ -47172,21 +48315,15 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+ftu
+xVz
+xVz
+xVz
+xVz
+twi
+mlz
+xVz
 uoO
 uoO
 uoO
@@ -47200,29 +48337,12 @@ uoO
 uoO
 xVz
 xVz
-uoO
-uoO
-uoO
-hQE
-uoO
+xVz
 xVz
 xVz
 uoO
 uoO
 uoO
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
 uoO
 uoO
 uoO
@@ -47234,6 +48354,29 @@ uoO
 uoO
 uoO
 uoO
+uoO
+eLE
+eLE
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 aoj
@@ -47284,22 +48427,22 @@ uoO
 uoO
 uoO
 eLE
-blc
-blc
-cnA
-gMS
-blc
-blc
-blc
-blc
-blc
-blc
-krm
-sAl
-eAm
-wzt
-jXC
-blc
+abi
+abi
+aGO
+cyG
+abi
+abi
+abi
+abi
+abi
+abi
+igH
+jej
+imj
+kss
+lKT
+abi
 eLE
 uoO
 uoO
@@ -47393,14 +48536,14 @@ uoO
 uoO
 eLE
 jmN
-bSS
-aTr
-aWF
-bWl
-bSS
-dzJ
-bSS
-bSS
+unV
+uAb
+uFj
+vnW
+unV
+wqi
+unV
+unV
 jmN
 eLE
 uoO
@@ -47428,53 +48571,12 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 xVz
 xVz
-tUT
-hQE
-uoO
-wKH
+hYE
 xVz
 xVz
-uoO
-jPC
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-buV
 xVz
-xVz
-uoO
 xVz
 xVz
 xVz
@@ -47487,11 +48589,52 @@ uoO
 uoO
 aoj
 aoj
+aoj
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
 uoO
 uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
 uoO
 uoO
 uoO
@@ -47542,21 +48685,21 @@ uoO
 uoO
 eLE
 eLE
-blc
-rfo
-aYg
-wtj
-wtj
-pPs
-dWJ
-ijq
-dEt
-rWG
-eAm
-rwI
-rwI
-cOk
-blc
+abi
+aLy
+czF
+aWF
+aWF
+feB
+gmL
+buJ
+hMw
+ihg
+imj
+jvg
+jvg
+lOt
+abi
 eLE
 uoO
 uoO
@@ -47650,14 +48793,14 @@ eLE
 eLE
 eLE
 jmN
-bSS
-aWF
-buJ
-cid
-cQf
+unV
+uFj
+uVY
+vpz
+vTa
 jmN
-dMQ
-bSS
+wHf
+unV
 jmN
 eLE
 uoO
@@ -47685,54 +48828,12 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
 hQE
-qrc
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-bRX
-tUT
 hQE
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-xVz
+hQE
 xVz
 xVz
 uoO
@@ -47741,17 +48842,20 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
+aoj
+aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+tFc
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -47762,7 +48866,46 @@ aoj
 aoj
 uoO
 uoO
-aoj
+uoO
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+oFg
+oFg
+oFg
+oFg
+rvI
+oFg
+oFg
+oFg
+rvI
+oFg
+oFg
+oFg
+oFg
+eLE
+eLE
+oid
+uoO
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -47799,21 +48942,21 @@ uoO
 uoO
 uoO
 eLE
-blc
-cGV
-rrQ
-ijq
-ijq
-evP
-ijq
-wtj
-mTO
-dmy
-eAm
-rwI
-lyc
-jEt
-blc
+abi
+aMg
+cBH
+buJ
+buJ
+ffJ
+buJ
+aWF
+hMQ
+ili
+imj
+jvg
+kvK
+lPs
+abi
 eLE
 uoO
 uoO
@@ -47907,14 +49050,14 @@ jmN
 jmN
 jmN
 jmN
-bSS
-bcv
-aWF
-ckZ
-cWd
-dAK
-dUC
-wjU
+unV
+uHt
+uFj
+vqb
+vVz
+wrg
+wHB
+wXG
 jmN
 eLE
 uoO
@@ -47942,59 +49085,34 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-xVz
-uyQ
 xVz
 xVz
 xVz
+hQE
+hqc
+cep
 xVz
-vSd
-mlz
-xVz
+oXu
+hQE
 uoO
 uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 xVz
 xVz
 xVz
-xVz
-xVz
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -48006,6 +49124,29 @@ aoj
 uoO
 uoO
 uoO
+eLE
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+ohk
+jlb
+qmV
+oXs
+dLD
+dnu
+lQW
+xHZ
+oXs
+xHZ
+ygp
+oFg
+oFg
+oFg
+kRE
 uoO
 uoO
 uoO
@@ -48015,11 +49156,13 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -48056,21 +49199,21 @@ uoO
 uoO
 uoO
 eLE
-blc
-wtj
-wSg
-vag
-ijq
-cGV
-rBa
-viS
+abi
+aWF
+cFR
+dgy
+buJ
+aMg
+gni
+gWt
 fLU
-eAm
-aIH
-oxm
-svD
-eup
-blc
+imj
+jeE
+jwm
+kAp
+lUq
+abi
 eLE
 uoO
 uoO
@@ -48160,18 +49303,18 @@ aoj
 uoO
 eLE
 jmN
-ahB
-alO
-ask
+tZf
+ufQ
+ukI
 jmN
-awR
-bSS
-bBf
-bSS
-qSf
+uoo
+unV
+uZy
+unV
+vWg
 jmN
-lsJ
-bSS
+wMy
+unV
 jmN
 eLE
 eLE
@@ -48199,40 +49342,15 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-xVz
-xVz
-uzc
 xVz
 xVz
 xVz
+hQE
+hQE
+hQE
 xVz
 xVz
-xVz
+uoO
 uoO
 uoO
 uoO
@@ -48245,14 +49363,14 @@ aoj
 aoj
 uoO
 uoO
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
+aoj
+aoj
 uoO
+uoO
+xVz
+xVz
+oXu
+uXs
 uoO
 uoO
 uoO
@@ -48263,6 +49381,29 @@ aoj
 uoO
 uoO
 uoO
+eLE
+oFg
+gdG
+hHz
+dpV
+dpV
+dpV
+oFg
+fvL
+wiG
+xHZ
+xHZ
+xHZ
+xHZ
+urZ
+xHZ
+xHZ
+xHZ
+ygp
+oFg
+abG
+uQO
+kRE
 uoO
 uoO
 uoO
@@ -48272,11 +49413,13 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -48313,21 +49456,21 @@ uoO
 uoO
 uoO
 eLE
-blc
-gui
-kHi
-uvV
+abi
+bcv
+boc
+dLK
 fLU
 fLU
 fLU
-ovF
+epH
 fLU
-juj
+iot
 fLU
 fLU
-xyU
-ovF
-blc
+kBD
+epH
+abi
 eLE
 uoO
 uoO
@@ -48417,18 +49560,18 @@ uoO
 uoO
 eLE
 jmN
-ajk
-ajk
-ajk
-aty
-bSS
-aTr
-aWF
-bWl
-kJJ
-dAK
-dWi
-wjU
+tZq
+tZq
+tZq
+umG
+unV
+uAb
+uFj
+vnW
+vWr
+wrg
+wOg
+wXG
 jmN
 jmN
 jmN
@@ -48456,37 +49599,13 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+ckx
 xVz
 xVz
 xVz
-hQE
-hQE
-hQE
+xVz
 xVz
 xVz
 uoO
@@ -48495,17 +49614,16 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
-aoj
 uoO
 uoO
-aoj
-aoj
-uoO
-jPC
 xVz
 xVz
 xVz
@@ -48520,6 +49638,32 @@ aoj
 uoO
 uoO
 uoO
+eLE
+rvI
+aLr
+pXC
+pXC
+pXC
+pXC
+oFg
+hQW
+eeX
+xHZ
+xHZ
+fXm
+aNI
+sJK
+xHZ
+nDl
+xHZ
+qLm
+oFg
+nJe
+uQO
+iWE
+uoO
+uoO
+eLE
 uoO
 uoO
 uoO
@@ -48529,11 +49673,10 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -48570,21 +49713,21 @@ uoO
 uoO
 uoO
 eLE
-blc
-ujL
-baE
-erD
-ovF
-wql
-tGU
-dUz
-mjq
-dyS
-nfo
-uAs
-wql
-epS
-blc
+abi
+beY
+bgu
+dML
+epH
+fkv
+gsQ
+gZF
+hNq
+ioO
+jeM
+jwp
+fkv
+lUI
+abi
 eLE
 uoO
 uoO
@@ -48674,22 +49817,22 @@ uoO
 uoO
 eLE
 jmN
-ajk
-ajk
-ajk
+tZq
+tZq
+tZq
 jmN
-bSS
-bek
-buJ
-cid
-cWn
+unV
+uKB
+uVY
+vpz
+vWZ
 jmN
-dYV
-bSS
-vbY
-bSS
-ecf
-smu
+wQC
+unV
+xEd
+unV
+hkm
+hEW
 jmN
 eLE
 uoO
@@ -48712,61 +49855,36 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-xVz
-xVz
-xVz
 hQE
-uMi
-uZy
-xVz
-tUT
-hQE
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
+tDl
 xVz
 xVz
 xVz
+mlz
+xVz
+hYE
+ftu
+xVz
+xVz
 uoO
+uXs
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -48777,9 +49895,34 @@ aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+eLE
+oFg
+lYZ
+pXC
+pXC
+pXC
+pXC
+oFg
+cqA
+xHZ
+xHZ
+xHZ
+xdA
+kxY
+tPQ
+xHZ
+xHZ
+xHZ
+ckZ
+oFg
+esG
+uQO
+oFg
+uoO
+uoO
+eLE
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -48827,21 +49970,21 @@ uoO
 uoO
 uoO
 eLE
-blc
-baE
-baE
-pPr
-blc
+abi
+bgu
+bgu
+cIG
+abi
 fLU
 fLU
-qLE
+hev
 fLU
-wHP
-fLU
-fLU
+ipw
 fLU
 fLU
-blc
+fLU
+fLU
+abi
 eLE
 uoO
 uoO
@@ -48931,22 +50074,22 @@ uoO
 uoO
 eLE
 jmN
-ajM
-ajk
-ato
+ubW
+tZq
+ulE
 jmN
-bSS
-bcv
-aWF
-ckZ
-bSS
-dzJ
-bSS
-bSS
-vbY
-bSS
-bSS
-jwv
+unV
+uHt
+uFj
+vqb
+unV
+wqi
+unV
+unV
+xEd
+unV
+unV
+xba
 jmN
 eLE
 uoO
@@ -48972,58 +50115,33 @@ uoO
 uoO
 uoO
 uoO
+vuj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+vuj
 xVz
 xVz
-xVz
-hQE
-hQE
+oXu
 hQE
 xVz
-xVz
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 xVz
 xVz
-tUT
-jPC
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -49034,9 +50152,34 @@ aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+eLE
+oFg
+gdG
+pXC
+hXQ
+tlL
+pXC
+oFg
+xHZ
+xHZ
+xHZ
+kvL
+kvL
+kvL
+wnG
+xHZ
+xHZ
+xHZ
+sfI
+oFg
+xLd
+uQO
+oFg
+uoO
+uoO
+eLE
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -49084,21 +50227,21 @@ uoO
 uoO
 uoO
 eLE
-blc
-hqw
-pPr
-mQO
-blc
-wox
-ieG
-gbx
+abi
+bis
+cIG
+bmc
+abi
+flP
+guL
+hhe
 fLU
-ioV
+ivm
 fLU
-wiq
-pMj
-jJO
-blc
+jxG
+kCx
+lVr
+abi
 eLE
 uoO
 uoO
@@ -49188,22 +50331,22 @@ uoO
 uoO
 eLE
 jmN
-ala
-anB
-ala
+ufo
+uif
+ufo
 jmN
-bSS
-bSS
-bBZ
-bSS
-bSS
+unV
+unV
+vaf
+unV
+unV
 jmN
-qFX
-bSS
-vbY
-sEL
-bSS
-eIS
+wUi
+unV
+xEd
+xVt
+unV
+umw
 jmN
 eLE
 uoO
@@ -49229,58 +50372,33 @@ uoO
 uoO
 uoO
 uoO
+hQE
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+hQE
 xVz
-xVz
-ckx
+uoO
 xVz
 xVz
 xVz
 xVz
 xVz
 xVz
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
 uoO
 uoO
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 xVz
 xVz
-xVz
-uoO
 uoO
 uoO
 uoO
@@ -49291,9 +50409,34 @@ aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+eLE
+oFg
+oFg
+oFg
+oFg
+oFg
+tRe
+oFg
+hfb
+jYt
+urZ
+qwV
+hfb
+jYt
+oFg
+aqQ
+hfb
+jYt
+oFg
+oFg
+oFg
+tcC
+oFg
+uoO
+eLE
+eLE
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -49341,21 +50484,21 @@ uoO
 uoO
 uoO
 eLE
-blc
-aLk
-baE
-mQO
-blc
-nKL
-tCo
-wtj
+abi
+bjr
+bgu
+bmc
+abi
+fmf
+gxq
+aWF
 fLU
-wql
+fkv
 fLU
-oZe
-gON
-jSc
-blc
+jFx
+kDS
+lWy
+abi
 eLE
 uoO
 uoO
@@ -49452,15 +50595,15 @@ jmN
 jmN
 jmN
 jmN
-coe
-dcV
+vra
+vXh
 jmN
 jmN
-wjU
+wXG
 jmN
-eom
-bSS
-tHF
+xYz
+unV
+rhv
 jmN
 eLE
 uoO
@@ -49493,47 +50636,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-hQE
-qrc
 xVz
 xVz
 xVz
-mlz
-xVz
-uzc
-uyQ
-xVz
-xVz
-uoO
-jPC
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 xVz
 xVz
 xVz
@@ -49541,16 +50646,54 @@ xVz
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
 aoj
 aoj
 uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+uoO
+uoO
+uoO
+uoO
+oFg
+vTH
+vTH
+nVN
+vTH
+vTH
+vTH
+vTH
+vTH
+vTH
+vTH
+vTH
+ldZ
+vTH
+vTH
+ggp
+vTH
+oFg
+uoO
+eLE
+eLE
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -49598,20 +50741,20 @@ uoO
 uoO
 uoO
 eLE
-blc
-wNN
-uei
-kHi
-blc
-wol
-rog
-swZ
+abi
+bjw
+cNz
+boc
+abi
+frh
+gyB
+hhi
 fLU
-baX
+iER
 fLU
-cSU
-xpJ
-jJO
+jFU
+kPb
+lVr
 fLU
 eLE
 uoO
@@ -49706,18 +50849,18 @@ eLE
 eLE
 eLE
 jmN
-azr
-azr
-azr
-azr
-azr
-dEh
+upC
+upC
+upC
+upC
+upC
+wry
 jmN
-bSS
-bSS
-eoC
-xsc
-bSS
+unV
+unV
+xYV
+xbP
+unV
 jmN
 jmN
 jmN
@@ -49746,68 +50889,68 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-vuj
-uoO
-uoO
-uoO
-vuj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 xVz
 xVz
-tUT
-hQE
-xVz
-uoO
-uoO
 xVz
 xVz
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-xVz
-xVz
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 aoj
 aoj
 uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+uoO
+uoO
+uoO
+uoO
+oFg
+pSE
+vTH
+nVN
+vTH
+iHB
+vTH
+vTH
+vTH
+iHB
+vTH
+vTH
+ldZ
+vTH
+vTH
+vTH
+vTH
+oFg
+uoO
+eLE
+eLE
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -49855,21 +50998,21 @@ uoO
 uoO
 uoO
 eLE
-blc
-oUM
-mQO
-mHc
-blc
-lvL
-vEc
-jQK
+abi
+bjF
+bmc
+dMQ
+abi
+ftV
+gyZ
+hmZ
 fLU
-mNc
-ovF
-ijq
-viS
-eIo
-blc
+iKB
+epH
+buJ
+gWt
+lYE
+abi
 eLE
 uoO
 uoO
@@ -49963,22 +51106,22 @@ uoO
 uoO
 eLE
 jmN
-azr
-beY
-bEw
-crg
-dgy
-azr
-dcV
-bSS
-bSS
-bSS
-bSS
-qSf
+upC
+uKP
+vat
+vuf
+vXF
+upC
+vXh
+unV
+unV
+unV
+unV
+vWg
 jmN
-fbC
-aNG
-fuE
+eOL
+ujm
+ceu
 jmN
 uoO
 uoO
@@ -50003,38 +51146,13 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-hQE
-uoO
-uoO
-uoO
-hQE
-xVz
-uoO
-xVz
-xVz
-xVz
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 xVz
 xVz
 xVz
@@ -50049,7 +51167,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
+xVz
+xVz
 xVz
 xVz
 uoO
@@ -50057,14 +51176,38 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
+eLE
 uoO
-aoj
+uoO
+uoO
+uoO
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+hSe
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+vTH
+vTH
+vTH
+uWW
+oFg
+uoO
+eLE
+eLE
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -50112,21 +51255,21 @@ uoO
 uoO
 uoO
 eLE
-blc
-mQO
-kHi
-wtj
-blc
-vAp
-wtj
-wfn
+abi
+bmc
+boc
+aWF
+abi
+fuE
+aWF
+hpe
 fLU
-byb
+iNY
 fLU
-max
-ijq
-jJO
-blc
+jHN
+buJ
+lVr
+abi
 eLE
 uoO
 uoO
@@ -50220,21 +51363,21 @@ uoO
 uoO
 eLE
 jmN
-aCf
-bgu
-bSS
-crt
-dkZ
-dFC
-dcV
-bSS
-bSS
-jqg
-bSS
-bSS
+urM
+uKU
+unV
+vzL
+vYC
+wsK
+vXh
+unV
+unV
+ycj
+unV
+unV
 jmN
-gOB
-fkv
+snG
+bfj
 jmN
 jmN
 uoO
@@ -50256,37 +51399,17 @@ aoj
 aoj
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 xVz
@@ -50294,11 +51417,6 @@ xVz
 xVz
 xVz
 xVz
-xVz
-xVz
-uoO
-uoO
-uoO
 aoj
 aoj
 aoj
@@ -50309,6 +51427,7 @@ uoO
 xVz
 xVz
 xVz
+xVz
 uoO
 uoO
 uoO
@@ -50318,11 +51437,35 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
 uoO
 uoO
-aoj
 uoO
+uoO
+oFg
+qdZ
+oRf
+gBq
+qvI
+qvI
+oFg
+xhf
+vTH
+bsp
+bsp
+oFg
+vTH
+vTH
+vTH
+pEm
+oFg
+uoO
+eLE
+eLE
+uoO
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -50369,21 +51512,21 @@ uoO
 uoO
 uoO
 eLE
-blc
-dQk
-baE
-aaM
-blc
-dOI
-wRb
-uoR
+abi
+bmj
+bgu
+dOF
+abi
+fxN
+gza
+hqg
 fLU
-jZI
+iPr
 fLU
-ehS
-hhI
-acJ
-blc
+jJT
+kQO
+dYV
+abi
 rex
 uoO
 uoO
@@ -50477,23 +51620,23 @@ uoO
 uoO
 eLE
 jmN
-azr
-bis
-bSS
-cuz
-dkZ
-azr
-dcV
-xsc
-bSS
-bSS
-bSS
-xsc
-wjU
-fbD
-flP
-mTN
-fAs
+upC
+uLn
+unV
+vzR
+vYC
+upC
+vXh
+xbP
+unV
+unV
+unV
+xbP
+wXG
+lBZ
+wqp
+sbZ
+yaG
 xVz
 xVz
 uoO
@@ -50513,33 +51656,8 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
 uoO
 uoO
 aoj
@@ -50549,18 +51667,18 @@ aoj
 aoj
 aoj
 aoj
+uoO
+uoO
 xVz
 xVz
 xVz
 xVz
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
+xVz
 aoj
-aoj
-aoj
-uoO
-uoO
 uoO
 uoO
 xVz
@@ -50572,24 +51690,49 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
-aoj
-aoj
+uoO
+uoO
+eLE
+uoO
+eLE
+eLE
+uoO
+uoO
+oFg
+qvI
+qvI
+qvI
+qvI
+qvI
+oFg
+wSv
+vTH
+vTH
+vTH
+ftT
+vTH
+vTH
+vTH
+pEm
+rvI
+uoO
+eLE
+eLE
+uoO
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -50626,24 +51769,24 @@ uoO
 uoO
 eLE
 eLE
-blc
-kHi
-mSo
-anL
-tEv
-blc
-sVN
-oBa
-blc
-vPH
-cKK
-blc
-caS
-blc
-blc
-udr
-wzs
-wzs
+abi
+boc
+cOn
+dUC
+epZ
+abi
+gAz
+hsH
+abi
+iPH
+jfS
+abi
+kRu
+abi
+abi
+nha
+nLK
+nLK
 hkD
 jmN
 jmN
@@ -50734,21 +51877,21 @@ uoO
 uoO
 eLE
 jmN
-azr
-bjr
-bHz
-cAb
-dmH
-azr
+upC
+uMi
+ven
+vBA
+vZW
+upC
 jmN
-bSS
-mSj
-sEL
-sEL
-bSS
+unV
+vSd
+xVt
+xVt
+unV
 jmN
-gOB
-fkv
+snG
+bfj
 jmN
 jmN
 xVz
@@ -50770,53 +51913,17 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-xVz
-xVz
-xVz
-xVz
+qDR
 xVz
 uoO
 uoO
 aoj
 aoj
 aoj
-uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -50824,21 +51931,17 @@ xVz
 xVz
 xVz
 xVz
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
+vuj
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+mlz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -50846,7 +51949,47 @@ uoO
 aoj
 aoj
 aoj
-aoj
+uoO
+uoO
+eLE
+uoO
+uoO
+uoO
+eLE
+uoO
+oFg
+uov
+qvI
+qvI
+qvI
+hxz
+oFg
+hNX
+vTH
+vTH
+bVh
+oFg
+vTH
+vTH
+vTH
+hUA
+oFg
+uoO
+eLE
+eLE
+uoO
+eLE
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -50884,21 +52027,21 @@ uoO
 eLE
 uoO
 rXA
-kHi
+boc
 rXA
-xSA
-qIw
-jgR
-wtj
-ijq
-rRT
-wtj
-wtj
-hLw
-kHi
+dWi
+eug
+fAs
+aWF
+buJ
+hOz
+aWF
+aWF
+jKM
+boc
 rXA
 rXA
-gTa
+nhK
 nBk
 nBk
 nBk
@@ -50906,7 +52049,7 @@ nBk
 nBk
 nBk
 nBk
-mcH
+qEf
 nBk
 nBk
 mRT
@@ -50991,22 +52134,22 @@ uoO
 uoO
 eLE
 jmN
-azr
-azr
-aWF
-cFR
-azr
-azr
+upC
+upC
+uFj
+vCM
+upC
+upC
 jmN
-eeX
-uiz
-epH
-adc
-qSf
+xcH
+xEg
+ydV
+cSu
+vWg
 jmN
-ffJ
-fmf
-cyT
+amV
+jHk
+rdq
 jmN
 xVz
 xVz
@@ -51027,31 +52170,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -51065,34 +52183,19 @@ aoj
 aoj
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uXs
+aoj
+aoj
 xVz
 xVz
 xVz
 xVz
 xVz
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-xVz
-xVz
-xVz
-xVz
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -51103,7 +52206,47 @@ uoO
 aoj
 aoj
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+uoO
+oFg
+qvI
+qvI
+qvI
+qvI
+qvI
+oFg
+pra
+vTH
+vTH
+vTH
+ftT
+vTH
+vTH
+vTH
+vTH
+oFg
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+uoO
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -51142,21 +52285,21 @@ eLE
 uoO
 rXA
 rXA
-uzr
-jEg
-lcr
-cgm
-wtj
-wtj
-wtj
-gZL
-vag
-iFe
+cQf
+dYr
+ajM
+fBi
+aWF
+aWF
+aWF
+idi
+dgy
+cWd
 rXA
-uKE
-kHi
-eth
-bMb
+mba
+boc
+nhY
+nMh
 nBk
 nBk
 nBk
@@ -51248,23 +52391,23 @@ uoO
 uoO
 eLE
 jmN
-aCf
-azr
-aCq
-azr
-azr
-dJc
+urM
+upC
+utr
+upC
+upC
+wus
 jmN
-bSS
-uiz
-epZ
-eCx
-eLb
-jmN
-jmN
+unV
+xEg
+yeZ
+nRD
+mtN
 jmN
 jmN
 jmN
+jmN
+jmN
 aoj
 aoj
 xVz
@@ -51284,33 +52427,8 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-xVz
 uoO
 uoO
 aoj
@@ -51322,22 +52440,6 @@ aoj
 aoj
 uoO
 uoO
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-aoj
-uoO
-uoO
-xVz
-xVz
-xVz
-xVz
 uoO
 uoO
 uoO
@@ -51345,10 +52447,8 @@ uoO
 uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 aoj
 uoO
 uoO
@@ -51360,8 +52460,51 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+uoO
+oFg
+llv
+llv
+tKU
+ovY
+ads
+oFg
+xhf
+vTH
+vTH
+tsK
+oFg
+nAf
+vTH
+vTH
+vTH
+oFg
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -51398,21 +52541,21 @@ uoO
 eLE
 uoO
 rXA
-itL
-koJ
-wtj
-ijq
-ijq
-ijq
-mLa
-rBa
-gKv
-wtj
-oDN
-ydr
-iau
-kgo
-gTa
+bof
+cUk
+aWF
+buJ
+buJ
+buJ
+hsK
+gni
+iPO
+aWF
+jOe
+kSa
+mbX
+mKh
+nhK
 nBk
 nBk
 nBk
@@ -51420,7 +52563,7 @@ nBk
 nBk
 nBk
 dhi
-vqj
+qFn
 nBk
 nBk
 nBk
@@ -51505,18 +52648,18 @@ uoO
 uoO
 eLE
 jmN
-azr
-azr
-aWF
-aWF
-azr
-azr
-dzJ
-bSS
-bSS
-eoC
-eoC
-bSS
+upC
+upC
+uFj
+uFj
+upC
+upC
+wqi
+unV
+unV
+xYV
+xYV
+unV
 jmN
 eLE
 aoj
@@ -51539,62 +52682,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-qDR
-xVz
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 aoj
 uoO
-uoO
-uoO
-xVz
-xVz
-xVz
-xVz
-vuj
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-mlz
-xVz
-xVz
-xVz
 uoO
 uoO
 uoO
@@ -51613,12 +52702,66 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+uoO
+uoO
+oFg
+oFg
+oFg
+rvI
+oFg
+oFg
+oFg
+oFg
+jQV
+fvV
+oFg
+oFg
+oFg
+oFg
+mwN
+mwN
+oFg
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -51654,22 +52797,22 @@ uoO
 uoO
 eLE
 uoO
-blc
-jkJ
-iFe
-ijq
+abi
+bqs
+cWd
+buJ
 fLU
 fLU
 fLU
-uCN
+ezl
 fLU
 fLU
 fLU
-ogz
-snF
+jPC
+euY
 fLU
 rXA
-gTa
+nhK
 uoO
 hQE
 uoO
@@ -51679,11 +52822,11 @@ uoO
 hQE
 hQE
 hQE
-gFg
+qZq
 eoy
 eoy
 eoy
-mVU
+sCZ
 eoy
 eoy
 eoy
@@ -51762,18 +52905,18 @@ uoO
 uoO
 eLE
 jmN
-aCq
-bjw
-bIh
-bIh
-dnu
-azr
+utr
+uMA
+veq
+veq
+wcm
+upC
 jmN
-efa
-bSS
-bSS
-bSS
-bSS
+xfu
+unV
+unV
+unV
+unV
 jmN
 eLE
 aoj
@@ -51796,32 +52939,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -51841,23 +52959,6 @@ uoO
 uoO
 uoO
 uoO
-jPC
-aoj
-aoj
-xVz
-xVz
-xVz
-xVz
-xVz
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 aoj
 aoj
 aoj
@@ -51873,11 +52974,53 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+eLE
+eLE
+uoO
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
+uoO
+oFg
+oVe
+lhQ
+oVe
+oVe
+oVe
+oVe
+lhQ
+oVe
+xVf
+ujx
+vQq
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+uoO
+uoO
+eLE
 uoO
 uoO
 uoO
@@ -51911,21 +53054,21 @@ uoO
 uoO
 eLE
 uoO
-blc
-luy
-ijq
-wtj
+abi
+bsw
+buJ
+aWF
 fLU
-xFI
-avY
-ijq
-avY
-geL
+bAz
+gED
+buJ
+gED
+iQC
 fLU
-pOm
-jAL
-wql
-blc
+jSJ
+kSn
+fkv
+abi
 eLE
 uoO
 uoO
@@ -51938,11 +53081,11 @@ uoO
 uoO
 uoO
 eoy
-leM
+rqc
 dxj
 dxj
 dxj
-hyn
+tjA
 eoy
 uoO
 uoO
@@ -52019,17 +53162,17 @@ uoO
 uoO
 eLE
 jmN
-azr
-bjF
-bJG
-bSS
-dkZ
-azr
+upC
+uNS
+vfi
+unV
+vYC
+upC
 jmN
 jmN
-vbY
-vbY
-xVR
+xEd
+xEd
+pKo
 jmN
 jmN
 eLE
@@ -52053,43 +53196,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 aoj
 uoO
 uoO
@@ -52106,16 +53212,6 @@ aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 aoj
 aoj
 aoj
@@ -52135,6 +53231,53 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+eLE
+eLE
+uoO
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+oFg
+oVe
+qjd
+xDr
+olw
+qjd
+xDr
+olw
+oVe
+cGL
+ujx
+ujx
+oFg
+ckZ
+kUL
+mYm
+xHZ
+tpl
+oFg
+kJa
+aGH
+iID
+aGH
+siP
+qcp
+siP
+qcp
+xhF
+oFg
+aoj
+uoO
+eLE
 uoO
 uoO
 uoO
@@ -52168,21 +53311,21 @@ uoO
 uoO
 eLE
 uoO
-blc
-bFl
-ijq
-wtj
-snF
-rfo
-aiI
-mLa
-xFI
-omU
+abi
+bud
+buJ
+aWF
+euY
+aLy
+eeG
+hsK
+bAz
+iRE
 fLU
 fLU
 fLU
-eBj
-blc
+miw
+abi
 eLE
 uoO
 uoO
@@ -52195,11 +53338,11 @@ uoO
 uoO
 uoO
 eoy
-jlp
-rei
-jel
-rei
-wle
+rqF
+rXg
+sHo
+rXg
+tmM
 eoy
 uoO
 uoO
@@ -52276,18 +53419,18 @@ uoO
 uoO
 eLE
 jmN
-aCf
-bis
-bMq
-cIa
-doL
-dFC
-dcV
-tZO
-tZO
-tZO
-tZO
-tZO
+urM
+uLn
+vfL
+vDl
+wcF
+wsK
+vXh
+xkd
+xkd
+xkd
+xkd
+xkd
 jmN
 eLE
 uoO
@@ -52324,12 +53467,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 aoj
@@ -52341,13 +53478,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -52355,8 +53485,9 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
@@ -52370,28 +53501,40 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+eLE
+uoO
+oFg
+oVe
+qjd
+xDr
+olw
+qjd
+xDr
+olw
+oVe
+cGL
+ujx
+ujx
+mcL
+xHZ
+gaa
+vyb
+eml
+xHZ
+oFg
+okh
+kQl
+wbf
+aGH
+siP
+qcp
+siP
+qcp
+aGH
+oFg
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -52424,22 +53567,22 @@ uoO
 uoO
 uoO
 eLE
-blc
-blc
-wtj
-vcc
-acJ
+abi
+abi
+aWF
+cWn
+dYV
 fLU
-sFr
-ijq
-vBG
-eQZ
-sFr
+dfO
+buJ
+hvw
+hWZ
+dfO
 fLU
-hKR
-jJA
-eph
-blc
+jWC
+kTJ
+miy
+abi
 eLE
 uoO
 uoO
@@ -52452,11 +53595,11 @@ uoO
 uoO
 uoO
 eoy
-tXj
+rrm
 dxj
 dxj
 dxj
-ccU
+toA
 eoy
 uoO
 uoO
@@ -52533,18 +53676,18 @@ uoO
 uoO
 eLE
 jmN
-azr
-bmc
-bRs
-cIA
-doZ
-azr
-dcV
-tZO
-ekK
-vPm
-vPm
-ikX
+upC
+uOE
+vgo
+vKh
+wfh
+upC
+vXh
+xkd
+xOj
+xPz
+xPz
+hvr
 jmN
 eLE
 uoO
@@ -52569,64 +53712,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 aoj
@@ -52646,9 +53732,66 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+uoO
+oFg
+oVe
+qjd
+xDr
+olw
+qjd
+xDr
+olw
+oVe
+cGL
+ujx
+ujx
+mcL
+xHZ
+lEh
+hxS
+xHZ
+xHZ
+oFg
+aGH
+aGH
+aIJ
+aGH
+aGH
+aGH
+aGH
+aGH
+aGH
+oFg
+uoO
+uoO
+eLE
 uoO
 uoO
 uoO
@@ -52681,22 +53824,22 @@ uoO
 uoO
 uoO
 eLE
-blc
-xLN
-ijq
-wAX
-wtj
+abi
+ahB
+buJ
+dcV
+aWF
 fLU
-oEw
-eVp
-wtj
-gIH
-wtj
+fEB
+gFu
+aWF
+hYr
+aWF
 fLU
-qZB
-fNu
-aGz
-blc
+jYL
+kVD
+mln
+abi
 eLE
 uoO
 uoO
@@ -52790,18 +53933,18 @@ uoO
 uoO
 eLE
 jmN
-aCu
-azr
-bSL
-azr
-azr
-azr
+uub
+upC
+vkD
+upC
+upC
+upC
 jmN
-egg
-vPm
-esG
-tZO
-tZO
+xvS
+xPz
+ygC
+xkd
+xkd
 jmN
 eLE
 uoO
@@ -52826,64 +53969,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 aoj
@@ -52903,6 +53989,63 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+uoO
+oFg
+oVe
+qjd
+xDr
+olw
+qjd
+xDr
+olw
+oVe
+cGL
+ujx
+ujx
+mcL
+xHZ
+xHZ
+xHZ
+xHZ
+xHZ
+kvN
+aGH
+aGH
+aGH
+aGH
+siP
+qcp
+siP
+qcp
+aGH
+oFg
 uoO
 uoO
 uoO
@@ -52938,22 +54081,22 @@ uoO
 uoO
 uoO
 eLE
-blc
-ykL
-ijq
-sFr
-wtj
-aZo
+abi
+ajk
+buJ
+dfO
+aWF
+evD
 fLU
 fLU
 fLU
 fLU
-ovF
+epH
 fLU
-wpi
-poJ
-wql
-blc
+jZf
+kWK
+fkv
+abi
 eLE
 eLE
 eLE
@@ -53054,7 +54197,7 @@ jmN
 jmN
 jmN
 jmN
-ehk
+xxV
 jmN
 jmN
 jmN
@@ -53122,47 +54265,47 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
+eLE
+uoO
+oFg
+oVe
+oVe
+oVe
+oVe
+oVe
+oVe
+oVe
+oVe
+kLy
+ujx
+ujx
+oFg
+jtY
+fsw
+wCM
+mXF
+xHZ
+oFg
+aGH
+hhr
+aGH
+aGH
+siP
+qcp
+siP
+qcp
+aGH
+oFg
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -53195,38 +54338,38 @@ uoO
 uoO
 uoO
 eLE
-blc
-lcr
-ijq
-vag
-akZ
+abi
+ajM
+buJ
+dgy
+edM
 fLU
-nof
-rNs
-wtj
-ovF
-baX
+fKq
+gFV
+aWF
+epH
+iER
 fLU
 fLU
 fLU
-sIq
-blc
-blc
-blc
-blc
-cKK
-blc
-blc
-blc
-blc
-blc
-blc
-blc
-blc
-blc
-blc
-blc
-blc
+mmL
+abi
+abi
+abi
+abi
+jfS
+abi
+abi
+abi
+abi
+abi
+abi
+abi
+abi
+abi
+abi
+abi
+abi
 eLE
 uoO
 uoO
@@ -53304,18 +54447,18 @@ uoO
 uoO
 eLE
 jmN
-aGv
-bmj
-aNI
-cIG
-dpD
-dJx
+uug
+uPu
+uzO
+vLg
+wfE
+wuM
 jmN
-ehY
-wfe
-jDW
-euY
-uBN
+xzh
+xAw
+cim
+ioZ
+aYf
 jmN
 eLE
 uoO
@@ -53365,14 +54508,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -53385,41 +54520,49 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
 eLE
 uoO
+oFg
+mwN
+oFg
+xpN
+xpN
+xpN
+oFg
+oFg
+dLN
+oFg
+ljk
+ujx
+oFg
+oFg
+oFg
+oFg
+oFg
+tVV
+oFg
+xMB
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -53452,37 +54595,37 @@ uoO
 uoO
 uoO
 eLE
-frc
-qfA
-kHi
-oUM
-kHi
-uCN
-wtj
-rMc
-nBr
-xHv
-dUz
-mjq
-bSU
-viw
-rWl
-hlu
-vsG
-mAf
-ijb
-lhg
-dyn
-lhg
-lhg
-ajn
-kvE
-ioV
+acs
+ala
+boc
+bjF
+boc
+ezl
+aWF
+gJz
+hyj
+ias
+gZF
+hNq
+kfQ
+kZR
+mng
+mLL
+njZ
+nNR
+oiy
+oFh
+oZJ
+oFh
+oFh
+qpI
+qHc
+ivm
 fLU
-bmv
-dAb
-suJ
-yjB
+rce
+rrq
+rXS
+nZI
 fLU
 eLE
 uoO
@@ -53561,18 +54704,18 @@ uoO
 uoO
 eLE
 jmN
-aGH
-bqs
-bmj
-bmj
-dvZ
-dJV
+uwt
+uRL
+uPu
+uPu
+wfG
+wuY
 jmN
-wfe
-bvH
-wfe
-ezl
-wfe
+xAw
+xSb
+xAw
+hIo
+xAw
 jmN
 eLE
 uoO
@@ -53622,14 +54765,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -53642,31 +54777,41 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
 eLE
 uoO
+oFg
+ujx
+ujx
+ujx
+ujx
+ujx
+bWY
+oFg
+ujx
+ldZ
+ujx
+ujx
+ldZ
+ujx
+ujx
+ujx
+ujx
+ujx
+ujx
+ujx
+ujx
+ldZ
+ahr
+oFg
 uoO
 uoO
 uoO
@@ -53674,9 +54819,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -53710,10 +54853,10 @@ uoO
 uoO
 eLE
 eLE
-blc
-mQO
-iFe
-kHi
+abi
+bmc
+cWd
+boc
 fLU
 fLU
 fLU
@@ -53723,23 +54866,23 @@ fLU
 fLU
 fLU
 fLU
-nfv
+mot
 fLU
-snF
+euY
 fLU
-vLy
-hCT
-fmj
-eJU
-cQn
-dMb
-fTA
-nbC
-juj
-ijq
-qcb
-xyR
-mPK
+omq
+oIo
+pab
+pCn
+qez
+qpY
+qJM
+qUx
+iot
+buJ
+rsf
+rZZ
+sMc
 fLU
 eLE
 uoO
@@ -53818,18 +54961,18 @@ uoO
 uoO
 eLE
 jmN
-aGO
-bmj
-bWa
-bmj
-dwF
-dLJ
+uyz
+uPu
+vkL
+uPu
+wkN
+wyl
 jmN
-wfe
-wfe
-wfe
-wfe
-ePe
+xAw
+xAw
+xAw
+xAw
+plN
 jmN
 eLE
 uoO
@@ -53894,46 +55037,46 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+oFg
+fJM
+ujx
+ujx
+ujx
+ujx
+oJB
+oFg
+ujx
+ldZ
+ujx
+ujx
+ldZ
+ujx
+ujx
+hVa
+ujx
+ujx
+ujx
+ujx
+ujx
+upp
+ahr
+oFg
+aoj
 uoO
 uoO
 uoO
 eLE
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -53967,36 +55110,36 @@ uoO
 uoO
 eLE
 eLE
-hXB
-mQO
-kHi
-wtj
-ijq
-gtH
-wtj
-tMn
-ijq
-vcc
-wtj
+alO
+bmc
+boc
+aWF
+buJ
+fNk
+aWF
+hBU
+buJ
+cWn
+aWF
 fLU
-wmf
-sFr
-wAX
-gsM
+icj
+dfO
+dcV
+nkf
 fLU
-ifn
-ciN
-nss
-lhg
-qXq
-crx
-kvE
-baX
-dTO
-rrQ
-jHU
-uJx
-tIG
+org
+oJc
+pdh
+oFh
+qgP
+qsr
+qHc
+iER
+rbg
+cBH
+rsB
+sdI
+sMQ
 fLU
 eLE
 uoO
@@ -54075,18 +55218,18 @@ uoO
 uoO
 eLE
 jmN
-aLy
-bmj
-bmj
-cNz
-bmj
-bWa
-eeG
-wfe
-uMz
-uAK
-eAk
-uAK
+uyQ
+uPu
+uPu
+vMO
+uPu
+vkL
+wUB
+xAw
+xTR
+kfT
+eVL
+kfT
 jmN
 eLE
 uoO
@@ -54151,46 +55294,46 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
 eLE
 uoO
+oFg
+oFg
+dFU
+vGI
+fGA
+iEl
+xby
+oFg
+oFg
+oFg
+ujx
+vQq
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+ftT
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+uoO
+eLE
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -54225,35 +55368,35 @@ uoO
 eLE
 eLE
 rex
-baE
-baE
-vag
-wtj
-ijq
-nGx
-wAX
-sFr
-caq
-unJ
-daW
-wtj
-ijq
-hRA
-lps
-nhq
-aqg
-nbx
-uKg
-fKv
-lGe
-rha
+bgu
+bgu
+dgy
+aWF
+buJ
+eeT
+dcV
+dfO
+iWH
+hKG
+kjW
+aWF
+buJ
+mMC
+nnz
+nRP
+oro
+oOR
+phP
+ouz
+qhk
+qwP
 fLU
-exF
-jwh
-uSi
-eQZ
-hGW
-afT
+qUO
+rbt
+bBf
+hWZ
+sfm
+sNu
 fLU
 eLE
 uoO
@@ -54332,18 +55475,18 @@ uoO
 uoO
 eLE
 jmN
-aMg
-bsw
-bmj
-bmj
-bmj
-bmj
-eeT
-wfe
-wfe
-uAK
-eCE
-ePk
+uzc
+uRY
+uPu
+uPu
+uPu
+uPu
+wWc
+xAw
+xAw
+kfT
+dLO
+bAq
 jmN
 eLE
 uoO
@@ -54416,39 +55559,39 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+bYk
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+tWw
+oFg
+ujx
+ujx
+oFg
+niX
+tKQ
+opH
+jgr
+vTH
+vTH
+vTH
+oFg
+rjR
+gvS
+lGw
+sba
+jnW
+oFg
 uoO
 eLE
 eLE
 eLE
 eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -54481,36 +55624,36 @@ uoO
 uoO
 eLE
 eLE
-blc
-xFI
-baE
-aiI
-mfi
-wtj
-ijq
-wtj
-wtj
-ijq
-hoc
+abi
+bAz
+bgu
+eeG
+eAk
+aWF
+buJ
+aWF
+aWF
+buJ
+jgP
 fLU
-uSi
-acJ
-ijq
-ijq
+bBf
+dYV
+buJ
+buJ
 fLU
-fKv
-lhg
-tqF
-rjs
-jGd
-sxm
+ouz
+oFh
+pjj
+pGw
+qhB
+qyc
 fLU
-nfo
-dTO
-ioj
-oAm
-wnT
-wMa
+jeM
+rbg
+rcf
+rtO
+shF
+sPK
 fLU
 eLE
 uoO
@@ -54589,18 +55732,18 @@ uoO
 uoO
 eLE
 jmN
-aNI
-bmj
-bWk
-cOn
-dyQ
-dLK
+uzO
+uPu
+vmm
+vQn
+wpJ
+wDO
 jmN
-ekE
-wfe
-eug
-cOb
-uAK
+xCv
+xAw
+wWi
+riI
+kfT
 jmN
 eLE
 uoO
@@ -54608,7 +55751,7 @@ uoO
 uoO
 uoO
 uoO
-azs
+ask
 xVz
 xVz
 uoO
@@ -54673,39 +55816,39 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
+oFg
+oFg
+oFg
+aqQ
+oFg
+oFg
+ogU
+vTH
+vTH
+vTH
+vTH
+lcu
+vTH
+oFg
+rjR
+gvS
+oFg
+dcq
+tJe
+oFg
 uoO
 uoO
 eLE
 eLE
 eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -54738,36 +55881,36 @@ uoO
 uoO
 eLE
 uoO
-blc
-uSi
-ijq
-wtj
-mbC
-rOZ
-sgL
-oSG
-btu
-oSG
+abi
+bBf
+buJ
+aWF
+eBn
+fNr
+gNZ
+hCb
+iaO
+hCb
 fLU
 fLU
 fLU
-sRL
-baX
+mzR
+iER
 fLU
 fLU
-ibo
-fKv
-jvJ
-lhg
-ngv
-nvn
+ozm
+ouz
+pnL
+oFh
+qhW
+qyC
 fLU
-jew
-jwh
-xdM
-wJk
-wnT
-rde
+qVG
+rbt
+rfH
+run
+shF
+sUl
 fLU
 eLE
 uoO
@@ -54865,8 +56008,8 @@ uoO
 uoO
 uoO
 uoO
-azs
-azs
+ask
+ask
 uoO
 uoO
 uoO
@@ -54921,52 +56064,52 @@ eLE
 eLE
 eLE
 eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+oFg
+doN
+xHZ
+xHZ
+doN
+oFg
+ljs
+fzx
+vik
+fzx
+fMa
+vTH
+vTH
+ftT
+gvS
+gvS
+oFg
+oFg
+oFg
+oFg
+uoO
+uoO
+eLE
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 eLE
 "}
@@ -54995,36 +56138,36 @@ uoO
 uoO
 eLE
 uoO
-blc
-lue
-wAX
-ijq
-sWM
-tAO
-cLR
-wtj
-wmf
-tfi
-jcB
-nox
-sVV
-mNc
-wql
-yfm
+abi
+bBZ
+dcV
+buJ
+eCE
+fPj
+gPe
+aWF
+icj
+iYF
+jkb
+kkU
+ldY
+iKB
+fkv
+nqA
 fLU
 fLU
 fLU
 fLU
-snF
+euY
 fLU
 fLU
 fLU
-qBn
-xyU
-ibv
-loe
-jLI
-vyt
+qWm
+kBD
+riT
+oQa
+sic
+dpt
 fLU
 eLE
 uoO
@@ -55178,26 +56321,6 @@ eLE
 eLE
 eLE
 eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -55208,22 +56331,42 @@ uoO
 uoO
 uoO
 eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+uoO
+oFg
+gPi
+xHZ
+xHZ
+xHZ
+wwt
+vTH
+vTH
+vTH
+vTH
+vTH
+lcu
+bmX
+oFg
+yfL
+gvS
+lGw
+sba
+jnW
+oFg
+uoO
+eLE
+eLE
+eLE
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-aoj
-uoO
-aoj
-aoj
 uoO
 eLE
 "}
@@ -55252,36 +56395,36 @@ uoO
 uoO
 eLE
 uoO
-blc
-kXo
-vag
-nGx
-sWM
-xFI
-ijq
-adf
-wtj
-ijq
-baX
-dUz
-pho
-pwR
-bxQ
-tcT
-uJt
-aNQ
-wql
-ylz
-ciS
-uYD
-esM
-aOz
-lOo
-ovF
-ahI
-rBa
-vyt
-urt
+abi
+bEp
+dgy
+eeT
+eCE
+bAz
+buJ
+hEp
+aWF
+buJ
+iER
+gZF
+lev
+mAa
+mNF
+nsa
+nTt
+ozp
+fkv
+poI
+pMg
+qjs
+qyW
+qLf
+qXr
+epH
+rjq
+gni
+dpt
+efX
 fLU
 eLE
 uoO
@@ -55448,39 +56591,39 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 eLE
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
+oFg
+doN
+xHZ
+xHZ
+doN
+oFg
+vOA
+vOA
+vOA
+vOA
+iFF
+iFF
+iFF
+oFg
+rjR
+gvS
+oFg
+dcq
+tJe
+oFg
+uoO
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-aoj
-aoj
 uoO
 eLE
 "}
@@ -55509,37 +56652,37 @@ uoO
 uoO
 eLE
 uoO
-blc
+abi
 rXA
-kHi
-ijq
+boc
+buJ
 fLU
 fLU
 fLU
-lHn
+hIq
 fLU
 fLU
-bHO
-blc
-blc
-tEv
-blc
-wLp
-bHO
-blc
-blc
-blc
-blc
-blc
-blc
-blc
-qLE
-blc
-blc
-blc
-yeT
-blc
-blc
+egg
+abi
+abi
+epZ
+abi
+nue
+egg
+abi
+abi
+abi
+abi
+abi
+abi
+abi
+hev
+abi
+abi
+abi
+siK
+abi
+abi
 eLE
 uoO
 uoO
@@ -55705,39 +56848,39 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+oFg
+xHZ
+xHZ
+xHZ
+jvp
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+rjR
+gvS
+oFg
+oFg
+oFg
+oFg
 uoO
 uoO
 eLE
-uoO
-aoj
-aoj
-uoO
-aoj
-aoj
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-aoj
-aoj
 uoO
 eLE
 "}
@@ -55768,34 +56911,34 @@ eLE
 uoO
 uoO
 rXA
-fmB
-vag
-xFI
-wtj
-wtj
-bOv
-ijq
-aiI
-oQd
-wtj
-nEo
-tMn
-bUK
-nRh
-yjB
-wtj
-loe
-xOE
-tMn
-gfb
-ijq
-ugu
-nRh
-cGy
+dmH
+dgy
+bAz
+aWF
+aWF
+hIy
+buJ
+eeG
+jlt
+aWF
+ljj
+hBU
+mYV
+klZ
+nZI
+aWF
+oQa
+pvI
+hBU
+qju
+buJ
+pvV
+klZ
+rca
 eLE
 uoO
 uoO
-fAl
+sXV
 eLE
 eLE
 uoO
@@ -55958,26 +57101,36 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
+oFg
+doN
+erA
+sLq
+doN
+oFg
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+oFg
+rjR
+gvS
+lGw
+sba
+jnW
+oFg
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 eLE
 uoO
 uoO
@@ -55985,16 +57138,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 eLE
 "}
@@ -56026,34 +57169,34 @@ uoO
 uoO
 rXA
 rXA
-jRu
-tfZ
-wtj
-sFr
-unJ
-gZL
-wtj
-hWB
-viS
-ijq
-ijq
-uUO
-ijq
-vag
-bUK
-yjB
-wtj
-mfb
-wtj
-wtj
-gui
-oUM
-baE
+efa
+eGX
+aWF
+dfO
+hKG
+idi
+aWF
+jmA
+gWt
+buJ
+buJ
+mZH
+buJ
+dgy
+mYV
+nZI
+aWF
+pYA
+aWF
+aWF
+bcv
+bjF
+bgu
 eLE
 uoO
 uoO
-uee
-eAL
+sZJ
+jaY
 eLE
 uoO
 uoO
@@ -56215,26 +57358,36 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
+oFg
+oFg
+oFg
+oFg
+oFg
+oFg
+uoO
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+oFg
+oFg
+oFg
+oFg
+dcq
+tJe
+oFg
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 eLE
 uoO
 uoO
@@ -56242,16 +57395,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-aoj
-aoj
 uoO
 eLE
 "}
@@ -56282,33 +57425,33 @@ eLE
 uoO
 uoO
 rXA
-vyt
-urt
-xLN
-ijq
-nGx
-ijq
-wtj
-vcc
-oQd
-nRh
-fkm
-lsn
-ijq
-pFb
-fmB
-kHi
-ijq
-ugu
-rBa
-wtj
-fRU
-vag
-uHb
+dpt
+efX
+ahB
+buJ
+eeT
+buJ
+aWF
+cWn
+jlt
+klZ
+llV
+mBn
+buJ
+nxH
+dmH
+boc
+buJ
+pvV
+gni
+aWF
+qAK
+dgy
+qYq
 rXA
 eLE
 uoO
-onS
+ska
 cSY
 eLE
 eLE
@@ -56472,26 +57615,36 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+aoj
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+oFg
+oFg
+oFg
+oFg
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 eLE
 uoO
 uoO
@@ -56499,16 +57652,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 eLE
 "}
@@ -56538,25 +57681,25 @@ uoO
 eLE
 eLE
 uoO
-blc
-cFS
-bHO
-blc
-blc
-blc
-blc
-blc
-blc
-djM
-blc
-blc
-pZm
-nAM
-mgu
-vag
-mgu
-cnS
-pZm
+abi
+dyQ
+egg
+abi
+abi
+abi
+abi
+abi
+abi
+jrm
+abi
+abi
+mDK
+naY
+nCD
+dgy
+nCD
+oRb
+mDK
 fLU
 fLU
 fLU
@@ -56564,10 +57707,10 @@ rXA
 fLU
 fLU
 eLE
-gwD
-dNN
+rux
+smm
 cSY
-waj
+tfB
 eLE
 uoO
 uoO
@@ -56729,26 +57872,12 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+eLE
 eLE
 uoO
 uoO
@@ -56758,11 +57887,25 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -56796,35 +57939,35 @@ eLE
 uoO
 eLE
 uoO
-iSV
-ksD
-buV
-pbu
+dzJ
+ehk
+iDt
+fTt
 xVz
 uoO
 uoO
 uoO
 uoO
-hyd
-lzR
-lDm
-hDP
-any
-hyd
-lDm
-otJ
-lKW
-oUg
-fDI
+emX
+loc
+ato
+bEw
+nEr
+emX
+ato
+ozN
+pzu
+dEh
+qoB
 uoO
 uoO
 eLE
 eLE
 eLE
-xuH
+rAx
 cSY
 cSY
-vSD
+jcf
 eLE
 uoO
 uoO
@@ -56995,17 +58138,24 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 eLE
 uoO
 uoO
@@ -57013,13 +58163,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -57051,13 +58194,13 @@ uoO
 uoO
 eLE
 uoO
-azs
-hDP
-oUg
-eTb
-mjS
-oUg
-oUg
+ask
+bEw
+dEh
+ehY
+ePk
+dEh
+dEh
 uoO
 uoO
 uoO
@@ -57066,13 +58209,13 @@ uoO
 uoO
 uoO
 xVz
-jbU
-lDm
-otJ
-hyd
-lDm
-azs
-fuX
+nEz
+ato
+ozN
+emX
+ato
+ask
+qpe
 uoO
 eLE
 eLE
@@ -57080,8 +58223,8 @@ uoO
 uoO
 xVz
 cSY
-eAL
-vSD
+jaY
+jcf
 eLE
 uoO
 uoO
@@ -57252,17 +58395,10 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+eLE
+eLE
 eLE
 uoO
 uoO
@@ -57278,7 +58414,14 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -57308,12 +58451,12 @@ uoO
 uoO
 eLE
 uoO
-lDm
-nyb
-lDm
-lDm
-lDm
-xUb
+ato
+bIh
+ato
+ato
+ato
+fZO
 uoO
 uoO
 eLE
@@ -57328,7 +58471,7 @@ uoO
 uoO
 uoO
 uoO
-rmb
+pZr
 uoO
 uoO
 eLE
@@ -57337,7 +58480,7 @@ uoO
 uoO
 uoO
 cSY
-hyd
+emX
 eLE
 eLE
 uoO
@@ -57567,8 +58710,8 @@ eLE
 uoO
 uoO
 uoO
-cjw
-lDm
+dEG
+ato
 uoO
 uoO
 uoO
@@ -57593,7 +58736,7 @@ eLE
 xVz
 uoO
 uoO
-eAL
+jaY
 xVz
 eLE
 eLE
@@ -57825,13 +58968,13 @@ uoO
 eLE
 uoO
 uoO
-uio
+ekK
 uoO
 uoO
 eLE
 uoO
 uoO
-jWG
+jak
 xVz
 uoO
 uoO
@@ -57847,7 +58990,7 @@ eLE
 eLE
 uoO
 uoO
-hyd
+emX
 cSY
 cSY
 cSY
@@ -58088,8 +59231,8 @@ uoO
 eLE
 xVz
 xVz
-hyd
-eAL
+emX
+jaY
 cSY
 xVz
 uoO
@@ -58104,9 +59247,9 @@ uoO
 uoO
 uoO
 xVz
-hyd
-tHM
-eAL
+emX
+rjG
+jaY
 cSY
 xVz
 uoO
@@ -58254,8 +59397,8 @@ pBk
 wWF
 miI
 wWF
-weW
-weW
+nuA
+nuA
 miI
 bcM
 bcM
@@ -58344,16 +59487,16 @@ uoO
 eLE
 uoO
 xVz
-hyd
-eAL
+emX
+jaY
 cSY
 cSY
-eAL
-jVf
+jaY
+dJx
 cSY
-eAL
-hyd
-hyd
+jaY
+emX
+emX
 xVz
 uoO
 uoO
@@ -58363,9 +59506,9 @@ xVz
 xVz
 cSY
 cSY
-hyd
-aWs
-hyd
+emX
+rln
+emX
 xVz
 eLE
 uoO
@@ -58593,21 +59736,21 @@ uoO
 uoO
 eLE
 uoO
-tCC
+awR
 uoO
 uoO
 eLE
 eLE
 uoO
 xVz
-hyd
+emX
 xVz
 xVz
 xVz
 xVz
-eAL
+jaY
 cSY
-lrt
+ndi
 cSY
 cSY
 cSY
@@ -58616,13 +59759,13 @@ xVz
 xVz
 uoO
 xVz
-eAL
-eAL
+jaY
+jaY
 cSY
-hyd
-uKW
-vja
-fbT
+emX
+rCv
+ssQ
+rGw
 uoO
 eLE
 uoO
@@ -58763,16 +59906,16 @@ uoO
 uoO
 uoO
 tur
-kvK
-lUq
-uMA
-vaf
-lOt
+tdP
+nsP
+bWf
+xUu
+rEp
 nrO
-wgT
-rca
-rca
-wUi
+vLr
+mia
+mia
+cpD
 tur
 uoO
 uoO
@@ -58850,36 +59993,36 @@ uoO
 uoO
 eLE
 uoO
-cda
-aoD
+azr
+bJG
 uoO
 uoO
 uoO
 xVz
 xVz
-hyd
+emX
 xVz
 uoO
 uoO
 uoO
-hsH
-jVf
+lwc
+dJx
 cSY
-eAL
-eAL
+jaY
+jaY
 cSY
 cSY
 cSY
-hyd
+emX
 xVz
-baF
+qDo
 cSY
 xVz
 xVz
-aWs
-ijP
-aWs
-lAm
+rln
+rFQ
+rln
+tbE
 uoO
 eLE
 uoO
@@ -59014,22 +60157,22 @@ eoy
 eoy
 uoO
 uoO
-rrq
-rXg
+msE
+rwb
 xVz
 uoO
-tZf
+jlI
 tur
-rca
-uHt
-lUq
-lUq
-lOt
-lOt
-wjW
+mia
+uOV
+nsP
+nsP
+rEp
+rEp
+qYL
 nrO
 iuv
-wUo
+jyF
 tur
 uoO
 uoO
@@ -59108,35 +60251,35 @@ uoO
 eLE
 uoO
 uoO
-vUz
-wPo
-hyd
-hyd
-hyd
-ime
+bMq
+dFC
+emX
+emX
+emX
+gRa
 xVz
 uoO
-vSD
-vSD
-vSD
-vSD
-vSD
+jcf
+jcf
+jcf
+jcf
+jcf
 xVz
-nTY
-hyd
+nIP
+emX
 xVz
 cSY
 cSY
-eAL
+jaY
 cSY
 cSY
-hyd
-hyd
+emX
+emX
 uoO
-hyd
-fbT
-hyd
-vPN
+emX
+rGw
+emX
+teW
 uoO
 eLE
 uoO
@@ -59262,31 +60405,31 @@ uoO
 uoO
 uoO
 eoy
-miw
-ncQ
-hEp
-hLd
-iYF
-pvI
+xtH
+qJb
+npL
+cql
+jCW
+mEb
 eoy
 uoO
 uoO
-rsf
+cwV
 xVz
-rXg
+rwb
 xVz
 xVz
 tur
-uAb
+tRl
 rxG
-lOt
-hEp
-vii
-vTH
-hLd
-wuM
-wIb
-wUB
+rEp
+npL
+ikv
+erJ
+cql
+rjn
+uoy
+wBu
 tur
 uoO
 uoO
@@ -59366,25 +60509,25 @@ eLE
 eLE
 uoO
 uoO
-jVf
+dJx
 xVz
-bxJ
-nWY
+eUp
+gbH
 uoO
 uoO
 eLE
-vSD
-vMc
-lgn
-kiY
-ixU
-bsQ
-kqK
-nZb
+jcf
+jro
+kpk
+lzW
+mHM
+ndk
+nJB
+odk
 xVz
 xVz
 cSY
-hyd
+emX
 xVz
 xVz
 xVz
@@ -59519,29 +60662,29 @@ uoO
 uoO
 uoO
 eoy
-miw
-miw
-hEp
-oaG
-hLd
-pCn
+xtH
+xtH
+npL
+mIW
+cql
+kNg
 eoy
 uoO
 uoO
 uoO
 xVz
-srz
+tOU
 xVz
 wuf
 lnr
 lnr
-hLd
-kvK
-kvK
-kvK
-vVz
+cql
+tdP
+tdP
+tdP
+uYQ
 tur
-wyc
+lfN
 tur
 tur
 tur
@@ -59630,18 +60773,18 @@ uoO
 uoO
 uoO
 eLE
-vSD
-aJc
-isI
-vSD
+jcf
+jrV
+krt
+jcf
 eLE
 eLE
 uoO
-hsH
+lwc
 uoO
 xVz
 xVz
-hyd
+emX
 uoO
 uoO
 uoO
@@ -59776,30 +60919,30 @@ uoO
 uoO
 uoO
 eoy
-miw
-miw
-hEp
-hEp
-hEp
-pvI
+xtH
+xtH
+npL
+npL
+npL
+mEb
 eoy
 uoO
 uoO
 uoO
 tiS
-sBm
+pGS
 uoO
 uoO
 tur
 nrO
-uKB
-hEp
-hEp
-vkD
-kvK
+jQm
+npL
+npL
+ehg
+tdP
 tur
 ghw
-wJm
+xJU
 tur
 tur
 uoO
@@ -60033,12 +61176,12 @@ uoO
 uoO
 uoO
 eoy
-miy
-miy
-nqA
-hLd
-hLd
-pGw
+pcw
+pcw
+lzj
+cql
+cql
+edm
 eoy
 uoO
 uoO
@@ -60049,14 +61192,14 @@ uoO
 uoO
 tur
 tur
-uKP
-uNS
-pbp
-vkL
-vWg
+rAn
+qTw
+dpI
+vdI
+qKE
 tur
-wDO
-wMy
+oUA
+bad
 tur
 tur
 uoO
@@ -60292,10 +61435,10 @@ uoO
 eoy
 eoy
 eoy
-nsa
-obT
-hEp
-pGw
+cHb
+tDU
+npL
+edm
 eoy
 uoO
 uoO
@@ -60311,10 +61454,10 @@ tur
 tur
 tur
 tur
-wkN
-wFx
-wOg
-wXG
+baJ
+ekn
+jSq
+xrf
 tur
 uoO
 uoO
@@ -60548,10 +61691,10 @@ tur
 tur
 tur
 tur
-hLd
-hEp
-hEp
-hLd
+cql
+npL
+npL
+cql
 tur
 tur
 tur
@@ -60568,9 +61711,9 @@ weW
 weW
 weW
 weW
-wpJ
+bVn
 nuA
-wQC
+ccP
 weW
 tur
 uoO
@@ -60798,24 +61941,21 @@ uoO
 uoO
 uoO
 tur
-jcf
+aJp
 weW
 weW
-kAp
-weW
-weW
-weW
-weW
-nue
-weW
-nue
-pMg
-qwV
-weW
-rbt
+nCU
 weW
 weW
 weW
+weW
+dYh
+weW
+dYh
+xrE
+feN
+weW
+ovA
 weW
 weW
 weW
@@ -60825,9 +61965,12 @@ weW
 weW
 weW
 weW
-wpJ
+weW
+weW
+weW
+bVn
 nuA
-wQC
+ccP
 weW
 tur
 uoO
@@ -61062,25 +62205,25 @@ tur
 tur
 eoy
 tur
-hLd
-hLd
-hEp
-hEp
+cql
+cql
+npL
+npL
 tur
 tur
 tur
 tur
 tur
 tur
-sCZ
+bez
 pBk
 pBk
 pBk
 wWF
 wWF
-uOE
-uOE
-uOE
+kxW
+kxW
+kxW
 wWF
 wWF
 miI
@@ -61318,29 +62461,29 @@ uoO
 uoO
 uoO
 eoy
-hEp
-ndi
-nxH
-hEp
-oAe
-hEp
+npL
+aoi
+dlx
+npL
+ddY
+npL
 eoy
-hkD
-hkD
-hkD
+uoO
+uoO
+uoO
 tur
-sHb
-tur
-tur
+xTN
 tur
 tur
 tur
 tur
 tur
 tur
-vWZ
-hLd
-hEp
+tur
+tur
+ueP
+cql
+npL
 fGO
 weW
 tur
@@ -61568,36 +62711,36 @@ uoO
 uoO
 uoO
 nrO
-iKB
+oJO
 nrO
 iuv
 iuv
 iuv
 uoO
 eoy
-mzR
-hEp
+nWR
+npL
 eoy
-hLd
+cql
 eoy
-pYA
+peF
 eoy
-hkD
-rca
-run
-nIP
+uoO
+mia
+sTz
+cGm
 nuA
 nuA
-tZq
+pVq
 nuA
 weW
 vuv
 lnr
 iuv
-vmm
+esC
 iuv
 rxG
-ozN
+llb
 fGO
 weW
 tur
@@ -61823,30 +62966,30 @@ eLE
 uoO
 uoO
 lnr
-hxM
+qtQ
 lnr
-hkD
-hkD
+uoO
+uoO
 nrO
-gWt
-kBD
-gWt
+bfY
+vnR
+bfY
 eoy
 eoy
 eoy
 eoy
-odk
+mij
 eoy
-pZr
+dsT
 eoy
-hkD
-hkD
+uoO
+uoO
 iuv
 iuv
 vuv
-tmM
+wwV
 vuv
-tmM
+wwV
 weW
 vuv
 rxG
@@ -62080,26 +63223,26 @@ eLE
 uoO
 lnr
 nrO
-gWt
-gWt
-gWt
-gWt
-gWt
-gWt
+bfY
+bfY
+bfY
+bfY
+bfY
+bfY
 iuv
-lev
+qFM
 iuv
 nrO
 vuv
 vuv
 nrO
-oDY
-qcp
+toj
+ftD
 vuv
-hkD
-rce
-rux
-rXS
+uoO
+cgp
+mSp
+rjx
 vuv
 vuv
 vuv
@@ -62107,7 +63250,7 @@ vuv
 vuv
 vuv
 iuv
-vat
+fwM
 vuv
 vuv
 vuv
@@ -62337,22 +63480,22 @@ eLE
 uoO
 iuv
 lnr
-gWt
+bfY
 iuv
-iNY
+cMT
 iuv
 nrO
-gWt
-iNY
-gWt
+bfY
+cMT
+bfY
 iuv
-mAa
+wtI
 vuv
 nrO
 nrO
 iuv
 iuv
-qyc
+ekx
 nrO
 nrO
 nrO
@@ -62365,9 +63508,9 @@ iuv
 vuv
 iuv
 vuv
-urZ
+bwR
 nrO
-rca
+mia
 tur
 fGO
 weW
@@ -62475,7 +63618,7 @@ uoO
 uoO
 qDR
 uoO
-adY
+rTh
 uoO
 uoO
 aoj
@@ -62593,33 +63736,33 @@ tur
 eLE
 iuv
 iuv
-gWt
-gWt
+bfY
+bfY
 iuv
 uJD
 iuv
 nrO
 iuv
 iuv
-jeM
+uFW
 iuv
 nrO
-gWt
-nEr
+bfY
+bCy
 nrO
 iuv
-qcp
+ftD
 vuv
 vuv
-hkD
-qyI
-qLf
+uoO
+wbO
+sGP
 vuv
 vuv
 nrO
 nrO
 iuv
-urZ
+bwR
 nrO
 nrO
 nrO
@@ -62730,7 +63873,7 @@ uoO
 uoO
 uoO
 uoO
-abi
+nfM
 qDR
 uoO
 uoO
@@ -62850,29 +63993,29 @@ tur
 eLE
 iuv
 iuv
-gWt
-hyj
+bfY
+rQY
 iuv
 uJD
 iuv
 iuv
 nrO
 iuv
-gWt
+bfY
 iuv
 iuv
-ndk
+mvy
 iuv
-ohv
+wSh
 iuv
 iuv
-qyC
+uux
 vuv
-rca
+mia
 nrO
 nrO
-sMc
-toA
+bhS
+fff
 vuv
 vuv
 iuv
@@ -63107,21 +64250,21 @@ tur
 eLE
 lnr
 iuv
-gWt
-hAT
-hYr
+bfY
+uDV
+kVL
 uJD
-jdP
+ciD
 nrO
-jSJ
-kDS
-gWt
-gWt
-gWt
-gWt
-nEz
+irf
+lST
+bfY
+bfY
+bfY
+bfY
+fpl
 nrO
-oEi
+edK
 vuv
 vuv
 vuv
@@ -63130,7 +64273,7 @@ iuv
 iuv
 iuv
 iuv
-ubW
+vpe
 vuv
 iuv
 nrO
@@ -63364,19 +64507,19 @@ tur
 eLE
 lnr
 lnr
-gWt
-hEp
-hLd
+bfY
+npL
+cql
 uJD
-jej
-jFB
-jWC
+iWo
+pVP
+gcN
 iuv
-lfb
-gWt
-gWt
-gWt
-nEH
+nKK
+bfY
+bfY
+bfY
+roS
 iuv
 vuv
 vuv
@@ -63384,11 +64527,11 @@ vuv
 nrO
 nrO
 iuv
-rZZ
-sPK
+iZZ
+wkB
 iuv
 iuv
-qyI
+wbO
 iuv
 nrO
 nrO
@@ -63503,7 +64646,7 @@ uoO
 uoO
 xVz
 xVz
-lMI
+dJQ
 uoO
 uoO
 uoO
@@ -63621,36 +64764,36 @@ tur
 eLE
 uoO
 lnr
-gWt
-hIq
-ias
+bfY
+aSX
+dQn
 uJD
-jeE
-jGy
+wNC
+krJ
 iuv
-kFg
-kFg
-gWt
-gWt
-gWt
-gWt
-oiy
+wDB
+wDB
+bfY
+bfY
+bfY
+bfY
+xWG
 vuv
 vuv
 vuv
 nrO
 nrO
 iuv
-sdI
-sPK
+sNW
+wkB
 iuv
-udH
+pCt
 vuv
 iuv
 vuv
 nrO
-tdY
-vnW
+tYf
+mmN
 nrO
 iuv
 tur
@@ -63878,23 +65021,23 @@ tur
 eLE
 uoO
 lnr
-gWt
-gWt
-gWt
-gWt
-jeM
-gWt
-gWt
-gWt
-gWt
-gWt
-mBn
+bfY
+bfY
+bfY
+bfY
+uFW
+bfY
+bfY
+bfY
+bfY
+bfY
+pGg
 nrO
 nrO
 iuv
-mBn
-qdZ
-qyI
+pGg
+xzq
+wbO
 nrO
 nrO
 nrO
@@ -63906,9 +65049,9 @@ vuv
 nrO
 nrO
 vuv
-vbI
-vpz
-vXh
+dQV
+gQz
+nCt
 vuv
 tur
 wIM
@@ -64137,17 +65280,17 @@ uoO
 rxG
 iuv
 rxG
-icj
+phL
 iuv
 iuv
-jHN
-iuv
-nrO
+prM
 iuv
 nrO
 iuv
 nrO
 iuv
+nrO
+iuv
 iuv
 vuv
 vuv
@@ -64155,13 +65298,13 @@ vuv
 nrO
 iuv
 nrO
-sfm
+sHN
 vuv
 vuv
 vuv
 vuv
 nrO
-kSa
+oYk
 vuv
 vuv
 vuv
@@ -64276,7 +65419,7 @@ uoO
 xVz
 xVz
 xVz
-acT
+oZF
 xVz
 xVz
 uoO
@@ -64392,22 +65535,22 @@ tur
 eLE
 uoO
 lnr
-gWG
-gWG
+wOt
+wOt
 jmN
 jmN
-hhi
-hhi
-jXe
-jXe
-gWG
+fRt
+fRt
+wqw
+wqw
+wOt
 iuv
 nrO
 iuv
 nrO
 iuv
-oEi
-hkD
+edK
+uoO
 vuv
 nrO
 iuv
@@ -64416,10 +65559,10 @@ vuv
 vuv
 vuv
 nrO
-upC
+mbx
 nrO
 nrO
-uPu
+jcj
 vuv
 vuv
 vuv
@@ -64546,7 +65689,7 @@ uoO
 uoO
 xVz
 xVz
-afj
+tEW
 dhi
 eoy
 eoy
@@ -64649,40 +65792,40 @@ tur
 eLE
 nrO
 lnr
-gWG
-hIy
-igH
-iPs
+wOt
+niM
+bdt
+vRE
 iuv
-jJT
-jYt
-kPb
-gWG
-iuv
-nrO
-nrO
+ivl
+dIB
+iDI
+wOt
 iuv
 nrO
-oFh
-hkD
-hkD
+nrO
+iuv
+nrO
+eoX
+uoO
+uoO
 vuv
 nrO
 nrO
 vuv
-nrO
-mBn
+tsn
+pGg
 nrO
 iuv
 nrO
 vuv
-uQO
+nXJ
 ghw
-vqb
+iYa
 vuv
 vuv
-ozN
-wRj
+llb
+ngc
 weW
 tur
 uoO
@@ -64787,7 +65930,7 @@ uoO
 uoO
 uoO
 uoO
-lMI
+dJQ
 xVz
 uoO
 xVz
@@ -64906,7 +66049,7 @@ tur
 eLE
 iuv
 lnr
-gXR
+hxP
 iuv
 iuv
 iuv
@@ -64914,18 +66057,18 @@ iuv
 nrO
 nrO
 nrO
-gWG
-lJa
-mGg
-nfM
-nIP
+wOt
+tNA
+wSj
+czc
+cGm
 nrO
 iuv
 nrO
-hkD
-hkD
+uoO
+uoO
 vuv
-qyI
+wbO
 vuv
 nrO
 iuv
@@ -64933,12 +66076,12 @@ nrO
 iuv
 nrO
 vuv
-uRY
-ven
-vra
+nXQ
+owU
+gkk
 vuv
 vuv
-ozN
+llb
 fGO
 weW
 tur
@@ -65049,8 +66192,8 @@ uoO
 uoO
 uoO
 uoO
-aeS
-kjz
+tqH
+qpG
 xVz
 xVz
 xVz
@@ -65163,25 +66306,25 @@ tur
 eLE
 iuv
 lnr
-gWG
-hKG
-ihg
-iPH
-jfS
-jKY
+wOt
+ecX
+nWT
+vqt
+nav
+tyw
 iuv
 nrO
-gWG
-lJa
-mHM
-nha
+wOt
+tNA
+bTJ
+xml
 nrO
 iuv
 nrO
 nrO
 nrO
 nrO
-mBn
+pGg
 nrO
 nrO
 nrO
@@ -65191,7 +66334,7 @@ iuv
 nrO
 vuv
 vuv
-veq
+iWh
 vuv
 vuv
 vuv
@@ -65309,7 +66452,7 @@ uoO
 xVz
 xVz
 xVz
-bRX
+qOc
 xVz
 xVz
 xVz
@@ -65419,7 +66562,7 @@ nBk
 tur
 eLE
 uoO
-gTv
+wQl
 jmN
 jmN
 jmN
@@ -65429,20 +66572,20 @@ jmN
 jmN
 nrO
 jmN
-lJa
-mKh
-nhK
-hkD
+tNA
+oev
+pHw
+uoO
 iuv
 iuv
-nIP
+cGm
 nrO
 iuv
 nrO
 iuv
 nrO
 iuv
-tqH
+nrO
 nrO
 nrO
 nrO
@@ -65450,9 +66593,9 @@ vuv
 iuv
 iuv
 vuv
-hEp
-wrg
-wGy
+npL
+iZg
+fkA
 fGO
 weW
 tur
@@ -65675,41 +66818,41 @@ nBk
 nBk
 tur
 eLE
-gQV
-gUm
+iUj
+gre
 lnr
 hkD
 hkD
 hkD
 hkD
-gWG
+wOt
 jmN
-kRu
+kAs
 jmN
-lJa
-mKm
-njZ
-hkD
+tNA
+uYc
+aTR
+uoO
+nBo
+kfy
+nrO
+nrO
+nrO
+cki
+weW
+nrO
+lZH
+nrO
 iuv
-nrO
-nrO
-nrO
-nrO
-nIP
-nrO
-nrO
 iuv
-nrO
-iuv
-iuv
-teW
+iIw
 vuv
 iuv
 iuv
-vuf
-hEp
-hEp
-wHf
+bMz
+npL
+npL
+kCi
 fGO
 weW
 tur
@@ -65824,7 +66967,7 @@ xVz
 xVz
 xVz
 xVz
-buV
+iDt
 uoO
 uoO
 xVz
@@ -65936,27 +67079,27 @@ rxG
 jmN
 jmN
 jmN
-gWG
-gWG
-gWG
-gWG
+wOt
+wOt
+wOt
+wOt
 jmN
 nrO
 jmN
-iuv
-hkD
-hkD
-hkD
-iuv
-oIo
-iuv
-iuv
-iuv
-oIo
+lwc
+uoO
+uoO
+uoO
+sMK
+nhV
+kfy
 nrO
+cki
+weW
+nKj
+weW
+lZH
 nrO
-iuv
-iuv
 nrO
 iuv
 vuv
@@ -65964,9 +67107,9 @@ vuv
 nrO
 iuv
 nrO
-hLd
-hLd
-wGy
+cql
+cql
+fkA
 fGO
 weW
 tur
@@ -66062,7 +67205,7 @@ uoO
 xVz
 xVz
 xVz
-acs
+ohv
 uoO
 uoO
 uoO
@@ -66191,39 +67334,39 @@ tur
 eLE
 rxG
 jmN
-gYE
-hLd
-ikD
-iRE
-gZF
-iWE
-jZf
+gtO
+cql
+dZc
+hfW
+wMo
+gyd
+qmY
 nrO
-gWc
-lKT
-hkD
-nmN
-nmN
-nmN
-nmN
-nmN
-qyW
-nmN
-nmN
-nmN
-nmN
+lBA
+uoO
+uoO
+uoO
+mia
+kfy
+kfy
+baF
+nrO
+cki
+vOu
+weW
+qdm
+weW
+lZH
 nrO
 iuv
-nrO
-iuv
-oZF
+niT
 nrO
 nrO
 iuv
 vuv
-vXF
-wsv
-wGy
+hLJ
+bFe
+fkA
 fGO
 weW
 tur
@@ -66309,7 +67452,7 @@ uoO
 qDR
 qDR
 qDR
-jPC
+uXs
 uoO
 uoO
 aoj
@@ -66446,41 +67589,41 @@ nBk
 nBk
 tur
 eLE
-gRa
+amL
 jmN
-gZF
-hLd
-ikD
-hEp
-hEp
-iWE
+wMo
+cql
+dZc
+npL
+npL
+gyd
 iuv
 nrO
 jmN
-rxG
-hkD
-nmN
-nJB
-omq
-oJc
-qez
-hEp
-hLd
-rcf
-rAx
-sfI
-sRw
-tqZ
+vuv
+vuv
+vuv
+vuv
+kfy
+kfy
+dUq
 nrO
-urM
+cki
+weW
+yaH
+uEs
+weW
+lZH
+nrO
+nFc
 vuv
 vuv
-uWl
+bdC
 iuv
 vuv
-vYC
-wsK
-wHB
+hGY
+qqD
+wmH
 fGO
 weW
 tur
@@ -66573,7 +67716,7 @@ aoj
 aoj
 uoO
 uoO
-jPC
+uXs
 xVz
 xVz
 xVz
@@ -66705,36 +67848,36 @@ tur
 eLE
 iuv
 jmN
-hev
-hNq
-imj
-iWE
-jgP
-iWE
+tVb
+ovE
+jec
+gyd
+cCT
+gyd
 iuv
-kRE
+dtS
 jmN
-lOt
-mMC
-nmN
-nLK
-org
-ghw
-ghw
-ghw
-qVG
-hLd
-qVG
-nmN
-sUl
-tqZ
+nrO
+tAC
+xKn
+vuv
+kfy
+kfy
+dUq
+nrO
+cki
+weW
+weW
+weW
+weW
+lZH
 iuv
 iuv
 nrO
 vuv
-kvL
-sZJ
-mgQ
+oeG
+dig
+gGr
 vuv
 vuv
 vuv
@@ -66819,7 +67962,7 @@ uoO
 uoO
 uoO
 uoO
-lMI
+dJQ
 xVz
 xVz
 xVz
@@ -66960,31 +68103,31 @@ nBk
 nBk
 tur
 eLE
-gSQ
-gWc
-heR
-hOR
-ioO
+xaV
+lBA
+rdE
+tHa
+gfS
 nrO
 nrO
 nrO
 iuv
-kSa
-gWG
-lPs
-mTq
-nmN
-nNR
-ghw
-oOm
-qgP
-qzG
-hLd
-hLd
-hLd
-nmN
-sXV
-tqZ
+oYk
+jmN
+nrO
+vuv
+xIy
+vuv
+kfy
+kfy
+baF
+nrO
+cki
+nKj
+weW
+vOu
+weW
+lZH
 iuv
 nrO
 nrO
@@ -66994,7 +68137,7 @@ vuv
 vuv
 vuv
 hkD
-vWZ
+ueP
 wWF
 weW
 tur
@@ -67219,38 +68362,38 @@ tur
 eLE
 iuv
 jmN
-hfb
+uey
 etN
-hAT
-hAT
-jkb
-hAT
+uDV
+uDV
+qTY
+uDV
 nrO
 nrO
-gWG
-lUq
-mUw
-nmN
-nRP
-ghw
-hEp
-hEp
-qAK
-hLd
-hLd
-rBn
-nmN
-sZJ
+jmN
+nrO
+tAC
+ibB
+vuv
+dIr
+kfy
+kfy
+nrO
+cki
+qdm
+weW
+weW
+lZH
 nrO
 nrO
-teW
+nrO
 iuv
-gWt
-gWt
-gWt
-gWt
-gWt
-gWt
+bfY
+bfY
+bfY
+bfY
+bfY
+bfY
 tur
 wWF
 weW
@@ -67347,7 +68490,7 @@ uoO
 uoO
 qDR
 uoO
-jPC
+uXs
 uoO
 uoO
 aoj
@@ -67476,38 +68619,38 @@ tur
 eLE
 iuv
 jmN
-hgP
-hQG
-hAT
-ias
-hLd
-hAT
+ieE
+iFC
+uDV
+dQn
+cql
+uDV
 nrO
-kTJ
-gWG
-iuv
-mVa
-nmN
-nTt
-ghw
-oOR
-qhk
-oOR
-hLd
-hLd
-rCv
-nmN
-sfI
-nmN
-nmN
-sfI
+txW
+jmN
 nrO
-uKU
+vuv
+vuv
+vuv
+kfy
+kfy
+nrO
+nrO
+nrO
+cki
+weW
+nrO
+lZH
+nrO
+nrO
+nrO
+nrO
+nxP
 iuv
-vfh
-vzL
-vZW
-gWt
+kzt
+qMs
+pfm
+bfY
 tur
 fGO
 weW
@@ -67602,7 +68745,7 @@ uoO
 uoO
 uoO
 uoO
-abi
+nfM
 qDR
 uoO
 uoO
@@ -67733,38 +68876,38 @@ tur
 eLE
 iuv
 jmN
-hhe
-hWZ
-ipw
-iWH
-jmA
-hAT
+hPu
+eui
+gau
+qyL
+qsb
+uDV
 nrO
-kVD
-gWG
-lUI
-hkD
-nmN
-nmN
-otk
-hLd
-hEp
-hLd
-hEp
-hLd
-rHL
-nmN
-tau
-tAr
-ufo
-sfI
+rWP
+gDj
 nrO
-oZF
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+niT
 iuv
-vfi
-vzR
-wcm
-gWt
+bsQ
+uhn
+gyn
+bfY
 tur
 fGO
 weW
@@ -67847,7 +68990,7 @@ uoO
 uoO
 uoO
 xVz
-buV
+iDt
 xVz
 uoO
 uoO
@@ -67855,7 +68998,7 @@ aoj
 uoO
 uoO
 uoO
-jPC
+uXs
 uoO
 uoO
 uoO
@@ -67885,7 +69028,7 @@ xVz
 xVz
 xVz
 xVz
-buV
+iDt
 uoO
 uoO
 uoO
@@ -67990,39 +69133,39 @@ tur
 eLE
 rxG
 jmN
-hhi
-hhi
-hhi
+fRt
+fRt
+fRt
 jmN
 jmN
-gWG
-gWG
-gWG
-gWG
-gWG
-hkD
-nnz
-nmN
-nmN
-oQa
-qjs
-qDo
-qWm
-hEp
-hLd
-shF
-hEp
-hEp
-hLd
-sfI
+wOt
+wOt
+wOt
+wOt
+wOt
+uoO
+uoO
+aqr
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+mia
+nrO
 iuv
-gWt
+bfY
 iuv
 iuv
 nrO
 nrO
 nrO
-wHB
+wmH
 fGO
 weW
 tur
@@ -68249,37 +69392,37 @@ lnr
 lnr
 lnr
 rxG
-ipx
-ipx
-jok
-jNe
-kfQ
-kWK
-hEp
-jwp
-hEp
-hEp
-hEp
-nmN
-oRb
-nmN
-nmN
-nmN
-qyW
-nmN
-nmN
-tbE
-tDl
-ufQ
-nmN
+wbi
+wbi
+muc
+aTJ
+tny
+gDj
+npL
+sjg
+npL
+cql
+cql
 nrO
-gWt
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+mia
+mia
+mia
+nrO
+bfY
 iuv
 iuv
 iuv
 nrO
 nrO
-wHB
+wmH
 fGO
 weW
 tur
@@ -68375,7 +69518,7 @@ uoO
 xVz
 xVz
 xVz
-lMI
+dJQ
 uoO
 uoO
 uoO
@@ -68399,7 +69542,7 @@ uoO
 xVz
 xVz
 xVz
-iwL
+tEH
 uoO
 uoO
 uoO
@@ -68504,39 +69647,39 @@ tur
 eLE
 uoO
 lnr
-hor
-gWG
-gWG
+tBL
+wOt
+wOt
 jmN
 jmN
 jmN
 jmN
 jmN
-jwp
+sjg
 jmN
 jmN
 jmN
-nZI
-nmN
-hEp
-qju
-qFn
-nmN
-hEp
-rMp
-sfI
-nmN
-nmN
-nmN
-nmN
+cql
 nrO
-gWt
-gWt
+nrO
+nrO
+uvW
+uvW
+uvW
+uvW
+jmN
+jmN
+jmN
+jmN
+jmN
+nrO
+bfY
+bfY
 nrO
 iuv
 iuv
 nrO
-wHB
+wmH
 fGO
 weW
 tur
@@ -68646,14 +69789,14 @@ uoO
 qDR
 qDR
 qDR
-jPC
+uXs
 uoO
 uoO
 uoO
 aoj
 uoO
-jPC
-qrc
+uXs
+tDl
 mlz
 xVz
 xVz
@@ -68762,37 +69905,37 @@ eLE
 uoO
 lnr
 lnr
-gWG
-ivm
-iYF
-jqX
-hEp
-hLd
-hLd
-hLd
-lVr
-mVo
+wOt
+lqk
+jCW
+ixO
+npL
+cql
+cql
+cql
+cfz
+kpy
 jmN
-hEp
-ouz
-hEp
-hLd
-qJL
-nmN
-rfH
-rMp
-nmN
-tcC
-tqZ
-iuv
-urZ
+xod
+vuv
+vuv
+vuv
+uvW
+ttg
+dRU
+wpU
+dug
+cql
+rer
+nyy
+glQ
 nrO
 vuv
-gWt
-mgQ
+bfY
+gGr
 nrO
-uWl
-gWt
+bdC
+bfY
 tur
 fGO
 weW
@@ -69018,38 +70161,38 @@ tur
 eLE
 uoO
 lnr
-hpe
-gWG
-hEp
-hEp
-jrm
-hEp
-kjW
-hLd
-llV
-hLd
-mYV
+dsS
+wOt
+npL
+npL
+atm
+npL
+qcN
+cql
+cvs
+cql
+eKx
 jmN
-hEp
-nmN
-oXs
-oXs
-qJM
-nmN
-riT
-rMG
-nmN
-tdY
-tDW
-umG
-iuv
+cql
+hgD
+lZH
+orB
+uvW
+gsr
+xhg
+ghw
+ghw
+ghw
+cql
+cql
+uvW
 iuv
 vuv
-gWt
-gWt
-gWt
-gWt
-gWt
+bfY
+bfY
+bfY
+bfY
+bfY
 tur
 wIM
 weW
@@ -69148,7 +70291,7 @@ uoO
 xVz
 xVz
 xVz
-acT
+oZF
 xVz
 xVz
 uoO
@@ -69156,7 +70299,7 @@ uoO
 uoO
 uoO
 uoO
-lMI
+dJQ
 xVz
 xVz
 xVz
@@ -69276,37 +70419,37 @@ eLE
 uoO
 lnr
 lnr
-gWG
-hEp
-hEp
-jro
-hEp
-kkm
-hLd
-lnt
-hEp
-naY
+wOt
+npL
+npL
+aSM
+npL
+jfP
+cql
+smG
+npL
+ivV
 jmN
-hLd
-nmN
-nmN
-nmN
-nmN
-nmN
-nmN
-nmN
-nmN
+cql
+sji
 nrO
 nrO
-nrO
-nrO
+uvW
+nZB
+ghw
+qfC
+uKs
+dZe
+cql
+cql
+uvW
 nrO
 vuv
-hkD
-hkD
-hkD
-hkD
-hkD
+uoO
+uoO
+uoO
+uoO
+uoO
 tur
 wIM
 weW
@@ -69391,7 +70534,7 @@ aoj
 uoO
 uoO
 uoO
-lMI
+dJQ
 xVz
 xVz
 xVz
@@ -69508,7 +70651,7 @@ uoO
 uoO
 uoO
 uoO
-eWV
+iXQ
 pYd
 pYd
 pYd
@@ -69520,7 +70663,7 @@ uoO
 uoO
 uoO
 dXE
-gsQ
+fTB
 pEF
 fGZ
 vnJ
@@ -69533,37 +70676,37 @@ eLE
 uoO
 uoO
 lnr
-gXR
-iwx
-hEp
-jrV
-hEp
-kkU
-hLd
-loc
-hEp
-naY
-gWc
-hLd
-oyo
-iuv
+hxP
+eAh
+npL
+fFn
+npL
+dcc
+cql
+ftz
+npL
+ivV
+lBA
+cql
+vuv
 nrO
 nrO
-iuv
-rjq
-iuv
-iuv
-nrO
-nrO
-nrO
-nrO
+uvW
+hyV
+ghw
+npL
+npL
+qMG
+cql
+vcz
+uvW
 nrO
 vuv
 vuv
 vuv
-hkD
-hkD
-hkD
+uoO
+uoO
+uoO
 tur
 wIM
 weW
@@ -69659,7 +70802,7 @@ uoO
 uoO
 uoO
 uoO
-lMI
+dJQ
 xVz
 uoO
 xVz
@@ -69678,8 +70821,8 @@ uoO
 uoO
 uoO
 uoO
-jPC
-qrc
+uXs
+tDl
 xVz
 xVz
 xVz
@@ -69764,9 +70907,9 @@ tur
 uoO
 uoO
 uoO
-eUp
+kcf
 pYd
-frh
+mWI
 irB
 pYd
 pYd
@@ -69776,12 +70919,12 @@ uoO
 uoO
 uoO
 uoO
-gev
+lsS
 jZT
 jZT
 jZT
 jZT
-gFV
+dDt
 tur
 nBk
 nBk
@@ -69790,33 +70933,33 @@ eLE
 eLE
 uoO
 uoO
-gWG
-iDt
-hEp
-jug
-hEp
-kpk
-hEp
-lsk
-hEp
-naY
+wOt
+kod
+npL
+rsa
+npL
+fCp
+npL
+enb
+npL
+ivV
 jmN
-hLd
-hLd
+cql
+vuv
+pyB
+gGr
+uvW
+dQm
+ghw
+npL
+npL
+npL
+cql
+ttl
+uvW
 nrO
-iuv
-nrO
-nrO
-nrO
-nrO
-nrO
-teW
-tEu
-nrO
-teW
-nrO
-uLn
-hLd
+eBP
+cql
 vuv
 vuv
 vuv
@@ -69921,8 +71064,8 @@ uoO
 uoO
 uoO
 uoO
-adx
-kjz
+pZt
+qpG
 xVz
 xVz
 uoO
@@ -70021,8 +71164,8 @@ tur
 uoO
 uoO
 uoO
-eWV
-fgW
+iXQ
+hMo
 ptQ
 ctu
 bgV
@@ -70033,12 +71176,12 @@ pYd
 rXA
 uoO
 uoO
-gev
+lsS
 jZT
 jZT
 jZT
 jZT
-gJz
+hQs
 tur
 nBk
 nBk
@@ -70046,39 +71189,39 @@ tur
 uoO
 eLE
 uoO
-hqg
-gWG
-iER
-hLd
-juP
-hLd
-krt
-hEp
-lzW
-hEp
-ncx
+aNB
+wOt
+mGT
+cql
+rrc
+cql
+mdK
+npL
+tTD
+npL
+pEZ
 jmN
-hLd
-hEp
+xod
+nKT
+vuv
+vuv
+uvW
+uvW
+bQx
+cql
+npL
+cql
+cql
+xTE
+uvW
 nrO
-iuv
-iuv
-iuv
-iuv
-iuv
-iuv
-gWc
-jmN
-unV
-jmN
-gWc
 vuv
-hLd
-hEp
-vBA
-wcF
+cql
+npL
+oTw
+avO
 vuv
-ozN
+llb
 fGO
 weW
 tur
@@ -70181,10 +71324,10 @@ uoO
 xVz
 xVz
 xVz
-bRX
+qOc
 uoO
 uoO
-buV
+iDt
 xVz
 uoO
 uoO
@@ -70192,9 +71335,9 @@ uoO
 uoO
 uoO
 uoO
-jPC
+uXs
 qDR
-adY
+rTh
 xVz
 xVz
 uoO
@@ -70278,8 +71421,8 @@ tur
 uoO
 uoO
 uoO
-eWV
-fjU
+iXQ
+tff
 cfL
 nqV
 iox
@@ -70290,12 +71433,12 @@ pYd
 rXA
 uoO
 uoO
-gev
-gxq
+lsS
+ukd
 dJF
 twj
 jZT
-gNZ
+kuj
 tur
 nBk
 nBk
@@ -70303,39 +71446,39 @@ tur
 uoO
 eLE
 uoO
-hsH
-gWG
-iHB
-jak
-jwm
-hEp
-hEp
-hEp
-lAW
-lYE
-ncK
+lwc
+wOt
+xHg
+bdd
+fel
+npL
+npL
+npL
+tNw
+deU
+cLx
 jmN
-hLd
+cql
+cql
+cql
+mxG
+uvW
+uvW
+cql
+pqY
+hJZ
+vJg
+npL
+cql
+uvW
+orB
 vuv
-vuv
-qmV
-qLf
-vuv
-vuv
-vuv
-sic
-jmN
-tEH
-hLd
-utr
-jmN
-vuv
-hEp
-hEp
-hEp
-hEp
-wus
-wHV
+npL
+npL
+npL
+npL
+gUC
+tAe
 miI
 weW
 tur
@@ -70535,7 +71678,7 @@ tur
 uoO
 aoj
 aoj
-eWV
+iXQ
 iox
 kIS
 fLK
@@ -70551,7 +71694,7 @@ dXE
 tur
 tur
 tur
-gFu
+qyj
 oeb
 tur
 nBk
@@ -70559,12 +71702,8 @@ nBk
 tur
 uoO
 eLE
-eLE
-hvw
-gWG
-jmN
-jmN
-hLd
+uoO
+uoO
 jmN
 jmN
 jmN
@@ -70572,27 +71711,31 @@ jmN
 jmN
 jmN
 jmN
-nnL
-hLd
-oZF
-nrO
-nrO
-nrO
-nrO
-nrO
+jmN
+jmN
+jmN
+cql
+cql
+kcm
+sGP
 vuv
-jmN
-tEW
-hLd
-hLd
-jmN
 vuv
-hEp
-vfL
-vfL
-hEp
+glQ
+bib
+uvW
+uvW
+uvW
+aAF
+uvW
+uvW
+uvW
 vuv
-ozN
+npL
+juo
+juo
+npL
+vuv
+llb
 miI
 weW
 tur
@@ -70709,8 +71852,8 @@ uoO
 xVz
 xVz
 xVz
-jPC
-jPC
+uXs
+uXs
 uoO
 uoO
 uoO
@@ -70792,9 +71935,9 @@ tur
 uoO
 aoj
 aoj
-eWV
+iXQ
 pYd
-ftV
+uBk
 iVi
 mSs
 gyf
@@ -70804,10 +71947,10 @@ pAK
 oFi
 pYd
 pYd
-giA
-gyB
+wDK
+vsu
 jZT
-gza
+gpf
 jZT
 jZT
 tur
@@ -70815,39 +71958,39 @@ nBk
 nBk
 tur
 uoO
+eLE
 uoO
 uoO
-eLE
-eLE
-hvw
+uoO
+uoO
+uoO
+uoO
+uoO
 jmN
-jwp
-jmN
-hEp
-hEp
-hEp
-mba
-hEp
-hLd
-hLd
-vuv
-pab
-iuv
+npL
+npL
+qYK
+npL
+cql
+cql
+niT
 nrO
 nrO
-iuv
-rOO
+nrO
+uvW
+npL
+nwX
+hEM
+uvW
+npL
+cql
+nnh
+uvW
 vuv
-jmN
-nRP
-hLd
-rBn
-jmN
-vuv
-hEp
-vgo
-vDl
-wdT
+npL
+pBJ
+mRd
+lpu
 vuv
 tur
 miI
@@ -71050,58 +72193,58 @@ uoO
 aoj
 aoj
 uoO
-eWV
+iXQ
 gyf
 gyf
 gyf
 gyf
 fLU
-fPj
+aYc
 eBg
-fXm
+fvM
 pAK
 pYd
-gmL
-gyZ
+ylT
+pwC
 jZT
-gBq
+wTK
 jZT
-gPe
+hqB
 tur
 nBk
 nBk
 tur
-uoO
-uoO
-uoO
-uoO
 uoO
 eLE
-jmN
-hLd
-jmN
+uoO
+uoO
+uoO
+uoO
+uoO
 vuv
-kZR
 vuv
 vuv
-hLd
-hLd
-hLd
+cyC
 vuv
-pbp
-qpG
-qRG
-qXr
-rjG
+vuv
+cql
+cql
+eOs
+dBI
+nrO
 iuv
+lLt
+uvW
+npL
+cql
+kqJ
+uvW
+vos
+cql
+nnh
+uvW
 vuv
-jmN
-hLd
-hLd
-hLd
-jmN
-vuv
-hEp
+npL
 vuv
 vuv
 vuv
@@ -71219,7 +72362,7 @@ xVz
 uoO
 xVz
 xVz
-oKH
+tqZ
 uoO
 uoO
 uoO
@@ -71307,18 +72450,18 @@ uoO
 uoO
 uoO
 uoO
-eWV
+iXQ
 gyf
 gyf
 gyf
 xSY
 fLU
-fPB
+kVN
 sgd
 tfw
 cfP
 pYd
-gmL
+ylT
 oeb
 tur
 oeb
@@ -71328,40 +72471,40 @@ tur
 nBk
 nBk
 tur
-uoO
-uoO
-uoO
-uoO
 uoO
 eLE
-jmN
-hEp
-jmN
+uoO
+uoO
+uoO
+uoO
+uoO
 vuv
-laT
-lCd
+nrO
+nrO
+aCt
+mmO
 vuv
-hEp
-hLd
-hLd
+npL
+cql
+gVN
+bql
+loK
+mVr
+iuv
+uvW
+tbc
+tbc
+aVg
+uvW
+mmx
+cql
+qbC
+uvW
 vuv
+npL
 vuv
-vuv
-vuv
-vuv
-vuv
-vuv
-siK
-jmN
-tII
-hAT
-uwt
-jmN
-vuv
-hEp
-vuv
-vDq
-uQO
+pqR
+nXJ
 vuv
 tur
 wWF
@@ -71476,7 +72619,7 @@ xVz
 uoO
 xVz
 xVz
-oKH
+tqZ
 uoO
 uoO
 uoO
@@ -71564,10 +72707,10 @@ uoO
 uoO
 uoO
 uoO
-eWV
+iXQ
 uaL
 eBg
-fBi
+bTy
 pkL
 fLU
 eBg
@@ -71586,39 +72729,39 @@ nBk
 nBk
 tur
 uoO
-uoO
-uoO
-uoO
-uoO
 eLE
-jmN
-hEp
-jmN
+eLE
+eLE
+eLE
+uoO
+uoO
 vuv
 nrO
 nrO
+nrO
+nrO
 vuv
-hEp
-hLd
-hLd
-oyo
-hLd
-hLd
-hLd
-oyo
-hLd
-hLd
-hLd
-jmN
-jmN
-jmN
-jmN
-jmN
+npL
+cql
 vuv
-hEp
-veq
-ven
-wfE
+vuv
+vuv
+vuv
+vuv
+uvW
+uvW
+uvW
+uvW
+uvW
+uvW
+uvW
+uvW
+uvW
+vuv
+npL
+iWh
+owU
+bPK
 vuv
 tur
 wWF
@@ -71728,12 +72871,12 @@ uoO
 uoO
 uoO
 uoO
-lMI
+dJQ
 xVz
 uoO
 xVz
 xVz
-oKH
+tqZ
 uoO
 uoO
 uoO
@@ -71821,14 +72964,14 @@ tur
 tur
 tur
 tur
-eWV
+iXQ
 hzg
 eBg
 eBg
 pkL
 fSV
 eBg
-fXa
+lgu
 lKk
 elU
 pYd
@@ -71846,21 +72989,18 @@ uoO
 uoO
 uoO
 uoO
-uoO
 eLE
-jmN
-hEp
-jmN
+uoO
+uoO
 vuv
-ldZ
-lED
+nrO
+nrO
+fDn
+dUu
 vuv
-hYr
-hLd
-kZR
-vuv
-vuv
-vuv
+npL
+cql
+cyC
 vuv
 vuv
 vuv
@@ -71872,7 +73012,10 @@ vuv
 vuv
 vuv
 vuv
-uXs
+vuv
+vuv
+vuv
+reu
 vuv
 vuv
 vuv
@@ -71990,11 +73133,11 @@ uoO
 uoO
 xVz
 xVz
-oKH
+tqZ
 uoO
 uoO
 xVz
-lMI
+dJQ
 uoO
 uoO
 uoO
@@ -72078,16 +73221,16 @@ tur
 ggH
 xJE
 tur
-eWV
+iXQ
 eBg
-fxN
+wnB
 xSY
-fMg
+byF
 fLU
 eBg
 elU
 eBg
-fTt
+gcC
 pYd
 rXA
 uoO
@@ -72103,37 +73246,37 @@ uoO
 uoO
 uoO
 uoO
-uoO
 eLE
-jmN
-hEp
-jmN
+uoO
+uoO
 vuv
 vuv
 vuv
 vuv
-hEp
-nnL
-hLd
-oyr
-pdh
-qpI
-hLd
-hLd
-oyo
-rTh
-siP
-thH
+vuv
+vuv
+npL
+asY
+cql
+omh
+tkQ
+tzm
+cql
+cql
+gLP
+gvB
+pKp
+dub
 iuv
-uoo
-uyz
-uDS
+bPV
+kae
+ucK
 vuv
-rxG
-rxG
-vKh
-rxG
-cqT
+emX
+emX
+wxP
+emX
+qWR
 tur
 miI
 weW
@@ -72247,11 +73390,11 @@ uoO
 uoO
 xVz
 xVz
-sNT
-xGO
-buV
+tzH
+tCt
+iDt
 xVz
-kjz
+qpG
 xVz
 uoO
 uoO
@@ -72335,18 +73478,18 @@ fvp
 fvp
 fvp
 tur
-eUp
+kcf
 pYd
 pYd
-fBU
+xxT
 jMT
 fLU
-fTt
+gcC
 eBg
-fPB
+kVN
 eBg
 pYd
-gni
+euP
 uoO
 uoO
 aoj
@@ -72360,37 +73503,37 @@ uoO
 uoO
 uoO
 uoO
-uoO
 eLE
-jmN
-jBv
-jmN
-kvK
-kvK
-kvK
-mbX
-hLd
-hLd
+uoO
+uoO
+uoO
+uoO
+tur
+tdP
+tdP
+gnR
+cql
+cql
 vuv
 vuv
-phP
-phP
-hLd
-phP
-phP
-mGg
+rxo
+rxo
+cql
+rxo
+rxo
+wSj
 vuv
 nrO
-tJD
+iYt
 vuv
 nrO
 iuv
 vuv
-lnr
-weW
-weW
-weW
-cqT
+xVz
+cSY
+cSY
+cSY
+qWR
 tur
 miI
 weW
@@ -72505,7 +73648,7 @@ uoO
 uoO
 xVz
 xVz
-oKH
+tqZ
 xVz
 xVz
 xVz
@@ -72594,11 +73737,11 @@ fvp
 tur
 uoO
 uoO
-eWV
+iXQ
 fLU
-fNr
+bGm
 fLU
-fTW
+rxd
 wiz
 eBg
 eBg
@@ -72617,37 +73760,37 @@ uoO
 uoO
 uoO
 uoO
-uoO
 eLE
+uoO
+uoO
+uoO
+uoO
+tur
 jmN
-hLd
 jmN
+niT
 jmN
-jmN
-jmN
-jmN
-jmN
-kvK
+tdP
 vuv
-ozp
-pip
-qpY
-qUx
-rbg
-rqc
-hEp
-ska
+qdE
+nuz
+uaR
+uUN
+eMW
+bVf
+npL
+tkG
 iuv
-tPY
+lnB
 vuv
 nrO
 iuv
 vuv
-cqT
-weW
-cqT
-weW
-cqT
+qWR
+cSY
+qWR
+cSY
+qWR
 tur
 wIM
 weW
@@ -72762,8 +73905,8 @@ uoO
 uoO
 xVz
 xVz
-sNT
-wum
+tzH
+tDW
 xVz
 xVz
 xVz
@@ -72797,8 +73940,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -72851,11 +73994,11 @@ tOY
 tur
 uoO
 uoO
-eWV
-fEB
+iXQ
+eYM
 lkt
 fLU
-fWr
+pQt
 dLP
 eBg
 elU
@@ -72874,39 +74017,39 @@ uoO
 uoO
 uoO
 uoO
-uoO
 eLE
-jmN
-hLd
-jOe
-nrO
-nrO
-nrO
-mgg
-jmN
-kvK
-vuv
-hEp
-pjj
-qsg
-qUx
-rbo
-rqF
-hEp
-smm
-tjd
-tTm
-vuv
-mgQ
-uFj
-vuv
-cqT
-weW
-cqT
-weW
-cqT
+uoO
+uoO
+uoO
+uoO
 tur
-wRj
+tFT
+nrO
+nrO
+jmN
+tdP
+vuv
+npL
+rZq
+vCT
+uUN
+cEO
+wTz
+npL
+pHQ
+lhw
+xKg
+vuv
+gGr
+rjT
+vuv
+qWR
+cSY
+qWR
+cSY
+qWR
+tur
+ngc
 weW
 tur
 uoO
@@ -73025,7 +74168,7 @@ xVz
 xVz
 xVz
 xVz
-buV
+iDt
 xVz
 xVz
 xVz
@@ -73054,8 +74197,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -73108,13 +74251,13 @@ tur
 tur
 uoO
 uoO
-eWV
-fKi
+iXQ
+wTk
 fLU
 fLU
 fLU
 fLU
-fZO
+aNr
 lKk
 pYd
 rXA
@@ -73131,37 +74274,37 @@ uoO
 uoO
 uoO
 uoO
-uoO
 eLE
-jmN
-hLd
-jmN
-kvL
+eLE
+eLE
+eLE
+uoO
+tur
 nrO
-lIw
-mgQ
+aLI
+gGr
 jmN
-kvK
+tdP
 vuv
 vuv
-pkH
-qvI
-hEp
-qvI
-rrm
+eqb
+qSL
+npL
+qSL
+quQ
 vuv
 vuv
-tjA
+bOb
 vuv
 vuv
 vuv
 vuv
 vuv
-cqT
-vgS
-cqT
-wfG
-cqT
+qWR
+cqp
+qWR
+bqV
+qWR
 tur
 wIM
 weW
@@ -73279,10 +74422,10 @@ xVz
 xVz
 xVz
 xVz
-oTR
+tEu
 xVz
 xVz
-lMI
+dJQ
 xVz
 xVz
 xVz
@@ -73311,8 +74454,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -73365,13 +74508,13 @@ uoO
 uoO
 uoO
 uoO
-eWV
-fKq
+iXQ
+lNv
 tgC
 tgC
-fWY
+mpt
 fLU
-gaf
+qSt
 sMr
 pYd
 rXA
@@ -73389,10 +74532,10 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
 eLE
-jmN
-jFx
-jmN
+uoO
 tur
 tur
 tur
@@ -73400,13 +74543,13 @@ tur
 tur
 tur
 tur
-ozN
-plF
-qwP
-qwP
-qwP
-qwP
-ozN
+llb
+wkW
+tvj
+tvj
+tvj
+tvj
+llb
 tur
 tur
 tur
@@ -73532,13 +74675,13 @@ uoO
 uoO
 uoO
 uoO
-buV
+iDt
 xVz
 xVz
 xVz
 qjT
 xVz
-bRX
+qOc
 uoO
 xVz
 xVz
@@ -73622,15 +74765,15 @@ uoO
 uoO
 uoO
 uoO
-eUp
+kcf
 pYd
 pYd
 pYd
-fKi
+wTk
 pYd
 pYd
 pYd
-gbH
+tvI
 rXA
 uoO
 uoO
@@ -73647,7 +74790,9 @@ uoO
 uoO
 uoO
 uoO
-tur
+uoO
+uoO
+uoO
 weW
 weW
 weW
@@ -73675,9 +74820,7 @@ weW
 weW
 weW
 weW
-weW
-weW
-weW
+nuA
 weW
 tur
 uoO
@@ -74082,8 +75225,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -74306,7 +75449,7 @@ xVz
 xVz
 xVz
 xVz
-buV
+iDt
 uoO
 uoO
 uoO
@@ -74339,8 +75482,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -74446,7 +75589,7 @@ weW
 weW
 weW
 weW
-wpJ
+bVn
 nuA
 nuA
 hsR
@@ -74596,8 +75739,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -74854,7 +75997,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -75111,7 +76254,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -75368,7 +76511,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -75625,7 +76768,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -76363,7 +77506,7 @@ xVz
 xVz
 xVz
 xVz
-lMI
+dJQ
 uoO
 uoO
 uoO
@@ -76616,7 +77759,7 @@ uoO
 uoO
 uoO
 uoO
-lMI
+dJQ
 xVz
 xVz
 xVz
@@ -77022,7 +78165,7 @@ cvb
 cvb
 coX
 cIF
-qUn
+xnw
 xkh
 iIu
 tnp
@@ -77252,11 +78395,11 @@ uoO
 aoj
 aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+pGc
+dFA
+rjz
+pGc
+rjz
 uoO
 uoO
 uoO
@@ -77509,11 +78652,11 @@ aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+qwR
+hQE
+dtu
+hQE
+qwR
 uoO
 uoO
 uoO
@@ -77680,7 +78823,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -77766,11 +78909,11 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+hQE
+iWF
+sop
+paI
+hQE
 uoO
 uoO
 uoO
@@ -77785,7 +78928,7 @@ jSu
 wrJ
 eGn
 wrJ
-ndr
+dTm
 cvb
 cvb
 cvb
@@ -78023,11 +79166,11 @@ uoO
 uoO
 uoO
 uoO
-uoO
-aoj
-uoO
-uoO
-uoO
+hQE
+gcp
+sop
+sop
+hQE
 uoO
 uoO
 uoO
@@ -78194,8 +79337,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -78280,11 +79423,11 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
+hQE
+sop
+sop
+sop
+hQE
 uoO
 uoO
 uoO
@@ -78537,11 +79680,11 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
+hQE
+dMs
+fFm
+ioR
+hQE
 uoO
 uoO
 uoO
@@ -78708,8 +79851,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -78794,11 +79937,11 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+hQE
+hQE
+hQE
+hQE
+hQE
 uoO
 uoO
 uoO
@@ -78818,7 +79961,7 @@ cvb
 cvb
 cvb
 cvb
-ndr
+dTm
 wrJ
 kkq
 cAf
@@ -79456,7 +80599,7 @@ uoO
 xVz
 qjT
 qoi
-lMI
+dJQ
 xVz
 uoO
 uoO
@@ -79568,7 +80711,7 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -79825,7 +80968,7 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -80082,7 +81225,7 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -80097,7 +81240,7 @@ tnp
 tnp
 tnp
 tnp
-ndr
+dTm
 tnp
 tnp
 cvb
@@ -80228,7 +81371,7 @@ uoO
 aoj
 qDR
 qDR
-egP
+tTm
 uoO
 uoO
 uoO
@@ -80344,8 +81487,8 @@ uoO
 uoO
 uoO
 uoO
-sdN
-hba
+eWp
+ixu
 deT
 cvb
 syq
@@ -80483,8 +81626,8 @@ uoO
 uoO
 uoO
 aoj
-ahe
-egP
+tJD
+tTm
 xVz
 uoO
 uoO
@@ -80601,9 +81744,9 @@ uoO
 uoO
 uoO
 uoO
-eLF
+giW
 tnp
-hba
+ixu
 cvb
 cvb
 cvb
@@ -81020,7 +82163,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -81277,7 +82420,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -81534,7 +82677,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -81791,7 +82934,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -82821,7 +83964,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -83077,8 +84220,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -83309,7 +84452,7 @@ xVz
 xVz
 xVz
 fou
-hOj
+tII
 byA
 vZr
 cSY
@@ -83334,8 +84477,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -83590,6 +84733,22 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -83604,25 +84763,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -83664,9 +84807,9 @@ aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -83824,7 +84967,7 @@ xVz
 xVz
 cSY
 cSY
-nmo
+tPY
 mTj
 cSY
 cSY
@@ -83847,6 +84990,7 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
@@ -83859,6 +85003,13 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -83869,15 +85020,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -83921,9 +85064,9 @@ aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -84104,6 +85247,7 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
@@ -84113,17 +85257,16 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -84178,9 +85321,9 @@ aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -84366,20 +85509,20 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -84435,6 +85578,7 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
@@ -84443,9 +85587,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -84622,6 +85765,8 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -84629,27 +85774,25 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -84692,6 +85835,7 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
@@ -84700,9 +85844,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -84878,6 +86021,8 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -84900,13 +86045,11 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -84949,17 +86092,17 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85134,6 +86277,8 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85161,10 +86306,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85212,11 +86355,11 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85378,6 +86521,30 @@ xoU
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -85396,32 +86563,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85469,11 +86612,11 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85637,6 +86780,30 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85653,32 +86820,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85725,12 +86868,12 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85897,6 +87040,8 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85907,6 +87052,15 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85916,26 +87070,15 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85974,6 +87117,7 @@ aoj
 aoj
 aoj
 aoj
+aoj
 uoO
 uoO
 uoO
@@ -85981,13 +87125,12 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -86155,45 +87298,45 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -86231,20 +87374,20 @@ aoj
 aoj
 aoj
 aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -86411,37 +87554,37 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -86488,6 +87631,8 @@ uoO
 aoj
 aoj
 aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -86496,12 +87641,10 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -86664,6 +87807,18 @@ uoO
 uoO
 uoO
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -86682,22 +87837,10 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -86745,6 +87888,8 @@ uoO
 uoO
 aoj
 aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -86753,12 +87898,10 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -86921,6 +88064,17 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -86941,20 +88095,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -87002,9 +88145,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -87193,25 +88336,25 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -87450,6 +88593,19 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -87459,20 +88615,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -87689,6 +88832,7 @@ xoU
 uoO
 uoO
 aoj
+aoj
 uoO
 uoO
 uoO
@@ -87715,6 +88859,12 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -87722,18 +88872,11 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -87946,6 +89089,40 @@ xoU
 uoO
 uoO
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -87956,42 +89133,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -88209,6 +89352,15 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -88219,6 +89371,16 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -88228,27 +89390,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -88466,6 +89609,15 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -88476,36 +89628,27 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -88693,7 +89836,7 @@ dVj
 xjE
 xhA
 fwX
-dSx
+wSy
 hac
 xjE
 sUs
@@ -88723,6 +89866,16 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -88732,6 +89885,15 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -88739,34 +89901,15 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 aoj
 aoj
 aoj
@@ -88984,6 +90127,29 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -88996,34 +90162,11 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 aoj
 aoj
 aoj
@@ -89241,6 +90384,8 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -89274,10 +90419,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -89495,6 +90638,21 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -89510,22 +90668,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -89751,6 +90894,12 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -89776,13 +90925,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -90007,6 +91150,12 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -90027,6 +91176,8 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -90038,15 +91189,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -90264,6 +91407,15 @@ uoO
 uoO
 uoO
 aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -90275,6 +91427,14 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -90286,24 +91446,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -90458,7 +91601,7 @@ tsm
 ejQ
 tsm
 xxn
-vUs
+xxn
 xxn
 gEZ
 xSi
@@ -90521,6 +91664,17 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -90530,30 +91684,19 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -90784,33 +91927,33 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -91043,20 +92186,20 @@ uoO
 uoO
 uoO
 aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -91308,6 +92451,8 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -91327,13 +92472,11 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -91563,6 +92706,10 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -91584,13 +92731,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -91819,6 +92962,9 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -91843,10 +92989,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -2825,7 +2825,7 @@
 /area/f13/tunnel)
 "cki" = (
 /obj/effect/decal/riverbank,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/tunnel)
 "ckm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6942,6 +6942,13 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"fta" = (
+/obj/machinery/light/fo13colored/Pink{
+	dir = 1;
+	name = "light tube"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "ftt" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/f13{
@@ -6955,7 +6962,7 @@
 "ftv" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
-	id = "clinicoutsideladder"
+	id = "church"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
@@ -7845,6 +7852,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
+"gcJ" = (
+/obj/structure/destructible/tribal_torch/lit,
+/obj/machinery/light/fo13colored/Pink{
+	dir = 1;
+	name = "light tube"
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/tunnel)
 "gcN" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -10996,6 +11011,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "iID" = (
@@ -11158,6 +11174,9 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"iQg" = (
+/turf/open/indestructible/ground/outside/river,
+/area/f13/tunnel)
 "iQt" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -16124,6 +16143,10 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"nsn" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "nsw" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13{
@@ -16389,6 +16412,7 @@
 	dir = 1;
 	name = "light tube"
 	},
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
 "nBL" = (
@@ -16589,7 +16613,7 @@
 /area/f13/sewer)
 "nKj" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/tunnel)
 "nKk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19447,7 +19471,7 @@
 /area/f13/brotherhood/offices2nd)
 "qdm" = (
 /obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/tunnel)
 "qdE" = (
 /obj/structure/billboard/cola/pristine,
@@ -24639,7 +24663,7 @@
 /area/f13/ncr)
 "uEs" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/tunnel)
 "uEu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25932,7 +25956,7 @@
 /area/f13/caves)
 "vOu" = (
 /obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/tunnel)
 "vOA" = (
 /obj/structure/closet/secure_closet/personal,
@@ -27994,7 +28018,7 @@
 	pixel_x = -33;
 	pixel_y = -3
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/river,
 /area/f13/tunnel)
 "yaO" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -64570,7 +64594,7 @@ iuv
 iuv
 wbO
 iuv
-nrO
+nsn
 nrO
 iuv
 iuv
@@ -66101,7 +66125,7 @@ czc
 cGm
 nrO
 iuv
-nrO
+nsn
 uoO
 uoO
 vuv
@@ -66618,7 +66642,7 @@ iuv
 cGm
 nrO
 iuv
-nrO
+nsn
 iuv
 nrO
 xcp
@@ -66869,14 +66893,14 @@ jmN
 tNA
 uYc
 aTR
-uoO
+uXs
 nBo
 kfy
 nrO
 nrO
 nrO
 cki
-weW
+iQg
 nrO
 lZH
 nrO
@@ -67132,9 +67156,9 @@ nhV
 kfy
 nrO
 cki
-weW
+iQg
 nKj
-weW
+iQg
 lZH
 nrO
 nrO
@@ -67390,9 +67414,9 @@ baF
 nrO
 cki
 vOu
-weW
+iQg
 qdm
-weW
+iQg
 lZH
 nrO
 iuv
@@ -67646,10 +67670,10 @@ gxc
 dUq
 nrO
 cki
-weW
+iQg
 yaH
 uEs
-weW
+iQg
 lZH
 nrO
 nFc
@@ -67903,10 +67927,10 @@ gxc
 dUq
 nrO
 cki
-weW
-weW
-weW
-weW
+iQg
+iQg
+iQg
+iQg
 lZH
 iuv
 iuv
@@ -68151,7 +68175,7 @@ nrO
 iuv
 oYk
 jmN
-nrO
+fta
 vuv
 xIy
 vuv
@@ -68161,13 +68185,13 @@ baF
 nrO
 cki
 nKj
-weW
+iQg
 vOu
-weW
+iQg
 lZH
 iuv
 nrO
-nrO
+nsn
 vuv
 vuv
 vuv
@@ -68418,8 +68442,8 @@ kfy
 nrO
 cki
 qdm
-weW
-weW
+iQg
+iQg
 lZH
 nrO
 gNQ
@@ -68669,13 +68693,13 @@ nrO
 vuv
 vuv
 vuv
-kfy
+gcJ
 kfy
 nrO
 nrO
 ajt
 cki
-weW
+iQg
 nrO
 lZH
 nrO
@@ -68931,7 +68955,7 @@ nrO
 nrO
 iuv
 nrO
-nrO
+nsn
 nrO
 nrO
 nrO
@@ -69194,7 +69218,7 @@ iuv
 iuv
 iuv
 mia
-nrO
+nsn
 iuv
 bfY
 iuv
@@ -69699,7 +69723,7 @@ jmN
 cql
 nrO
 iuv
-nrO
+nsn
 uvW
 uvW
 uvW

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -9,6 +9,11 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"aaM" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/ash,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "abg" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/uranium{
@@ -18,33 +23,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "abi" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/ore/blackpowder/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "abY" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/f13{
@@ -63,45 +45,58 @@
 	},
 /area/f13/building)
 "acs" = (
-/obj/structure/decoration/hatch,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/tunnel)
+/obj/structure/closet/crate/miningcar,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "acv" = (
 /obj/structure/sign/poster/prewar/poster65,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
-"acT" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
+"acJ" = (
+/obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"adx" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowbottom"
+/area/f13/bunker)
+"acT" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old";
+	tag = "icon-gib5-old"
 	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"acY" = (
+/obj/structure/closet/crate/large,
+/obj/item/storage/box/stockparts/basic,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "redrustyfull"
 	},
-/area/f13/followers)
+/area/f13/bunker)
+"adc" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
+"adf" = (
+/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/destructible/tribal_torch/lit,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"adx" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "adO" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
 "adY" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/tunnel)
+/obj/structure/decoration/warning,
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "aej" = (
 /obj/structure/sign/poster/prewar/poster61,
 /turf/closed/wall/r_wall,
@@ -115,11 +110,10 @@
 /turf/open/water,
 /area/f13/tunnel)
 "aeS" = (
-/obj/structure/frame/machine,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aeZ" = (
 /obj/structure/bed/mattress,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -132,9 +126,10 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "afj" = (
-/obj/structure/campfire,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/warning,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "afP" = (
 /obj/machinery/computer/terminal{
 	dir = 4;
@@ -143,6 +138,11 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"afT" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "agm" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
@@ -153,22 +153,39 @@
 	},
 /area/f13/tunnel)
 "ahe" = (
-/obj/machinery/vending/medical{
-	req_access = null
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/warning{
+	pixel_x = -3;
+	pixel_y = -5
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ahB" = (
-/obj/structure/dresser,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/tunnel)
+"ahI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/human/corpse/raider,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "aiq" = (
 /obj/structure/sign/poster/prewar/poster60,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
+"aiI" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ajc" = (
 /obj/structure/curtain{
 	color = "#5c131b"
@@ -177,27 +194,34 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "ajk" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/tunnel)
 "ajl" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/item/fusion_fuel,
+/obj/item/fusion_fuel,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
+/area/f13/bunker)
+"ajn" = (
+/obj/machinery/gibber,
+/turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "ajJ" = (
 /obj/structure/sign/poster/prewar/poster71,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "ajM" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	pixel_x = -6
+/obj/structure/toilet,
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
+/area/f13/tunnel)
 "ajQ" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
@@ -236,10 +260,20 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"akZ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ala" = (
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/tunnel)
 "alw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mirror{
@@ -255,13 +289,40 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "alO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/tunnel)
 "amf" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
+"any" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"anB" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/tunnel)
+"anL" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "aoj" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
@@ -271,6 +332,18 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"aoD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"aqg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "aqn" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/f13/vault,
@@ -300,14 +373,16 @@
 	},
 /area/f13/brotherhood/leisure)
 "ask" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 8;
-	light_color = "#800080";
-	name = "light fixture"
+/obj/machinery/shower{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/obj/structure/curtain,
+/obj/item/reagent_containers/syringe,
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/tunnel)
 "atb" = (
 /obj/structure/table,
@@ -316,13 +391,20 @@
 	},
 /area/f13/tcoms)
 "ato" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
+/obj/structure/toilet{
+	dir = 1
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/tunnel)
+"aty" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/tunnel)
 "atO" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -363,10 +445,24 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/tunnel)
-"awR" = (
-/obj/structure/bed/mattress,
+"avY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/weightlifter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"awR" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
+"axC" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ayH" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -385,7 +481,14 @@
 	},
 /area/f13/clinic)
 "azr" = (
-/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/plasteel/f13,
+/area/f13/tunnel)
+"azs" = (
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"azz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
@@ -402,6 +505,13 @@
 "aBb" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/tunnel)
+"aBk" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "aBq" = (
 /obj/structure/toilet{
 	pixel_y = 10
@@ -421,8 +531,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "aCf" = (
-/turf/closed/wall/f13/supermart,
-/area/f13/caves)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13,
+/area/f13/tunnel)
 "aCo" = (
 /obj/structure/foamedmetal,
 /turf/open/floor/f13{
@@ -430,15 +543,12 @@
 	},
 /area/f13/bunker)
 "aCq" = (
-/obj/structure/table/wood/poker,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/stage_br,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "aCu" = (
-/obj/structure/ore_box,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/reagent_containers/syringe/piercing,
+/turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "aCE" = (
 /obj/structure/simple_door/house,
@@ -451,35 +561,35 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "aGv" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/showcase/horrific_experiment{
+	icon_state = "pod_0"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
+"aGz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "aGH" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/showcase/horrific_experiment,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
 "aGO" = (
-/obj/effect/landmark/start/f13/dendoc,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/syringes,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
 "aHj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -507,6 +617,13 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
+"aIH" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "aIU" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/f13/combat,
@@ -515,9 +632,16 @@
 /obj/item/clothing/suit/armor/f13/combat/mk2,
 /obj/item/clothing/head/helmet/f13/combat/mk2,
 /obj/item/clothing/mask/gas/syndicate,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"aJc" = (
+/obj/machinery/button/door{
+	id = "soup";
+	name = "Door Control"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/caves)
 "aJR" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "bosarmoryacc";
@@ -529,6 +653,24 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"aJX" = (
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/cut/random,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"aKV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"aLk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "aLn" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /turf/open/floor/plating/tunnel,
@@ -538,19 +680,24 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "aLy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/structure/table/reinforced,
+/obj/item/storage/box/beakers,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
 "aLA" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "aMg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/f13/wood,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
 "aND" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -558,9 +705,34 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"aNG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "aNI" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/structure/showcase/horrific_experiment,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
+"aNQ" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"aOz" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "aQg" = (
 /obj/machinery/button/door{
 	id = "bosdorm6";
@@ -615,6 +787,14 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/brotherhood/offices1st)
+"aTr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/tunnel)
 "aUo" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13{
@@ -639,6 +819,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
+"aWs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aWx" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -646,8 +832,9 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "aWF" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/tunnel)
 "aWJ" = (
 /obj/machinery/telecomms/receiver/preset_right,
@@ -662,6 +849,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"aYg" = (
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "aYI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -833,6 +1024,24 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"aZo" = (
+/obj/structure/decoration/smokeold,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"baE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"baF" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw,
+/turf/open/water,
+/area/f13/caves)
+"baX" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "bbq" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -909,23 +1118,13 @@
 	},
 /area/f13/tunnel)
 "bcv" = (
-/obj/structure/decoration/vent{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
+/area/f13/tunnel)
 "bcw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed,
@@ -977,6 +1176,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"bdL" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "bdP" = (
 /obj/effect/landmark/start/f13/seniorpaladin,
 /obj/effect/decal/cleanable/dirt,
@@ -987,6 +1193,13 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"bek" = (
+/obj/effect/decal/remains/human,
+/obj/effect/gibspawner/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "ber" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/cigarette,
@@ -995,12 +1208,19 @@
 	},
 /area/f13/brotherhood/leisure)
 "beY" = (
-/obj/machinery/light/small{
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/ore_box,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/item/storage/box/stockparts/deluxe,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "bfh" = (
 /obj/structure/bed/pod,
@@ -1029,12 +1249,16 @@
 	},
 /area/f13/tunnel)
 "bgu" = (
-/obj/structure/guncase,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/ballistic/shotgun/trench,
-/obj/item/gun/ballistic/shotgun/trench,
-/obj/item/gun/ballistic/shotgun/trench,
-/turf/open/floor/f13/wood,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "bgL" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -1043,8 +1267,13 @@
 	},
 /area/f13/enclave)
 "bgV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
+	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
+	name = "strange meat"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -1060,13 +1289,17 @@
 	},
 /area/f13/brotherhood/medical)
 "bis" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/area/f13/followers)
+/obj/structure/closet/crate/secure/loot,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/tunnel)
 "biy" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/mouse/white{
@@ -1091,22 +1324,33 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "bjr" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/plastic/five,
-/obj/item/stack/sheet/plastic/five,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "bjw" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/medsprays,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/area/f13/followers)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/tunnel)
 "bjz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -1115,16 +1359,24 @@
 	},
 /area/f13/brotherhood/leisure)
 "bjF" = (
-/obj/structure/barricade/bars{
-	layer = 5
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/tunnel)
 "bkU" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"blc" = (
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "ble" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "bosdorm9";
@@ -1135,6 +1387,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"blF" = (
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "blH" = (
 /obj/structure/table,
 /obj/item/multitool,
@@ -1143,14 +1401,29 @@
 	},
 /area/f13/tcoms)
 "bmc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/rock,
-/area/f13/caves)
-"bmj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
+"bmj" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
+"bmv" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "bmx" = (
 /obj/docking_port/stationary/bosaway,
 /turf/closed/wall/f13/tunnel,
@@ -1187,23 +1460,6 @@
 /obj/structure/simple_door/bunker,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"boc" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "124"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/followers)
-"bof" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
 "bor" = (
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white/bos,
@@ -1250,12 +1506,12 @@
 	},
 /area/f13/brotherhood/operations)
 "bqs" = (
-/obj/structure/guncase,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/f13/wood,
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
 "bqO" = (
 /obj/machinery/light/small{
@@ -1305,12 +1561,12 @@
 	},
 /area/f13/tunnel)
 "bsw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/obj/item/fermichem/pHmeter,
-/obj/item/storage/bag/chemistry,
-/obj/item/fermichem/pHmeter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
 "bsF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1330,6 +1586,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"bsQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "bta" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser/pistol,
@@ -1347,6 +1609,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"btu" = (
+/obj/structure/simple_door/fakeglass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "btB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -1355,13 +1622,23 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"bud" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "clinicladder"
-	},
+"btV" = (
+/obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/f13/bunker)
+"bud" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
 "bum" = (
 /obj/structure/rack,
@@ -1388,12 +1665,25 @@
 	},
 /area/f13/tunnel)
 "buJ" = (
-/obj/machinery/shower{
+/obj/machinery/power/rtg,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/window/reinforced{
+	dir = 1;
+	icon_state = "fwindow"
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	icon_state = "fwindow"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "buN" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -1401,8 +1691,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "buV" = (
-/obj/item/pickaxe/mini,
-/turf/closed/mineral/random/low_chance,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "buZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1433,6 +1723,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"bvH" = (
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
 "bxz" = (
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -1451,6 +1747,18 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
+"bxJ" = (
+/obj/item/gun/ballistic/automatic/tribalbow{
+	desc = "A simple wooden bow with small pieces of turquiose. This one looks particularly blood-covered. Who the fuck brings a /BOW/ to a /BUNKER/"
+	},
+/obj/effect/mob_spawn/human/corpse,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"bxQ" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "bxU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1463,6 +1771,13 @@
 /obj/structure/window/reinforced/tinted,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
+"byb" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "byA" = (
 /obj/structure/flora/grass/wasteland,
 /obj/structure/flora/rock/jungle,
@@ -1470,7 +1785,7 @@
 	name = "vines"
 	},
 /obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/water,
 /area/f13/caves)
 "bzt" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -1495,15 +1810,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"bAz" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/followers)
 "bAD" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
@@ -1515,26 +1821,25 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bBf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	desc = "A lighting fixture.";
-	dir = 1;
-	light_color = "#008000";
-	name = "light tube"
+/mob/living/simple_animal/hostile/handy/robobrain{
+	name = "Conscripted Engineer"
 	},
-/obj/structure/girder/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
 "bBZ" = (
-/obj/item/storage/trash_stack{
-	layer = 2
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
 	},
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 1;
-	name = "light fixture"
+/obj/machinery/camera/autoname{
+	dir = 9
 	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "bCf" = (
 /obj/structure/bed/pod,
 /obj/machinery/button/door{
@@ -1588,15 +1893,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
-"bEp" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/followers)
 "bEu" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -1605,8 +1901,16 @@
 	},
 /area/f13/clinic)
 "bEw" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/f13/wood,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/inducer,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "bEz" = (
 /obj/structure/table/reinforced,
@@ -1634,16 +1938,25 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"bGf" = (
-/obj/machinery/light/small{
+"bFl" = (
+/obj/machinery/light/broken{
 	dir = 1
 	},
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibtorso"
-	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"bFU" = (
+/obj/structure/table,
+/obj/item/fusion_fuel,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "bluerustyfull"
+	},
+/area/f13/bunker)
+"bGf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "bGi" = (
@@ -1676,15 +1989,32 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"bHz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/window/eastleft,
+/obj/item/stack/sheet/plasteel/twenty,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "bHA" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"bHO" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "bIh" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/water,
+/obj/machinery/door/window/westright,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/tunnel)
 "bIS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1713,10 +2043,13 @@
 	},
 /area/f13/clinic)
 "bJG" = (
-/obj/item/paper_bin/bundlenatural,
-/obj/structure/rack,
-/obj/item/paper_bin/bundlenatural,
-/turf/open/floor/plasteel/floorgrime,
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 35
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
 "bKi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1761,6 +2094,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"bMb" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
 "bMe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -1775,11 +2112,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/leisure)
 "bMq" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "bMy" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -1850,6 +2186,11 @@
 /obj/effect/landmark/start/f13/initiate,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
+"bOv" = (
+/obj/effect/decal/remains/robot,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "bPh" = (
 /obj/structure/simple_door/metal/dirtystore,
 /obj/structure/decoration/rag{
@@ -1872,10 +2213,18 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"bRN" = (
-/obj/structure/curtain{
-	open = 0
+"bRs" = (
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/tunnel)
+"bRN" = (
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -1885,19 +2234,30 @@
 /obj/structure/decoration/vent,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
+"bRX" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bSs" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
 "bSL" = (
-/obj/structure/table,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/machinery/light/small/broken{
-	dir = 4
+/obj/machinery/camera/autoname{
+	dir = 9
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"bSS" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
+"bSU" = (
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "bTu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced/tinted{
@@ -1942,6 +2302,11 @@
 /obj/structure/wreck/trash/halftire,
 /turf/open/water,
 /area/f13/tunnel)
+"bUK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "bUX" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -1970,24 +2335,32 @@
 /obj/structure/sign/poster/prewar/poster91,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
-"bWk" = (
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "topcellghoul"
+"bWa" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"bWk" = (
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/obj/structure/showcase/horrific_experiment,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
 "bWl" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "clinicoutsideladder"
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light/small{
-	dir = 8
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"bWq" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "bWQ" = (
 /obj/effect/decal/cleanable/dirt{
@@ -1995,12 +2368,6 @@
 	},
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
-"bWY" = (
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/followers)
 "bYK" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -2014,6 +2381,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"caq" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "caQ" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt{
@@ -2021,6 +2392,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"caS" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/indestructible/fakedoor{
+	desc = "An indestructible door. Hm.";
+	name = "Strong Door"
+	},
+/area/f13/bunker)
 "cbs" = (
 /obj/structure/fluff/railing{
 	dir = 9
@@ -2063,6 +2441,22 @@
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"ccU" = (
+/obj/machinery/workbench/advanced,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/item/book/granter/crafting_recipe/gunsmith_two,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/tunnel)
+"cda" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier9,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "cej" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -2106,15 +2500,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "cfL" = (
-/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "cfP" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "cfU" = (
@@ -2124,6 +2519,17 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/sewer)
+"cgm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"chC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "chW" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/f13{
@@ -2138,9 +2544,12 @@
 	},
 /area/f13/clinic)
 "cid" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13/wood,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/tunnel)
 "ciF" = (
 /obj/structure/table,
@@ -2148,6 +2557,18 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
+"ciN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"ciS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "cje" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -2157,6 +2578,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/tunnel)
+"cjw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "okay";
+	name = "Door Control"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "ckm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -2175,18 +2605,21 @@
 	},
 /area/f13/brotherhood/offices1st)
 "ckx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/closet/crate/miningcar,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ckZ" = (
-/obj/structure/table/snooker{
-	dir = 5
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/tunnel)
 "clz" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier9,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
@@ -2203,6 +2636,15 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"clP" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "clT" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -2222,6 +2664,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"cnA" = (
+/obj/structure/decoration/shock,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "cnF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -2235,6 +2681,19 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
+"cnS" = (
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"coe" = (
+/obj/machinery/door/airlock/hatch{
+	locked = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/tunnel)
 "cof" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood{
@@ -2308,11 +2767,30 @@
 	},
 /area/f13/brotherhood/operations)
 "crg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/f13/wood,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
+"crt" = (
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
+"crx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "crL" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2346,7 +2824,8 @@
 	},
 /area/f13/tunnel)
 "ctu" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -2374,6 +2853,12 @@
 /obj/structure/decoration/vent,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
+"cuz" = (
+/obj/item/computer_hardware/recharger/APC,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "cuT" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/f13{
@@ -2408,13 +2893,15 @@
 /obj/structure/wreck/car/bike,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"cxu" = (
-/obj/structure/reagent_dispensers/fueltank,
+"cxy" = (
 /obj/machinery/light/small{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plating/f13,
-/area/f13/followers)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "cxR" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigars/havana,
@@ -2432,6 +2919,12 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"cxU" = (
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "cyA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -2441,15 +2934,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/brotherhood/reactor)
-"cyG" = (
-/obj/structure/table/glass,
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/book/granter/trait/midsurgery,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "cyO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced/tinted{
@@ -2460,6 +2944,21 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
+"cyT" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/geiger_counter,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "czl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/start/f13/usprivate,
@@ -2474,29 +2973,31 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/leisure)
-"czF" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+"cAb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/area/f13/followers)
+/obj/machinery/door/window/eastleft,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "cAf" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/sewer)
+"cAq" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "cAB" = (
 /obj/structure/sign/poster/prewar/poster90,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
-"cBH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "cBS" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/dark,
@@ -2626,12 +3127,20 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "cFR" = (
-/obj/structure/handrail/g_central{
-	pixel_y = -16
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/area/f13/tunnel)
+"cFS" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "cGj" = (
 /obj/item/electronics/apc,
 /obj/item/stack/cable_coil,
@@ -2641,6 +3150,16 @@
 /obj/structure/sign/poster/prewar/poster93,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
+"cGy" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"cGV" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "cHw" = (
 /obj/structure/closet/crate/secure/weapon{
 	anchored = 1
@@ -2676,6 +3195,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"cIa" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "cIi" = (
 /obj/structure/chair/wood/worn{
 	dir = 8
@@ -2683,11 +3208,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "cIA" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Private Bar"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "cIF" = (
 /turf/open/floor/f13/wood{
@@ -2695,10 +3225,11 @@
 	},
 /area/f13/sewer)
 "cIG" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/book/granter/trait/chemistry,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "cIS" = (
 /obj/structure/dresser,
@@ -2723,6 +3254,15 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"cJZ" = (
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "cKI" = (
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt{
@@ -2730,6 +3270,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"cKK" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "cLJ" = (
 /obj/structure/closet/crate/secure/weapon{
 	anchored = 1
@@ -2768,6 +3314,11 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"cLR" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/ranged/legendary,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "cLS" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -2786,25 +3337,40 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cNz" = (
-/obj/machinery/workbench,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
-/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
-/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/mob/living/simple_animal/hostile/abomination{
+	health = 400;
+	name = "Escaped abomination"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
-"cOn" = (
+"cOb" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
+"cOk" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"cOn" = (
+/obj/structure/closet/l3closet/virology,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
+"cOo" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "cPA" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
@@ -2818,9 +3384,19 @@
 	},
 /area/f13/tunnel)
 "cQf" = (
-/obj/machinery/workbench,
-/turf/open/floor/f13/wood,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
+"cQn" = (
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "cQR" = (
 /obj/item/ammo_casing/spent{
 	pixel_x = -12;
@@ -2848,14 +3424,6 @@
 /obj/item/clothing/under/f13/rag,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
-	},
-/area/f13/tunnel)
-"cRm" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gibtorso"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
 "cRX" = (
@@ -2917,6 +3485,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"cSU" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "cSY" = (
 /turf/open/water,
 /area/f13/caves)
@@ -2956,21 +3528,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"cTz" = (
-/obj/structure/barricade/wooden,
-/obj/item/pickaxe{
-	anchored = 1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"cUk" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/followers)
 "cUt" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -3000,17 +3557,22 @@
 	},
 /area/f13/brotherhood/operations)
 "cWd" = (
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/indestructible/ground/inside/subway,
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
 "cWn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	pixel_x = -6
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "cXl" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -3054,6 +3616,17 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"daW" = (
+/obj/machinery/door/airlock/grunge,
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"dbg" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
 "dbZ" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -3082,13 +3655,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "dcV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/tunnel)
 "ddQ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
@@ -3123,17 +3695,17 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
-"dfO" = (
-/obj/item/storage/bag/ore,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "dgy" = (
-/obj/machinery/button/door{
-	id = "prospector2open";
-	name = "gate shutters";
-	pixel_x = -32
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/water,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
 "dgL" = (
 /obj/structure/table/wood/settler,
@@ -3190,6 +3762,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/reactor)
+"djM" = (
+/obj/structure/decoration/warning,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "djR" = (
 /obj/structure/toilet{
 	dir = 4
@@ -3212,6 +3788,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"dkZ" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/tunnel)
 "dlw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker{
@@ -3233,16 +3816,49 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"dmy" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old";
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "dmH" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/tunnel)
+"dns" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/wreck/trash/one_barrel,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "dnu" = (
-/obj/structure/simple_door/metal/barred,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/item/clothing/suit/radiation,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/tunnel)
 "dnM" = (
 /obj/machinery/power/smes/engineering,
 /obj/effect/decal/cleanable/dirt,
@@ -3258,26 +3874,47 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "doL" = (
-/obj/structure/dresser,
-/turf/open/floor/f13/wood,
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/tunnel)
-"dpt" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 1
+"doZ" = (
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/area/f13/followers)
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 35
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/tunnel)
+"dpx" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "dpz" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
-"dpV" = (
-/turf/open/floor/plating/f13,
-/area/f13/followers)
+"dpD" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
 "dqp" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "sentdorm";
@@ -3375,6 +4012,19 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"dvZ" = (
+/obj/effect/decal/remains/human,
+/obj/effect/gibspawner/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
+"dwF" = (
+/obj/effect/spawner/lootdrop/f13/deadrodent_or_brainwashdisk,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
 "dwY" = (
 /obj/structure/toilet/greyscale{
 	dir = 8
@@ -3435,6 +4085,11 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"dyn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "dyv" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -3453,8 +4108,12 @@
 	},
 /area/f13/sewer)
 "dyQ" = (
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/bottle/FEV_solution,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/tunnel)
 "dyR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3466,15 +4125,32 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
+"dyS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "dzJ" = (
-/obj/machinery/light{
+/obj/machinery/door/airlock/hatch{
+	locked = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
+"dAb" = (
+/obj/machinery/light/broken{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 10
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"dAK" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/tunnel)
 "dBy" = (
 /obj/structure/ladder/unbreakable{
@@ -3504,12 +4180,9 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dEh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/reagent_containers/syringe/piercing,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "dEm" = (
 /obj/effect/landmark/start/f13/seniorknight,
@@ -3528,6 +4201,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
+"dEt" = (
+/obj/machinery/defibrillator_mount,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "dEy" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -3535,16 +4212,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"dEG" = (
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/o2,
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/toxin,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "dFh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -3558,9 +4225,8 @@
 	},
 /area/f13/sewer)
 "dFC" = (
-/obj/structure/wreck/trash/four_barrels,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/light_construct,
+/turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "dGe" = (
 /obj/structure/table/reinforced,
@@ -3607,6 +4273,11 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"dJc" = (
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13,
+/area/f13/tunnel)
 "dJm" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/subway,
@@ -3620,15 +4291,11 @@
 	},
 /area/f13/clinic)
 "dJx" = (
-/obj/structure/guncase,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "dJD" = (
 /obj/machinery/door/window/brigdoor{
@@ -3643,21 +4310,17 @@
 	},
 /area/f13/brotherhood/operations)
 "dJF" = (
-/obj/item/instrument/accordion,
+/obj/item/instrument/saxophone,
 /obj/structure/rack,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"dJQ" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
 "dJV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/bottle/plasma,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
 "dKk" = (
 /obj/item/target,
 /obj/item/target,
@@ -3691,6 +4354,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"dKt" = (
+/obj/machinery/autolathe,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "dKx" = (
 /obj/item/chair,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -3726,34 +4395,32 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dLJ" = (
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/obj/structure/barricade/wooden{
-	layer = 2.5
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
 	},
 /area/f13/tunnel)
 "dLK" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/syringe/piercing,
+/obj/item/reagent_containers/syringe/piercing,
+/obj/item/reagent_containers/syringe/piercing,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
 	},
+/area/f13/tunnel)
+"dLP" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"dLP" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+"dMb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "dMj" = (
 /obj/structure/closet/cabinet,
@@ -3783,12 +4450,23 @@
 	},
 /area/f13/brotherhood/operations)
 "dML" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/hydroponics/constructable,
+/obj/item/seeds/potato,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
 "dMQ" = (
-/turf/closed/wall/f13/supermart,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/hatchet,
+/obj/item/reagent_containers/glass/bottle/killer/weedkiller,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
 "dMW" = (
 /obj/structure/noticeboard{
@@ -3817,6 +4495,12 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"dNN" = (
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/water,
+/area/f13/caves)
 "dOk" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -3837,17 +4521,21 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"dOF" = (
-/obj/machinery/vending/snack,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/followers)
+"dOI" = (
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "dPx" = (
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/f13/tcoms)
+"dPM" = (
+/obj/structure/closet/crate/medical,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "dQc" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/remains/human,
@@ -3856,6 +4544,10 @@
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
+/area/f13/bunker)
+"dQk" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "dQA" = (
 /obj/machinery/light/small{
@@ -3866,6 +4558,15 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"dQD" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/frame,
+/obj/item/stack/cable_coil/cut/random,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "dRc" = (
 /obj/machinery/vending/wallmed,
 /turf/closed/wall/r_wall,
@@ -3955,6 +4656,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"dSx" = (
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "dSN" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /obj/effect/decal/waste{
@@ -3975,6 +4681,12 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"dSW" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "dTE" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor4-old"
@@ -3984,6 +4696,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"dTO" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "dTR" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -4007,14 +4727,19 @@
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"dUz" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "dUC" = (
-/obj/structure/closet/crate/medical,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/tunnel)
 "dUW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -4090,12 +4815,16 @@
 	},
 /area/f13/tunnel)
 "dWi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/turf/closed/wall/r_wall/rust,
+/area/f13/tunnel)
+"dWJ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/protectron/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "dWN" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -4127,12 +4856,6 @@
 "dXE" = (
 /turf/closed/wall/rust,
 /area/f13/caves)
-"dYr" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/followers)
 "dYy" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -4140,18 +4863,22 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"dYV" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 5
+"dYA" = (
+/obj/item/paper/crumpled/bloody/docsdeathnote{
+	info = "DON'T MAKE OUR MISTAKE"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"dYV" = (
+/obj/structure/closet/crate/secure/loot,
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
 /area/f13/tunnel)
 "dZE" = (
@@ -4204,6 +4931,24 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
+"ebs" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
+"ecf" = (
+/obj/structure/table,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/clothing/head/chefhat,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "ecp" = (
 /obj/structure/table{
 	layer = 2.9
@@ -4224,6 +4969,13 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"ecZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "ede" = (
 /obj/machinery/shower{
 	pixel_y = 32
@@ -4240,12 +4992,6 @@
 /obj/item/bedsheet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"edM" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "edO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4258,6 +5004,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
+"eec" = (
+/obj/structure/frame/machine,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "eew" = (
 /obj/structure/decoration/vent/rusty,
 /obj/machinery/shower{
@@ -4276,19 +5028,17 @@
 	},
 /area/f13/brotherhood/leisure)
 "eeG" = (
-/obj/structure/noticeboard{
-	pixel_x = 32
+/obj/machinery/door/airlock/hatch{
+	locked = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/tunnel)
 "eeT" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Oasis";
-	req_one_access_txt = "25"
-	},
-/turf/open/floor/f13/wood,
+/obj/item/reagent_containers/syringe/piercing,
+/turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "eeW" = (
 /obj/structure/table{
@@ -4303,37 +5053,53 @@
 	},
 /area/f13/brotherhood/leisure)
 "eeX" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
+"eeY" = (
+/obj/structure/closet/crate/large,
+/obj/item/multitool,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "efa" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/wood/house,
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/tunnel)
 "efl" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
-"efX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "egg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe/ammo,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenfull"
+	},
 /area/f13/tunnel)
+"egP" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/warning,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ehc" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "ehk" = (
-/obj/machinery/smartfridge/organ,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
 /area/f13/tunnel)
 "ehz" = (
 /obj/machinery/light/small{
@@ -4354,6 +5120,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
+"ehS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ehT" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -4370,15 +5141,10 @@
 	},
 /area/f13/brotherhood/operations)
 "ehY" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
 /area/f13/tunnel)
 "eiN" = (
 /obj/effect/decal/cleanable/dirt{
@@ -4420,26 +5186,23 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
+"ekE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
 "ekK" = (
-/obj/structure/decoration/vent{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greendirtysolid"
 	},
 /area/f13/tunnel)
 "elU" = (
-/obj/effect/decal/cleanable/blood/splats,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -4456,13 +5219,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"emX" = (
-/obj/structure/table/glass,
-/obj/item/pda,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "enl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -4473,24 +5229,29 @@
 	},
 /area/f13/brotherhood/medical)
 "eom" = (
-/obj/structure/wreck/trash/three_barrels,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/three_course_meal,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/tunnel)
 "eoy" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
 "eoC" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
 /area/f13/tunnel)
+"eoL" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "epe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4503,26 +5264,33 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"eph" = (
+/obj/effect/decal/fakelattice,
+/obj/item/ammo_casing/shotgun/improvised,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "epH" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/area/f13/tunnel)
+"epS" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "epZ" = (
-/obj/structure/sign/warning{
-	pixel_x = 6;
-	pixel_y = -3
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
 	},
-/obj/structure/decoration/warning{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/structure/decoration/warning{
-	pixel_x = -3;
-	pixel_y = -5
-	},
-/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "eqi" = (
 /obj/effect/decal/cleanable/dirt{
@@ -4559,6 +5327,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"erD" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "erF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/shower{
@@ -4569,11 +5343,23 @@
 	},
 /area/f13/brotherhood/operations)
 "esG" = (
-/obj/structure/table/snooker{
-	dir = 6
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenfull"
+	},
 /area/f13/tunnel)
+"esM" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "esP" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -4585,24 +5371,37 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
+"eth" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "etN" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
+/obj/structure/table/wood/poker,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 9;
+	pixel_y = 10
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/tunnel)
 "eub" = (
 /turf/open/floor/plating,
 /area/f13/brotherhood/reactor)
 "eug" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "cornerladder"
+/obj/structure/bed,
+/obj/machinery/camera/autoname{
+	dir = 9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
+"eup" = (
+/obj/structure/closet/crate/freezer/blood/anchored,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "euS" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -4618,14 +5417,26 @@
 	},
 /area/f13/brotherhood/mining)
 "euY" = (
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
-"evD" = (
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/structure/closet/wardrobe/white/medical,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
 	},
-/area/f13/followers)
+/area/f13/tunnel)
+"evP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"evS" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "exq" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -4633,6 +5444,12 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
+/area/f13/bunker)
+"exF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "exH" = (
 /obj/effect/decal/cleanable/dirt{
@@ -4679,14 +5496,9 @@
 	},
 /area/f13/tunnel)
 "ezl" = (
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/obj/item/storage/trash_stack{
-	layer = 2
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
 	},
 /area/f13/tunnel)
 "ezy" = (
@@ -4711,17 +5523,18 @@
 	},
 /area/f13/bunker)
 "eAk" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
 	},
-/obj/machinery/button/door{
-	id = "prospector1open";
-	name = "gate shutters";
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"eAm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "eAw" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -4730,9 +5543,13 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"eAQ" = (
+"eAL" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/water,
+/area/f13/caves)
+"eAQ" = (
+/obj/structure/nest/scorpion,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "eAV" = (
 /obj/structure/handrail/g_central{
@@ -4750,12 +5567,17 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"eBn" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+"eBh" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"eBj" = (
+/obj/item/storage/trash_stack,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/area/f13/followers)
+/area/f13/bunker)
 "eBK" = (
 /obj/machinery/shower{
 	dir = 8
@@ -4768,14 +5590,23 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/f13/tcoms)
+"eCx" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
+"eCA" = (
+/obj/effect/decal/waste,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "eCE" = (
-/obj/structure/barricade/bars{
-	layer = 5
+/obj/structure/table/reinforced,
+/obj/item/storage/part_replacer,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
 	},
-/obj/structure/decoration/hatch{
-	dir = 4
-	},
-/turf/open/water,
 /area/f13/tunnel)
 "eCK" = (
 /obj/effect/turf_decal/stripes/line{
@@ -4856,8 +5687,20 @@
 /area/f13/brotherhood/operations)
 "eDV" = (
 /obj/structure/closet,
+/obj/item/book/granter/trait/trekking,
 /turf/open/floor/f13{
 	icon_state = "dark"
+	},
+/area/f13/bunker)
+"eEE" = (
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "eEL" = (
@@ -4904,20 +5747,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"eGX" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "eHh" = (
 /turf/closed/indestructible/opshuttle{
 	icon = 'icons/turf/walls/reinforced_wall.dmi';
@@ -4954,6 +5783,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"eIo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "eIJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/deepfryer,
@@ -4962,6 +5797,16 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"eIS" = (
+/obj/structure/light_construct,
+/obj/structure/table,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/clothing/suit/armor/hos/trenchcoat,
+/obj/item/clothing/head/HoS/beret,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "eIU" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/subway,
@@ -4981,6 +5826,20 @@
 /obj/effect/landmark/start/f13/ncrveteranranger,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"eJq" = (
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"eJU" = (
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "eKT" = (
 /obj/structure/sign/poster/contraband/have_a_puff{
 	pixel_y = 32
@@ -4989,9 +5848,20 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"eLb" = (
+/obj/structure/light_construct,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "eLE" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
+"eLF" = (
+/obj/item/storage/trash_stack,
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "eLI" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -5047,6 +5917,12 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"eOt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "eOx" = (
 /obj/structure/simple_door/blast{
 	max_integrity = 10000;
@@ -5079,13 +5955,18 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"ePk" = (
-/obj/structure/simple_door/metal/barred,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "topcellghoul"
+"ePe" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
 	},
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"ePk" = (
+/obj/structure/light_construct,
+/obj/structure/bed,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
 /area/f13/tunnel)
 "eQC" = (
 /obj/machinery/telecomms/server/presets/engineering,
@@ -5100,6 +5981,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
+"eQZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "eRg" = (
 /obj/structure/falsewall/reinforced,
 /turf/open/floor/f13{
@@ -5132,6 +6018,10 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/tunnel)
+"eTb" = (
+/mob/living/simple_animal/hostile/handy/protectron/nsb,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "eTv" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -5159,15 +6049,18 @@
 	},
 /area/f13/clinic)
 "eUp" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/timeddoor,
+/obj/structure/timeddoor,
+/turf/closed/wall/r_wall/rust,
 /area/f13/caves)
 "eVi" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
+"eVp" = (
+/obj/structure/stacklifter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "eVA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -5191,11 +6084,8 @@
 	},
 /area/f13/tunnel)
 "eWV" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	pixel_x = -6
-	},
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/timeddoor,
+/turf/closed/wall/r_wall/rust,
 /area/f13/caves)
 "eXJ" = (
 /obj/structure/bed,
@@ -5207,6 +6097,11 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
+"eXP" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "eXS" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -5272,18 +6167,19 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "fbC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Aqua{
-	name = "light fixture"
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "fbD" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/tunnel)
 "fbP" = (
 /obj/machinery/computer/security/wooden_tv{
@@ -5294,6 +6190,18 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
+"fbT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"fdA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/chem_master/advanced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "fdN" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/pepper{
@@ -5365,14 +6273,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/surface)
-"feB" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowhorizontal"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "feM" = (
 /obj/effect/landmark/start/f13/offduty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -5400,13 +6300,19 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "ffJ" = (
-/obj/structure/barricade/bars,
-/obj/structure/table/wood,
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/geiger_counter,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/tunnel)
 "fgy" = (
 /obj/machinery/vending/toyliberationstation,
@@ -5414,6 +6320,15 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"fgW" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/bunker)
 "fhk" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -5427,6 +6342,18 @@
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"fjU" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/bunker)
 "fjW" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -5457,6 +6384,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"fkm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "fkn" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/mre,
@@ -5471,11 +6404,9 @@
 	},
 /area/f13/brotherhood/leisure)
 "fkv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "fkz" = (
 /obj/structure/window/fulltile/house{
@@ -5507,9 +6438,10 @@
 	},
 /area/f13/clinic)
 "flP" = (
-/obj/effect/landmark/start/f13/prospector,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/mob/living/simple_animal/pet/dog/eyebot,
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg2"
+	},
 /area/f13/tunnel)
 "flW" = (
 /obj/structure/simple_door/bunker{
@@ -5528,13 +6460,31 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "fmf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 8;
-	name = "light fixture"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
+"fmj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/splats,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"fmB" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "fmT" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -5626,16 +6576,26 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"frc" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "frf" = (
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
 /area/f13/tunnel)
 "frh" = (
-/obj/effect/landmark/start/f13/settler,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/structure/showcase/horrific_experiment,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/bunker)
 "frm" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -5679,13 +6639,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "ftV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/handrail/g_central{
-	layer = 2.7;
-	pixel_y = -16
+/obj/machinery/vending/medical,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/area/f13/bunker)
 "fuc" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -5697,14 +6655,19 @@
 	},
 /area/f13/brotherhood/operations)
 "fuE" = (
-/obj/structure/simple_door/metal/barred,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bottomcellghoul"
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bottomcellghoul"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/geiger_counter,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/tunnel)
 "fuQ" = (
 /obj/structure/curtain,
@@ -5717,6 +6680,14 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"fuX" = (
+/obj/machinery/button/door{
+	id = "hell";
+	name = "Door Control"
+	},
+/obj/structure/table/reinforced,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "fvp" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
@@ -5787,9 +6758,11 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "fxN" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "fze" = (
 /obj/item/flashlight/lamp{
 	pixel_x = -14;
@@ -5831,13 +6804,22 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/offices1st)
+"fAl" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
+"fAq" = (
+/turf/closed/indestructible/vaultdoor{
+	desc = "A wall made out of metal, really fucking tough metal. Someone built this waaaay in advance.";
+	name = "bunker wall"
+	},
+/area/f13/bunker)
 "fAs" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg2"
+	},
 /area/f13/tunnel)
 "fAJ" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -5847,10 +6829,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fBi" = (
-/obj/structure/closet/crate/large,
-/obj/structure/closet/crate/large,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/effect/decal/cleanable/blood/old,
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "fBQ" = (
 /obj/structure/noticeboard{
 	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
@@ -5858,6 +6842,17 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
+"fBU" = (
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "fCf" = (
 /obj/item/kirbyplants{
 	pixel_y = 14
@@ -5896,6 +6891,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"fDI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fEs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet,
@@ -5908,11 +6908,13 @@
 	},
 /area/f13/brotherhood/operations)
 "fEB" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
 	},
-/turf/open/floor/wood/f13/stage_tl,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "fEJ" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
@@ -5939,11 +6941,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"fGA" = (
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/followers)
 "fGO" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -5954,7 +6951,7 @@
 	},
 /area/f13/tunnel)
 "fGZ" = (
-/obj/item/instrument/harmonica,
+/obj/item/instrument/guitar,
 /obj/structure/rack,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
@@ -5995,13 +6992,8 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"fJM" = (
-/obj/effect/landmark/start/f13/followersguard,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "fJS" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -6020,6 +7012,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"fKi" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "fKm" = (
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/machinery/light{
@@ -6028,11 +7028,16 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "fKq" = (
-/obj/structure/chair/booth{
-	dir = 8
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"fKv" = (
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "fKP" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -6055,18 +7060,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/offices1st)
 "fLK" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/mob/living/simple_animal/hostile/raider/ranged/legendary{
-	name = "John Doe"
-	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "fLU" = (
 /turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"fMg" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/bunker)
 "fME" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -6080,22 +7085,21 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
-"fNk" = (
-/obj/machinery/autolathe,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/followers)
 "fNr" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
 	},
-/obj/structure/chair/booth{
-	dir = 8
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/tunnel)
+/area/f13/bunker)
+"fNu" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "fNX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
@@ -6109,14 +7113,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "fPj" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/flashlight/lantern,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/structure/campfire/barrel,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "fPu" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
@@ -6125,6 +7126,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"fPB" = (
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "fPJ" = (
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -6154,6 +7161,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"fRU" = (
+/mob/living/simple_animal/hostile/handy/protectron/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "fSe" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13{
@@ -6175,8 +7186,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "fSV" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "fSW" = (
@@ -6186,16 +7201,45 @@
 	},
 /area/f13/brotherhood/offices1st)
 "fTt" = (
-/obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"fTA" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/machinery/door/poddoor{
+	id = "malice"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"fTW" = (
+/obj/structure/table/wood,
+/obj/item/clothing/glasses/heat,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "fUZ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"fVn" = (
+/obj/structure/simple_door/bunker/glass,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/f13{
+	dir = 6;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
 "fVx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -6208,10 +7252,49 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"fWr" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
+	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
+	name = "strange meat"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"fWI" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"fWY" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"fXa" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "fXm" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "fXr" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -6286,19 +7369,22 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "fZO" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/handcuffs,
-/obj/machinery/light/small{
-	dir = 8
+/obj/item/flashlight/flare,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/area/f13/bunker)
 "gaf" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/wood,
-/area/f13/tunnel)
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"gbx" = (
+/obj/item/paper,
+/obj/item/paper/crumpled,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gbA" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Brig";
@@ -6318,8 +7404,10 @@
 	},
 /area/f13/clinic)
 "gbH" = (
-/turf/open/floor/wood/f13/stage_bl,
-/area/f13/tunnel)
+/obj/structure/timeddoor,
+/obj/structure/timeddoor,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "gcb" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -6327,19 +7415,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"gct" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "fadmin";
-	name = "Follower Admin shutters"
-	},
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "124"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "gcD" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -6349,14 +7424,18 @@
 	},
 /area/f13/brotherhood/mining)
 "gev" = (
-/obj/structure/decoration/hatch{
-	dir = 4
-	},
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/water,
-/area/f13/tunnel)
+/turf/closed/wall,
+/area/f13/caves)
+"geL" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"gfb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gfz" = (
 /obj/structure/table{
 	layer = 2.9
@@ -6373,6 +7452,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"gfP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "ggm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
@@ -6450,12 +7536,13 @@
 	},
 /area/f13/enclave)
 "giA" = (
-/obj/structure/table/snooker{
-	dir = 10
+/turf/closed/wall/rust,
+/area/f13/bunker)
+"gjk" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "gjB" = (
 /obj/structure/table{
 	layer = 2.9
@@ -6547,19 +7634,11 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "gmL" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = -3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/tunnel)
+/turf/closed/wall,
+/area/f13/bunker)
 "gni" = (
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/turf/closed/mineral/random/high_chance,
+/area/f13/bunker)
 "gnY" = (
 /obj/structure/toilet{
 	dir = 4
@@ -6606,6 +7685,16 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"gpr" = (
+/obj/machinery/door/poddoor/preopen{
+	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70);
+	id = eairlock
+	},
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "bluemark"
+	},
+/area/f13/bunker)
 "gpM" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6630,24 +7719,48 @@
 /obj/structure/decoration/vent,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/offices1st)
-"gsQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Pink{
-	dir = 4;
-	name = "light tube"
+"gsM" = (
+/obj/machinery/light/broken,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
 	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"gsQ" = (
+/obj/item/instrument/piano_synth,
+/obj/structure/rack,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/tunnel)
 "gta" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"gtH" = (
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gtY" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"gua" = (
+/obj/structure/reagent_dispensers/barrel,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"gui" = (
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "gul" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices2nd)
@@ -6661,12 +7774,12 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
-"guL" = (
-/obj/structure/bodycontainer/crematorium,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+"gvW" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
 	},
-/area/f13/followers)
+/area/f13/bunker)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -6685,17 +7798,24 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"gwD" = (
+/obj/structure/girder/reinforced,
+/turf/open/water,
+/area/f13/caves)
 "gwE" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"gxe" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "gxq" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_middle"
-	},
-/turf/open/floor/f13/wood,
+/obj/item/instrument/accordion,
+/obj/structure/rack,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "gyf" = (
 /obj/effect/decal/cleanable/oil/slippery,
@@ -6716,8 +7836,8 @@
 	},
 /area/f13/brotherhood/offices1st)
 "gyB" = (
-/obj/effect/landmark/start/f13/dendoc,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "gyS" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -6726,13 +7846,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gyZ" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "gza" = (
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/falsewall,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "gzs" = (
 /obj/structure/sink{
@@ -6766,12 +7891,6 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"gAz" = (
-/obj/structure/chair/f13chair1,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
 "gAN" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -6784,12 +7903,8 @@
 	},
 /area/f13/clinic)
 "gBq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden{
-	layer = 2.5
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/turf/closed/wall{
+	icon_state = "fwall_opening"
 	},
 /area/f13/tunnel)
 "gCd" = (
@@ -6798,18 +7913,33 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
-"gED" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
+"gCz" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"gEd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "gEZ" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
+"gFg" = (
+/turf/closed/wall/f13/ruins,
+/area/f13/caves)
 "gFu" = (
-/obj/structure/sign/poster/contraband/red_rum{
-	pixel_y = -32
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "gFv" = (
 /obj/structure/sign/warning/securearea,
@@ -6829,10 +7959,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "gFV" = (
-/obj/structure/table/booth,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "gGa" = (
 /obj/machinery/vending/coffee,
@@ -6840,6 +7968,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"gGS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "gHh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -6856,6 +7991,11 @@
 	},
 /turf/closed/wall,
 /area/f13/tcoms)
+"gIH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/stacklifter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gJa" = (
 /obj/effect/mine/stun,
 /turf/open/floor/f13{
@@ -6863,8 +8003,10 @@
 	},
 /area/f13/clinic)
 "gJz" = (
-/obj/effect/landmark/start/f13/prospector,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/paper_bin/bundlenatural,
+/obj/structure/rack,
+/obj/item/paper_bin/bundlenatural,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "gKc" = (
 /obj/structure/table/reinforced,
@@ -6873,6 +8015,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"gKv" = (
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gKJ" = (
 /obj/effect/turf_decal/caution/stand_clear/white,
 /obj/effect/decal/cleanable/dirt,
@@ -6900,6 +8046,15 @@
 /obj/effect/spawner/lootdrop/f13/ncr_k_ration,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"gMS" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/closed/indestructible/fakedoor{
+	desc = "An indestructible door. Hm.";
+	name = "Strong Door"
+	},
+/area/f13/bunker)
 "gMX" = (
 /obj/effect/turf_decal/caution/stand_clear/white,
 /obj/effect/decal/cleanable/dirt,
@@ -6931,23 +8086,53 @@
 /obj/item/clothing/head/helmet/roman/fake,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"gNR" = (
+/obj/structure/junk/small/bed,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "gNZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
+/obj/item/instrument/violin,
+/obj/structure/rack,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/tunnel)
+"gOB" = (
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/stripes/end,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/tunnel)
 "gOG" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
+"gON" = (
+/obj/item/cultivator,
+/mob/living/simple_animal/hostile/handy/protectron/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gPe" = (
-/obj/machinery/light/fo13colored/Aqua{
-	name = "light fixture"
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "radio";
+	level = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/tunnel)
 "gPJ" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden,
@@ -6964,10 +8149,18 @@
 /obj/effect/mine/stun,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"gRa" = (
-/obj/structure/barricade/bars,
+"gQV" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 5
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"gRa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gRq" = (
 /obj/structure/table/wood,
@@ -7032,17 +8225,19 @@
 /area/f13/brotherhood/rnd)
 "gSQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/money_stack,
+/obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"gTv" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 5
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+"gTa" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/mineral/random/low_chance,
 /area/f13/bunker)
+"gTv" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_7"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "gTy" = (
 /obj/structure/noticeboard{
 	desc = "A large, rusted plaque with a newly crafted nameplate displaying the current Head Knight on duty.";
@@ -7052,7 +8247,9 @@
 /area/f13/brotherhood/offices1st)
 "gTT" = (
 /obj/structure/bookcase/manuals/research_and_development,
-/turf/open/space/basic,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -7061,12 +8258,19 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"gUm" = (
-/obj/structure/table/snooker{
-	dir = 5
+"gUj" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"gUm" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gUF" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7091,18 +8295,14 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "gWc" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing,
-/turf/open/floor/f13/wood,
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "gWt" = (
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/water,
+/turf/closed/wall/f13/wood/house,
+/area/f13/tunnel)
+"gWG" = (
+/turf/closed/wall/r_wall,
 /area/f13/tunnel)
 "gWK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7123,6 +8323,20 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
+"gXR" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall,
+/area/f13/tunnel)
+"gYE" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/obj/structure/sign/poster/contraband/punch_shit{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "gYV" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -7140,9 +8354,15 @@
 	},
 /area/f13/brotherhood/operations)
 "gZF" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"gZL" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hac" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -7154,6 +8374,14 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"hae" = (
+/obj/structure/closet/crate/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "han" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/machinery/light/small/broken{
@@ -7187,6 +8415,30 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"hba" = (
+/obj/structure/barricade/wooden/planks,
+/turf/closed/wall/f13/wood,
+/area/f13/sewer)
+"hbd" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell/ammo/ec{
+	pixel_y = 7
+	},
+/obj/item/stock_parts/cell/ammo/ec,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/f13/bunker)
+"hbh" = (
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "hbQ" = (
 /obj/structure/table/booth,
 /obj/item/flashlight,
@@ -7263,15 +8515,12 @@
 	},
 /area/f13/tunnel)
 "hev" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "radio";
-	level = 1
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "topcellghoul"
 	},
-/obj/machinery/light/small/broken{
-	dir = 4
-	},
-/turf/open/floor/plasteel/floorgrime,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "heI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7280,10 +8529,27 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"heR" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/stage_tl,
+/area/f13/tunnel)
 "hfb" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/turf/open/floor/f13/wood,
+/obj/structure/chair/stool,
+/obj/machinery/button/door{
+	id = "bottomcellghoul";
+	name = "Bottom cell shutters";
+	pixel_x = -6;
+	pixel_y = 32
+	},
+/obj/machinery/button/door{
+	id = "topcellghoul";
+	name = "Top cell shutters";
+	pixel_x = 6;
+	pixel_y = 32
+	},
+/turf/open/floor/wood/f13/stage_t,
 /area/f13/tunnel)
 "hfr" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -7305,27 +8571,26 @@
 	},
 /area/f13/tcoms)
 "hgP" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	max_integrity = 500;
-	name = "Store Bedroom";
-	req_one_access_txt = "34"
-	},
-/turf/open/floor/f13/wood,
+/obj/structure/chair/stool,
+/turf/open/floor/wood/f13/stage_t,
 /area/f13/tunnel)
-"hhe" = (
-/obj/structure/barricade/bars,
-/obj/structure/curtain{
-	color = "#845f58"
+"hhc" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"hhe" = (
+/obj/machinery/jukebox,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/stage_tr,
 /area/f13/tunnel)
 "hhi" = (
-/obj/structure/closet/cabinet,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "hhn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7338,6 +8603,10 @@
 /obj/item/trash/f13/dog,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"hhI" = (
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hhQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -7380,6 +8649,20 @@
 "hkD" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/tunnel)
+"hlb" = (
+/obj/machinery/workbench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"hlu" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "hlS" = (
 /obj/structure/chair/left{
 	dir = 8
@@ -7416,11 +8699,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"hmZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
 "hng" = (
 /obj/structure/bookcase/random/religion,
 /obj/effect/decal/cleanable/dirt,
@@ -7435,6 +8713,11 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"hoc" = (
+/obj/machinery/light/broken,
+/obj/item/ammo_casing/shotgun/improvised,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hog" = (
 /obj/item/bedsheet/red,
 /obj/structure/bed/pod,
@@ -7454,6 +8737,13 @@
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
+"hor" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = -6
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "hoH" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/f13/wood,
@@ -7475,13 +8765,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "hpe" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 10
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
+/obj/structure/bonfire,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "hpp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -7511,15 +8797,22 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
 "hqg" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "hqt" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/snacks/soylentgreen,
 /obj/item/reagent_containers/food/snacks/soylentgreen,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"hqw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "hqC" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -7580,20 +8873,8 @@
 /area/f13/tunnel)
 "hsH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 8;
-	light_color = "#800080";
-	name = "light fixture"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"hsK" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/followers)
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "hsL" = (
 /obj/structure/chair{
 	dir = 4
@@ -7627,6 +8908,28 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
+"hsY" = (
+/mob/living/simple_animal/hostile/enclave/soldier{
+	aggro_vision_range = 15;
+	armour_penetration = 1;
+	desc = "What visibly appears to be a proud Enclave soldier clad in armor is in actuality a grotesque, FEV-exposed mutant grafted to the interior of his suit, never able to leave. You've gotten a lot farther than you should have...";
+	extra_projectiles = 10;
+	faction = list("wastebot");
+	health = 3000;
+	loot = list(/obj/item/keycard/library);
+	maxHealth = 3000;
+	melee_damage_lower = 100;
+	melee_damage_upper = 100;
+	melee_queue_distance = 10;
+	name = "Captain Arlem";
+	speak = list("Die... mutie!","AAAAUHGHHHH!","DIE!","Perish!","FOR THE ENCLAVE!");
+	speak_chance = 10;
+	speak_emote = list("shouts");
+	speed = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "huS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -7637,11 +8940,8 @@
 /area/f13/tcoms)
 "hvw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "hxB" = (
 /obj/structure/table{
 	layer = 2.9
@@ -7657,13 +8957,34 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"hyj" = (
+"hxM" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"hyd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"hyj" = (
+/obj/item/wirecutters/basic,
+/obj/item/screwdriver/crude,
+/obj/structure/table/wood,
+/obj/item/storage/box/handcuffs,
+/obj/item/lock_construct,
+/obj/item/key,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
+/obj/item/stack/f13Cash/random/med,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"hyn" = (
+/obj/structure/table/wood/settler,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/tunnel)
 "hyH" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -7697,6 +9018,10 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/sewer)
+"hAT" = (
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "hBz" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/cable{
@@ -7726,20 +9051,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"hBU" = (
-/obj/structure/sign/poster/prewar/poster90{
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
-"hCb" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "hCS" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -7748,6 +9059,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"hCT" = (
+/obj/item/ammo_casing/shotgun/improvised,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "hDw" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
@@ -7756,14 +9071,23 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building)
+"hDP" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/securitron/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "hDX" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "hEp" = (
-/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"hEv" = (
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "hFm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -7798,6 +9122,11 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
+"hGW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hHc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/f13foldupchair,
@@ -7807,14 +9136,6 @@
 /obj/item/trash/f13/cram_large,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"hHz" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/glass/ten,
-/obj/item/stack/sheet/glass/ten,
-/obj/item/stack/sheet/glass/ten,
-/obj/item/stack/rods/twentyfive,
-/turf/open/floor/plating/f13,
-/area/f13/followers)
 "hHI" = (
 /obj/structure/closet{
 	storage_capacity = 10
@@ -7833,26 +9154,20 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"hIl" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "hIq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "hIy" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/plastic/fifty,
-/obj/item/stack/sheet/plastic/fifty,
-/obj/item/stack/sheet/plastic/fifty,
-/obj/item/stack/sheet/plastic/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/guncase,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/ballistic/shotgun/trench,
+/obj/item/gun/ballistic/shotgun/trench,
+/obj/item/gun/ballistic/shotgun/trench,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "hJk" = (
 /obj/structure/lattice{
@@ -7863,6 +9178,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"hJs" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "hJV" = (
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7888,8 +9212,12 @@
 	},
 /area/f13/brotherhood/medical)
 "hKG" = (
-/obj/structure/falsewall,
-/turf/open/floor/plasteel/floorgrime,
+/obj/structure/rack,
+/obj/item/ammo_box/a308,
+/obj/item/ammo_box/a308,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/ballistic/automatic/marksman/sniper,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "hKI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7902,10 +9230,22 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
+"hKR" = (
+/obj/structure/wreck/trash/five_tires,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "hLd" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"hLh" = (
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "hLo" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -7917,6 +9257,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"hLw" = (
+/mob/living/simple_animal/hostile/raider/biker,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "hLS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/sign{
@@ -7927,33 +9271,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"hMw" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
-"hMA" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/followers)
 "hMJ" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
-"hMQ" = (
-/obj/structure/table,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/followers)
 "hMU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -7971,18 +9294,11 @@
 	},
 /area/f13/brotherhood/medical)
 "hNq" = (
-/obj/item/defibrillator/loaded,
-/obj/item/storage/box/syringes,
-/obj/item/cane,
-/obj/item/soap,
-/obj/effect/turf_decal/box/white,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/defibrillator/loaded,
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/gloves,
+/obj/structure/simple_door/metal/barred,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "topcellghoul"
+	},
+/obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "hNS" = (
@@ -7997,13 +9313,15 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"hOz" = (
-/obj/structure/sign/poster/prewar/poster91,
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
+"hOj" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/water,
+/area/f13/caves)
 "hOR" = (
-/obj/structure/girder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood/f13/stage_bl,
 /area/f13/tunnel)
 "hOT" = (
 /mob/living/simple_animal/hostile/deathclaw,
@@ -8011,6 +9329,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"hPk" = (
+/obj/structure/junk/small/bed,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "hPn" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
@@ -8069,8 +9394,9 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
 "hQG" = (
-/mob/living/simple_animal/hostile/deathclaw/mother,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/tunnel)
 "hQR" = (
 /mob/living/simple_animal/hostile/giantantqueen,
@@ -8085,6 +9411,10 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
+/area/f13/bunker)
+"hRA" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "hSU" = (
 /obj/structure/decoration/vent{
@@ -8194,6 +9524,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"hWB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor{
+	id = "pain"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hWJ" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -8202,10 +9539,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "hWZ" = (
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/obj/structure/table/wood/poker,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/stage_br,
+/area/f13/tunnel)
+"hXB" = (
+/obj/item/fishingrod,
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/water,
 /area/f13/bunker)
 "hYh" = (
 /obj/structure/chair/sofa/corp/right,
@@ -8215,9 +9557,7 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "hYr" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/simple_door/metal/barred,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
@@ -8244,20 +9584,18 @@
 	},
 /area/f13/brotherhood/rnd)
 "ias" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"iau" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "iav" = (
 /obj/structure/table{
 	layer = 2.9
@@ -8271,10 +9609,14 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"iaO" = (
-/obj/item/flashlight/lantern,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+"iaz" = (
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "iaS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8284,6 +9626,23 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
+"ibo" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "ibr" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
@@ -8291,16 +9650,30 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"ibv" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "icd" = (
 /obj/item/pickaxe/drill,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "icj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/toolbox/drone,
-/obj/item/storage/toolbox/drone,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/structure/simple_door/metal/barred,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"icB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/one_barrel,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "icI" = (
 /obj/structure/table{
 	layer = 2.9
@@ -8313,6 +9686,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood/offices1st)
+"icW" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "ide" = (
 /obj/structure/chair/sofa/corp/corner,
 /obj/effect/decal/cleanable/dirt{
@@ -8320,18 +9700,19 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"idi" = (
-/obj/machinery/workbench/advanced,
-/obj/item/storage/part_replacer,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/followers)
 "idK" = (
 /obj/structure/barricade/wooden,
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"ieG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/item/paper/crumpled/bloody/ruins,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ife" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/clothing_high,
@@ -8339,13 +9720,21 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"ifD" = (
-/obj/structure/table,
-/obj/machinery/processor/chopping_block,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+"iff" = (
+/obj/machinery/door/keycard{
+	puzzle_id = "library"
 	},
-/area/f13/followers)
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
+"ifn" = (
+/obj/item/storage/trash_stack,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "ifR" = (
 /obj/structure/table{
 	layer = 2.9
@@ -8358,6 +9747,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood/offices1st)
+"ifT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "ifW" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -8410,21 +9807,23 @@
 /obj/item/flashlight/flare/torch,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"igD" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "followerladder"
+"igG" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "igH" = (
-/obj/structure/wreck/trash/two_barrels,
+/obj/structure/guncase,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "igL" = (
@@ -8444,9 +9843,16 @@
 	},
 /area/f13/brotherhood/operations)
 "ihg" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "iiu" = (
@@ -8473,16 +9879,32 @@
 	},
 /turf/open/floor/plating,
 /area/f13/tcoms)
+"ijb" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"ijq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ijP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/human/corpse,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ikD" = (
-/obj/structure/table/snooker{
-	dir = 6
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "topcellghoul"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bottomcellghoul"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/dice{
-	pixel_x = 13;
-	pixel_y = -7
-	},
-/obj/item/dice,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ikI" = (
@@ -8493,6 +9915,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"ikX" = (
+/obj/structure/light_construct,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenfull"
+	},
+/area/f13/tunnel)
 "ilb" = (
 /obj/structure/decoration/vent{
 	pixel_x = 16;
@@ -8510,13 +9938,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"ili" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/emergency,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/plating/f13,
-/area/f13/followers)
 "ill" = (
 /obj/structure/sign/poster/prewar/poster92,
 /turf/closed/wall/r_wall,
@@ -8543,9 +9964,18 @@
 /obj/item/circular_saw,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"ime" = (
+/mob/living/simple_animal/hostile/deathclaw/legendary{
+	speed = -1.5
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "imj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "topcellghoul"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "imo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8554,31 +9984,43 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
+"imY" = (
+/obj/structure/junk/small/bed,
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "inU" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"iot" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+"ioj" = (
+/obj/item/trash/f13/yumyum,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
 	},
-/area/f13/followers)
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "iox" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "ioO" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
+	},
 /area/f13/tunnel)
 "ioQ" = (
 /obj/effect/turf_decal/arrows/white,
@@ -8590,6 +10032,13 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"ioV" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "ipv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/kitchenspike_frame{
@@ -8602,17 +10051,17 @@
 	},
 /area/f13/brotherhood/offices1st)
 "ipw" = (
-/obj/structure/rack,
+/obj/structure/barricade/bars,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"ipx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "iqE" = (
 /obj/structure/table/glass,
@@ -8649,9 +10098,22 @@
 	},
 /area/f13/tunnel)
 "irB" = (
-/obj/structure/showcase/horrific_experiment,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
+	},
+/area/f13/bunker)
+"irY" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "ise" = (
@@ -8682,6 +10144,21 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
+"isI" = (
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/item/gun/ballistic/automatic/m1garand/oldglory{
+	desc = "Arguably the most patriotic garand in existence, flag and well-known satisfying ping included, all the while hitting like a truck";
+	name = "M1 Garand"
+	},
+/obj/item/clothing/suit/armor/f13/battlecoat,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
 "isJ" = (
 /obj/machinery/shower{
 	layer = 2.8;
@@ -8704,6 +10181,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"itz" = (
+/obj/item/fusion_fuel,
+/obj/item/fusion_fuel,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/clinic)
 "itI" = (
 /obj/structure/table{
 	layer = 2.9
@@ -8721,6 +10205,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood/offices1st)
+"itL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "itP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -8736,13 +10236,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "iuv" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib5-old"
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/indestructible/ground/inside/subway,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "iuL" = (
 /obj/structure/table,
@@ -8752,6 +10247,16 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
+"iuU" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "iuX" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -8781,16 +10286,44 @@
 	},
 /area/f13/tunnel)
 "ivm" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/workbench/forge,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "iwu" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"iwx" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/prewar,
+/obj/item/stack/sheet/prewar,
+/obj/item/stack/sheet/prewar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"iwL" = (
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/structure/closet/crate/miningcar,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"ixU" = (
+/obj/machinery/door/poddoor{
+	id = "soup"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "ixX" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /obj/effect/decal/cleanable/dirt,
@@ -8802,14 +10335,6 @@
 /obj/structure/table/wood/fancy/blackred,
 /turf/open/floor/mineral/plastitanium/airless,
 /area/f13/brotherhood/rnd)
-"izq" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
-/area/f13/followers)
 "izC" = (
 /obj/item/chair/stool/retro/black,
 /obj/effect/spawner/lootdrop/trash,
@@ -8866,14 +10391,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "iDt" = (
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "topcellghoul"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bottomcellghoul"
-	},
+/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "iDP" = (
@@ -8882,19 +10407,29 @@
 	},
 /area/f13/brotherhood/reactor)
 "iER" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/stack/sheet/plastic/fifty,
+/obj/item/stack/sheet/plastic/fifty,
+/obj/item/stack/sheet/plastic/fifty,
+/obj/item/stack/sheet/plastic/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"iFe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "iFL" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"iGR" = (
+/obj/item/chair,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "iGY" = (
 /obj/item/storage/firstaid/regular{
 	pixel_y = 5
@@ -8918,8 +10453,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "iHB" = (
-/obj/structure/barricade/wooden,
-/turf/open/water,
+/obj/machinery/autolathe/ammo/unlocked,
+/obj/item/book/granter/crafting_recipe/gunsmith_two,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/item/book/granter/crafting_recipe/gunsmith_one,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "iIu" = (
 /turf/open/floor/f13/wood{
@@ -8966,12 +10504,11 @@
 	},
 /area/f13/brotherhood/rnd)
 "iKB" = (
-/obj/structure/table,
-/obj/item/book/granter/trait/chemistry,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/structure/barricade/bars{
+	layer = 5
 	},
-/area/f13/bunker)
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "iKI" = (
 /obj/structure/mirror,
 /turf/closed/wall/rust,
@@ -9006,6 +10543,14 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"iMh" = (
+/obj/effect/decal/cleanable/glass,
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
 "iMs" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/outside/ruins,
@@ -9030,8 +10575,12 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "iNY" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	desc = "There is something on the wind. It.. it smells like... crime.";
+	name = "Detective Office";
+	req_one_access_txt = "4"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "iOr" = (
@@ -9053,33 +10602,53 @@
 /obj/structure/mirror,
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
-"iPr" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/sleeper,
-/obj/item/circuitboard/machine/biogenerator,
-/obj/item/circuitboard/machine/seed_extractor,
-/obj/item/circuitboard/machine/chem_dispenser,
-/obj/item/circuitboard/machine/chem_master,
-/obj/item/circuitboard/machine/chem_heater,
-/obj/item/circuitboard/machine/ore_redemption,
-/obj/item/circuitboard/machine/mining_equipment_vendor,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/followers)
+"iPs" = (
+/obj/structure/guncase,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "iPu" = (
 /obj/machinery/defibrillator_mount/loaded,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
 "iPH" = (
-/mob/living/simple_animal/hostile/raider/ranged,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"iPO" = (
-/turf/closed/wall/f13/store,
-/area/f13/followers)
+/obj/structure/rack,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/radio/headset/headset_den,
+/obj/item/storage/box/citizenship_permits,
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "iQt" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -9089,22 +10658,22 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"iQC" = (
-/obj/machinery/vending/wardrobe/science_wardrobe,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "iRc" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"iRA" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
 "iRE" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "prospectorladder"
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -9159,12 +10728,23 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
+"iSV" = (
+/obj/effect/decal/fakelattice,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "iTb" = (
 /obj/structure/mopbucket,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"iTk" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/f13{
+	dir = 6;
+	icon_state = "bluemark"
+	},
+/area/f13/bunker)
 "iTJ" = (
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
@@ -9173,8 +10753,20 @@
 /obj/structure/decoration/vent,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
+"iVc" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "iVi" = (
-/obj/machinery/vending/medical,
+/obj/structure/table,
+/obj/item/roller,
+/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
+	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
+	name = "strange meat"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -9240,17 +10832,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "iWE" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bottomcellghoul"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "iWH" = (
-/obj/machinery/shower{
-	dir = 4
+/obj/structure/sign/poster/ripped{
+	pixel_x = 32
 	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "iWR" = (
 /obj/effect/decal/cleanable/dirt{
@@ -9297,9 +10889,11 @@
 	},
 /area/f13/clinic)
 "iYF" = (
-/obj/structure/girder,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/rust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "iYI" = (
 /obj/effect/decal/cleanable/dirt{
@@ -9319,6 +10913,12 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"iZl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "iZB" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -9343,17 +10943,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/mining)
 "jak" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"jaY" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/f13/followers)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "jbA" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
@@ -9372,13 +10966,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
+"jbU" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jcf" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/item/toy/figure/detective{
-	pixel_x = -4;
-	pixel_y = 11
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/f13/wood,
+/turf/open/water,
 /area/f13/tunnel)
 "jcl" = (
 /obj/structure/lattice{
@@ -9392,18 +10989,36 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"jdP" = (
-/obj/structure/chair/booth,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/pinup_couch{
-	pixel_y = 32
+"jcB" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"jdH" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"jdP" = (
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 1;
+	name = "light fixture"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "jej" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/detective,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"jel" = (
+/mob/living/simple_animal/hostile/stalkeryoung,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "jeo" = (
 /obj/structure/closet/cabinet,
@@ -9411,34 +11026,40 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"jew" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/securitron/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "jeE" = (
-/obj/machinery/shower{
-	dir = 8
-	},
+/obj/structure/closet/cabinet,
+/obj/item/taperecorder,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/storage/briefcase,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "jeM" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/f13/wood/house,
+/area/f13/tunnel)
 "jfx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "jfS" = (
-/obj/item/instrument/violin,
 /obj/structure/rack,
-/turf/open/floor/plasteel/floorgrime,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "jfU" = (
 /turf/open/indestructible/ground/inside/mountain,
@@ -9490,9 +11111,22 @@
 	},
 /area/f13/brotherhood/rnd)
 "jgP" = (
-/obj/structure/bed/roller,
+/obj/structure/simple_door/metal/barred,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bottomcellghoul"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bottomcellghoul"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"jgR" = (
+/mob/living/simple_animal/hostile/raider/thief,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jhN" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
@@ -9521,12 +11155,18 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "jiL" = (
-/obj/effect/landmark/map_load_mark/dungeons/northsewer,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "jkb" = (
-/obj/item/storage/trash_stack,
-/turf/open/water,
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jkp" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -9534,20 +11174,31 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/sewer)
+"jkJ" = (
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/structure/table,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "jll" = (
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/plasteel/vault/telecomms/mainframe{
 	dir = 8
 	},
 /area/f13/tcoms)
-"jlt" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
+"jlp" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/followers)
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/tunnel)
 "jlC" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -9559,14 +11210,8 @@
 	},
 /area/f13/tunnel)
 "jmA" = (
-/obj/structure/closet/cabinet,
-/obj/item/taperecorder,
-/obj/item/tape,
-/obj/item/tape,
-/obj/item/tape,
-/obj/item/storage/briefcase,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/structure/bed/mattress,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jmN" = (
 /turf/closed/wall/r_wall/rust,
@@ -9582,6 +11227,14 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"jok" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/tunnel)
 "jpg" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -9589,12 +11242,25 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"jqg" = (
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "jqx" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
+/area/f13/tunnel)
+"jqX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/smoke{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jrk" = (
 /obj/structure/chair/sofa/corp{
@@ -9606,20 +11272,32 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "jrm" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "jrn" = (
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
 "jro" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
+/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jrA" = (
@@ -9628,9 +11306,24 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "jrV" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jsD" = (
@@ -9659,10 +11352,22 @@
 	},
 /area/f13/brotherhood/medical)
 "jug" = (
-/obj/structure/chair/stool/retro,
+/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"juj" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "juq" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -9673,14 +11378,33 @@
 	},
 /area/f13/brotherhood/medical)
 "juP" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/ore/blackpowder/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "juU" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -9690,74 +11414,53 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"jvg" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+"jvJ" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"jwh" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/area/f13/followers)
+/area/f13/bunker)
 "jwm" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Oasis Housing";
-	req_one_access_txt = "25"
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "shopladder"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jwp" = (
-/obj/structure/rack,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/radio/headset/headset_den,
-/obj/item/storage/box/citizenship_permits,
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/f13/wood,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	max_integrity = 500;
+	name = "Store Backroom";
+	req_one_access_txt = "34"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"jwv" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/tunnel)
 "jwA" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"jwF" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jwN" = (
 /obj/machinery/rnd/production/protolathe,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
-"jxG" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowleft";
-	layer = 2
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "jyc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice{
@@ -9820,12 +11523,36 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"jAL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/biker,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "jAZ" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"jBe" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"jBv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
+	dir = 1;
+	light_color = "#008000";
+	name = "light tube"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "jBU" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -9841,6 +11568,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"jDW" = (
+/obj/structure/closet/wardrobe/chemistry_white,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
+"jEg" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"jEt" = (
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "jFd" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -9867,28 +11610,39 @@
 	},
 /area/f13/brotherhood/leisure)
 "jFx" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder/reinforced,
+/turf/closed/wall/r_wall/rust,
+/area/f13/tunnel)
+"jFB" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/caves)
-"jFB" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
 /area/f13/tunnel)
 "jFC" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"jFU" = (
-/obj/machinery/chem_master,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
+"jGd" = (
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/splats,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"jGy" = (
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "jGQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -9900,10 +11654,17 @@
 	},
 /area/f13/brotherhood/reactor)
 "jHN" = (
-/obj/machinery/chem_dispenser,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"jHU" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/sentrybot/nsb/riot,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jIm" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -9927,6 +11688,14 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
+"jJA" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "jJB" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/black,
@@ -9937,18 +11706,21 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
-"jJT" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+"jJO" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"jJT" = (
+/obj/structure/table/wood,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/f13Cash/random/med,
+/obj/item/megaphone,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "jJV" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/f13{
@@ -9969,18 +11741,46 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
-"jKM" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin,
+"jKq" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "redrustyfull"
 	},
-/area/f13/followers)
+/area/f13/bunker)
+"jKx" = (
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "jKY" = (
-/obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/money_stack,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"jLI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/item/reagent_containers/food/snacks/f13/deathclawomelette,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jLX" = (
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
@@ -10019,16 +11819,21 @@
 	},
 /area/f13/tunnel)
 "jMT" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/machinery/light/small{
+/obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"jNe" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/tunnel)
 "jNr" = (
 /obj/item/flag/bos,
 /turf/open/floor/circuit/f13_red,
@@ -10048,16 +11853,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "jOe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/chem_pile{
-	pixel_x = -19
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	max_integrity = 500;
+	name = "Store Bedroom";
+	req_one_access_txt = "34"
 	},
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "jOt" = (
 /obj/structure/barricade/bars,
@@ -10126,6 +11928,11 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
+"jQK" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/robobrain/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jQN" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood{
@@ -10137,23 +11944,21 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "jQU" = (
-/obj/structure/barricade/bars,
-/obj/structure/curtain{
-	color = "#845f58"
+/turf/closed/indestructible/vaultdoor{
+	desc = "A wall made out of metal, really fucking tough metal. Someone built this waaaay in advance.";
+	name = "bunker wall"
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/tunnel)
-"jQV" = (
-/obj/structure/table/glass,
-/obj/item/folder{
-	pixel_x = -4
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/followers)
+/area/f13/caves)
+"jRu" = (
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"jSc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jSf" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -10166,10 +11971,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "jSJ" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"jTg" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
 "jTD" = (
 /obj/machinery/shower{
 	dir = 8
@@ -10185,6 +11997,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"jVf" = (
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jVx" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 1
@@ -10207,11 +12023,31 @@
 	},
 /area/f13/bunker)
 "jWC" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/detective,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"jWG" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw/mother{
+	speed = -1.5
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"jXe" = (
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/closed/wall/r_wall,
+/area/f13/tunnel)
+"jXq" = (
+/obj/item/storage/trash_stack,
+/obj/structure/wreck/trash/two_tire,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "jXu" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 1
@@ -10219,6 +12055,13 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
+"jXC" = (
+/obj/machinery/light/broken,
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "jYe" = (
 /obj/machinery/door/window/southleft,
 /obj/effect/decal/cleanable/dirt,
@@ -10235,38 +12078,27 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "jYt" = (
-/obj/structure/chair/stool/retro,
-/obj/item/instrument/guitar{
-	anchored = 1;
-	pixel_y = 32
+/obj/structure/table/wood,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"jYL" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "jYP" = (
 /obj/structure/simple_door/bunker,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/medical)
 "jZf" = (
-/obj/structure/rack,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "gatehouseladder"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "jZg" = (
 /turf/open/floor/carpet/black,
@@ -10274,6 +12106,11 @@
 "jZH" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
+"jZI" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "jZT" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
@@ -10365,16 +12202,28 @@
 	},
 /area/f13/brotherhood/offices1st)
 "kfQ" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"kfU" = (
+/obj/structure/table,
+/obj/item/fusion_fuel,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "kfV" = (
 /obj/structure/simple_door/room,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"kgo" = (
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "kgP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -10424,11 +12273,30 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"kiY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/caves)
 "kja" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/microwave,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"kjo" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"kjz" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old";
+	tag = "icon-floor6-old"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kjU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -10443,15 +12311,35 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"kjW" = (
+"kjV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/area/f13/bunker)
+"kjW" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"kkm" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "kkq" = (
 /obj/item/flashlight/flare/torch,
@@ -10463,10 +12351,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "kkU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
+/obj/structure/rack,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/stack/sheet/cloth/ten,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "klj" = (
 /obj/structure/sink{
@@ -10482,20 +12373,26 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"klZ" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+"kne" = (
+/obj/machinery/door/keycard{
+	puzzle_id = "library"
 	},
-/area/f13/followers)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "kny" = (
 /obj/structure/sign/poster/prewar/poster74,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
-"kot" = (
-/obj/structure/sign/poster/prewar/poster89,
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
+"knU" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "koC" = (
 /obj/structure/lattice{
 	layer = 3
@@ -10505,6 +12402,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"koJ" = (
+/mob/living/simple_animal/hostile/raider/biker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "kpd" = (
 /obj/structure/lattice{
 	layer = 3
@@ -10515,9 +12416,35 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "kpk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/turf/open/floor/f13/wood,
+/obj/structure/rack,
+/obj/item/advanced_crafting_components/receiver,
+/obj/item/advanced_crafting_components/receiver,
+/obj/item/advanced_crafting_components/receiver,
+/obj/item/advanced_crafting_components/lenses,
+/obj/item/advanced_crafting_components/lenses,
+/obj/item/advanced_crafting_components/lenses,
+/obj/item/advanced_crafting_components/flux,
+/obj/item/advanced_crafting_components/flux,
+/obj/item/advanced_crafting_components/flux,
+/obj/item/advanced_crafting_components/conductors,
+/obj/item/advanced_crafting_components/conductors,
+/obj/item/advanced_crafting_components/conductors,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/alloys,
+/obj/item/advanced_crafting_components/alloys,
+/obj/item/advanced_crafting_components/alloys,
+/obj/item/advanced_crafting_components/alloys,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/conductors,
+/obj/item/advanced_crafting_components/flux,
+/obj/item/advanced_crafting_components/lenses,
+/obj/item/advanced_crafting_components/receiver,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "kpo" = (
 /obj/machinery/light/small,
@@ -10529,6 +12456,12 @@
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"kqK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
 "kqS" = (
 /obj/effect/turf_decal/arrows/white,
 /obj/effect/decal/cleanable/dirt,
@@ -10536,14 +12469,27 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"krt" = (
+"kqY" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Oasis";
-	req_one_access_txt = "25"
-	},
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"krm" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"krt" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/f13/battlecoat,
+/obj/item/circuitboard/machine/autolathe/ammo,
+/obj/item/circuitboard/machine/autolathe/ammo,
+/obj/item/circuitboard/machine/autolathe/ammo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ksg" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -10551,14 +12497,18 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"kss" = (
-/obj/machinery/light{
-	dir = 4
-	},
+"ksw" = (
+/obj/structure/table,
+/obj/item/clothing/under/f13/enclave_officer,
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "redrustyfull"
 	},
-/area/f13/followers)
+/area/f13/bunker)
+"ksD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "ksU" = (
 /obj/structure/table{
 	layer = 2.9
@@ -10621,17 +12571,16 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"kvE" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "kvK" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "floor2-old"
-	},
-/turf/open/indestructible/ground/inside/subway,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "kvL" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/obj/structure/dresser,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "kvO" = (
@@ -10654,14 +12603,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"kwJ" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/followers)
 "kxd" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
@@ -10691,11 +12632,8 @@
 	},
 /area/f13/clinic)
 "kAp" = (
-/obj/structure/table/wood,
-/obj/item/chair/stool,
-/obj/item/chair/stool,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/structure/simple_door/metal/barred,
+/turf/open/water,
 /area/f13/tunnel)
 "kAR" = (
 /obj/structure/simple_door/fakeglass,
@@ -10727,9 +12665,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "kBD" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Aqua{
+	name = "light fixture"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "kCg" = (
 /obj/structure/table{
@@ -10768,14 +12708,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"kCx" = (
-/obj/structure/table/glass,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "kCz" = (
 /obj/structure/mirelurkegg{
 	anchored = 1
@@ -10791,14 +12723,11 @@
 	},
 /area/f13/tunnel)
 "kDS" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
+/obj/machinery/light/fo13colored/Aqua{
+	name = "light fixture"
 	},
-/mob/living/simple_animal/hostile/raider/firefighter,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "kEP" = (
 /obj/structure/lattice{
 	layer = 3
@@ -10816,12 +12745,9 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
 "kFg" = (
-/obj/effect/decal/waste,
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/bookcase,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "kFo" = (
 /obj/structure/chair/stool/bar,
@@ -10849,12 +12775,20 @@
 /obj/structure/sign/poster/prewar/poster89,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
+"kHi" = (
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "kHD" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "kIS" = (
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/mob/living/simple_animal/hostile/raider/ranged/legendary{
+	name = "John Doe"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -10862,21 +12796,33 @@
 "kIY" = (
 /obj/item/flashlight/flare/torch,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
+	icon_state = "housewood2"
 	},
 /area/f13/sewer)
+"kJI" = (
+/obj/machinery/computer/security{
+	dir = 4;
+	network = "vault"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"kJJ" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "kJW" = (
 /obj/structure/toilet{
 	pixel_y = 10
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/offices2nd)
-"kKB" = (
-/mob/living/simple_animal/hostile/raider/firefighter,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "kLA" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/blue,
@@ -10923,10 +12869,15 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "kPb" = (
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/water,
+/obj/structure/table/wood,
+/obj/item/storage/fancy/ammobox/beanbag,
+/obj/item/storage/fancy/ammobox/beanbag,
+/obj/item/storage/fancy/ammobox/beanbag,
+/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "kPE" = (
 /obj/structure/closet/secure_closet/personal,
@@ -10953,33 +12904,24 @@
 /obj/item/documents/syndicate/blue,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
-"kQO" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "kRu" = (
-/obj/effect/decal/cleanable/blood/gibs/torso,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"kRE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/prewar/poster69{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"kSa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 8;
-	name = "light fixture"
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Armory";
+	req_one_access_txt = "62"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/caves)
+/area/f13/tunnel)
+"kRE" = (
+/obj/structure/sign/poster/contraband/red_rum{
+	pixel_y = -32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"kSa" = (
+/obj/machinery/light,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "kSl" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -10987,12 +12929,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"kSn" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "kTF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
@@ -11001,10 +12937,14 @@
 	},
 /area/f13/tunnel)
 "kTJ" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Business"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/mattress,
 /turf/open/floor/f13/wood,
-/area/f13/caves)
+/area/f13/tunnel)
 "kTO" = (
 /obj/machinery/light{
 	dir = 4
@@ -11041,9 +12981,11 @@
 	},
 /area/f13/tunnel)
 "kVD" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "kVP" = (
 /obj/structure/sink{
@@ -11087,11 +13029,8 @@
 	},
 /area/f13/brotherhood/offices1st)
 "kWK" = (
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "topcellghoul"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "kXn" = (
 /obj/structure/camera_assembly{
@@ -11101,6 +13040,20 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"kXo" = (
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "kXA" = (
 /obj/structure/table{
 	layer = 2.9
@@ -11127,21 +13080,37 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"kZR" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
+"kYy" = (
+/obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"kZR" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
+"lah" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "laO" = (
 /obj/structure/falsewall/rust,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"laT" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/item/storage/fancy/candle_box,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "lbk" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -11161,10 +13130,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"lcn" = (
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+"lbN" = (
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
+"lcr" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "lcE" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -11174,6 +13148,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"lcG" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "ldi" = (
 /obj/structure/sign/poster/prewar/poster84,
 /turf/closed/wall/r_wall,
@@ -11205,22 +13184,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices1st)
-"ldY" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/followers)
 "ldZ" = (
-/obj/structure/girder,
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "house1ladder"
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "lea" = (
 /obj/structure/noticeboard{
@@ -11229,27 +13198,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
-"lec" = (
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/followers)
 "lev" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "leG" = (
 /obj/structure/table{
@@ -11263,6 +13217,10 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"leM" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/tunnel)
 "leT" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cloth/ten,
@@ -11271,6 +13229,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
+"lfb" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/toy/figure/detective{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "lfw" = (
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11281,6 +13247,13 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
+"lgn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
 "lgv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/paladin,
@@ -11295,6 +13268,10 @@
 /obj/structure/sign/poster/prewar/poster85,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
+"lhg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "lhh" = (
 /obj/item/assembly/signaler{
 	code = 2;
@@ -11309,11 +13286,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"lhQ" = (
+"lhT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/mask/gas/enclave,
 /turf/open/floor/f13{
-	icon_state = "purplefull"
+	icon_state = "redrustyfull"
 	},
-/area/f13/followers)
+/area/f13/bunker)
 "liq" = (
 /obj/machinery/shower{
 	dir = 8
@@ -11324,6 +13303,11 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"liB" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "liD" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/light{
@@ -11356,16 +13340,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"ljj" = (
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/brute,
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/ancient,
-/obj/item/storage/firstaid/ancient,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "ljD" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11374,6 +13348,14 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
+"ljX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/armor/f13/power_armor/t45b/restored,
+/turf/open/floor/f13{
+	dir = 8;
+	icon_state = "bluemark"
+	},
+/area/f13/bunker)
 "ljY" = (
 /obj/structure/handrail/g_end{
 	pixel_x = 12;
@@ -11383,7 +13365,7 @@
 /area/f13/tunnel)
 "lkt" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 9
+	dir = 6
 	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
@@ -11397,13 +13379,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"llv" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "llQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -11412,7 +13387,17 @@
 	},
 /area/f13/brotherhood/operations)
 "llV" = (
-/obj/machinery/workbench/advanced,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "llW" = (
@@ -11445,17 +13430,37 @@
 "lnr" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"lnt" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "lnL" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
 "loc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"loe" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "lof" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -11478,6 +13483,20 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"loO" = (
+/obj/structure/frame/machine,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
+"lpa" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/indestructible/cobble{
+	desc = "An assortment of broken and battered bricks, stones, rebar, and dust.";
+	name = "rubble"
+	},
+/area/f13/bunker)
 "lpd" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -11488,6 +13507,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"lps" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/mob/living/simple_animal/hostile/raider/legendary,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "lpK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker{
@@ -11499,6 +13523,10 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"lqy" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lqC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -11514,6 +13542,10 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"lrt" = (
+/mob/living/simple_animal/hostile/deathclaw,
+/turf/open/water,
+/area/f13/caves)
 "lrP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11523,10 +13555,55 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"lsk" = (
+/obj/structure/rack,
+/obj/item/camera,
+/obj/item/camera_film,
+/obj/item/crafting/abraxo,
+/obj/item/crafting/sensor,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/radio,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"lsl" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"lsn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "lsy" = (
 /obj/structure/sign/poster/prewar/poster88,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
+"lsJ" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/obj/machinery/power/apc,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "lsW" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -11544,6 +13621,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"lue" = (
+/obj/item/storage/trash_stack,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"luy" = (
+/obj/item/wrench/crude,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "lvr" = (
 /obj/structure/table/optable/abductor,
 /obj/item/restraints/handcuffs,
@@ -11562,6 +13648,13 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"lvL" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/machinery/pdapainter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "lvT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -11569,16 +13662,12 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
-"lwc" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowleft";
-	layer = 2
-	},
+"lws" = (
+/obj/machinery/light/small,
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "bluedirtyfull"
 	},
-/area/f13/followers)
+/area/f13/bunker)
 "lwz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/f13foldupchair,
@@ -11595,6 +13684,16 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"lyc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "lyh" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11619,16 +13718,24 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"lzW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	desc = "A lighting fixture.";
-	dir = 1;
-	light_color = "#008000";
-	name = "light tube"
+"lzR" = (
+/obj/machinery/light/broken{
+	dir = 8
 	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"lzW" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"lAm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lAr" = (
 /obj/item/trash/f13/dog,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -11642,15 +13749,11 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"lAR" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder/constructed,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "lAW" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/tools{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lBb" = (
@@ -11666,6 +13769,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"lBR" = (
+/mob/living/simple_animal/hostile/handy/sentrybot,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "lBX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
@@ -11675,6 +13784,10 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"lCd" = (
+/obj/machinery/smartfridge/bottlerack,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "lCK" = (
 /obj/structure/table{
 	layer = 2.9
@@ -11704,6 +13817,10 @@
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
+"lDm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "lDx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/paladin,
@@ -11736,6 +13853,25 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"lED" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/storage/box/matches,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"lGe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"lGl" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "lGo" = (
 /obj/structure/table/optable,
 /obj/machinery/iv_drip{
@@ -11746,6 +13882,44 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"lGG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"lGO" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"lHn" = (
+/obj/structure/decoration/clock,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"lHu" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper/crumpled/bloody/docsdeathnote{
+	info = "Initial tests of the modified FEV on our subjects is promising, with an increase in strength and indurance and no notable decrease in intelligence. Further testin is require for now, however, and tests with the soldiers can begin soon...."
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
+"lIw" = (
+/obj/structure/sign/poster/contraband/pinup_topless{
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "lIx" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -11762,28 +13936,47 @@
 /obj/structure/sign/poster/prewar/poster86,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
+"lJa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/handrail/g_central{
+	layer = 2.7;
+	pixel_y = -16
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "lKh" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "lKk" = (
-/obj/item/flashlight/flare,
+/obj/effect/decal/cleanable/blood/splats,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"lKF" = (
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "lKT" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "133"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "clinicstorage";
-	name = "storage shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/simple_door/metal/barred,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"lKW" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"lLh" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/caves)
 "lLA" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -11830,6 +14023,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"lMI" = (
+/mob/living/simple_animal/hostile/trog/tunneler,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lMT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -11840,12 +14037,25 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"lOt" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6"
+"lOo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/bunker)
+"lOq" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"lOt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/tunnel)
 "lOJ" = (
 /obj/structure/sign/poster/contraband/pinup_pink{
 	pixel_y = -32
@@ -11873,10 +14083,11 @@
 	},
 /area/f13/tunnel)
 "lPs" = (
-/obj/structure/sign/poster/contraband/pinup_funk{
-	pixel_y = -32
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = -6
 	},
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "lPt" = (
 /obj/structure/closet,
@@ -11928,22 +14139,21 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "lUq" = (
-/obj/structure/table/wood,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/f13Cash/random/med,
-/obj/item/megaphone,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "lUI" = (
-/obj/structure/barricade/bars{
-	layer = 3.5
-	},
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/mattress,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"lUJ" = (
+/obj/structure/junk/small/bed2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "lVj" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibmid3"
@@ -11951,20 +14161,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "lVr" = (
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/caves)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "lVt" = (
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"lWy" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "lXw" = (
 /obj/machinery/workbench/advanced,
 /obj/effect/turf_decal/stripes/box,
@@ -12003,6 +14209,12 @@
 	icon_state = "r_wall"
 	},
 /area/f13/brotherhood/offices2nd)
+"lYf" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "lYu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -12019,18 +14231,16 @@
 /turf/open/water,
 /area/f13/tunnel)
 "lYE" = (
-/obj/structure/barricade/sandbags,
-/turf/open/water,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lYM" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"lYZ" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "lZb" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/brown,
@@ -12060,23 +14270,37 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"max" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"maE" = (
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/f13/bunker)
 "mba" = (
-/obj/structure/rack,
-/obj/item/twohanded/sledgehammer,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"mbC" = (
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/obj/item/book/granter/trait/trekking,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mbT" = (
 /obj/item/trash/f13/porknbeans,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mbX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/barred,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "mcC" = (
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/fancy/candle_box,
@@ -12085,6 +14309,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/medical)
+"mcH" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
 "mdv" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
@@ -12097,12 +14328,33 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/sewer)
+"mfb" = (
+/mob/living/simple_animal/hostile/handy/sentrybot/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"mfi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mfC" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
+"mgg" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"mgu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "mgx" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
@@ -12111,6 +14363,11 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
+"mgQ" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "mhc" = (
 /turf/closed/indestructible/opshuttle{
 	icon = 'icons/turf/walls/reinforced_wall.dmi';
@@ -12126,22 +14383,12 @@
 	},
 /area/f13/ncr)
 "miw" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/item/storage/fancy/candle_box,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
-/turf/open/floor/f13/wood,
+/obj/structure/ore_box,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "miy" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Prospector Entrance";
-	req_one_access_txt = "48"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "prospector1open"
-	},
+/obj/structure/ore_box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "miI" = (
@@ -12155,6 +14402,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mjq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "mjz" = (
 /obj/item/clothing/under/f13/brahmin,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12167,6 +14420,10 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"mjS" = (
+/mob/living/simple_animal/hostile/handy/securitron/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "mko" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -12195,14 +14452,6 @@
 "mkY" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/sewer)
-"mln" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "mlz" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12229,29 +14478,19 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"mlW" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "mmv" = (
 /obj/machinery/door/airlock/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
-"mmL" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
-"mng" = (
-/obj/structure/sink{
-	pixel_y = 19
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/followers)
 "mnk" = (
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/f13{
@@ -12259,9 +14498,11 @@
 	},
 /area/f13/clinic)
 "mot" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "mpn" = (
 /obj/structure/table{
 	layer = 2.9
@@ -12280,6 +14521,13 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"mqi" = (
+/obj/structure/junk/small/bed2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "mql" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -12290,6 +14538,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"mqF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "mqJ" = (
 /obj/effect/landmark/start/f13/seniorscribe,
 /obj/structure/chair/office/dark{
@@ -12330,6 +14585,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"mtA" = (
+/obj/structure/junk/small/bed,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "mui" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -12431,8 +14691,12 @@
 	},
 /area/f13/tunnel)
 "mzR" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "prospectorladder"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "mzX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12454,9 +14718,11 @@
 	},
 /area/f13/brotherhood/reactor)
 "mAa" = (
-/obj/structure/simple_door/metal/barred,
-/obj/structure/simple_door/metal/barred,
-/turf/open/water,
+/obj/machinery/light/fo13colored/Aqua{
+	name = "light fixture"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "mAc" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -12466,6 +14732,15 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"mAf" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/machinery/door/poddoor{
+	id = "hate"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "mAn" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -12493,9 +14768,10 @@
 	},
 /area/f13/brotherhood/reactor)
 "mBn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/flashlight/lamp,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "mBu" = (
 /obj/structure/closet/crate,
@@ -12522,20 +14798,18 @@
 "mDq" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
-"mDK" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "mDR" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/clinic)
+"mDZ" = (
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "mEf" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -12599,16 +14873,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"mFW" = (
+"mGf" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "stagestairs"
+	icon_state = "bluerustyfull"
 	},
-/area/f13/followers)
+/area/f13/bunker)
 "mGg" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "mGH" = (
 /obj/structure/dresser,
@@ -12616,6 +14890,19 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
+"mGY" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"mHc" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "mHj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bookcase/manuals/engineering,
@@ -12641,12 +14928,21 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "mHM" = (
-/obj/machinery/autolathe/ammo/unlocked,
-/obj/item/book/granter/crafting_recipe/gunsmith_two,
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
-/obj/item/book/granter/crafting_recipe/gunsmith_one,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/toolbox/drone,
+/obj/item/storage/toolbox/drone,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"mHW" = (
+/obj/structure/table,
+/obj/item/gun/energy/laser/plasma/glock,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "mIj" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -12656,6 +14952,23 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
+"mIx" = (
+/obj/structure/table,
+/obj/item/storage/backpack/enclave{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/storage/backpack/enclave{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "mII" = (
 /obj/structure/flora/junglebush/c,
 /turf/closed/mineral/random/low_chance,
@@ -12668,12 +14981,26 @@
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"mKh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
+"mKg" = (
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"mKh" = (
+/obj/structure/closet/crate/large,
+/obj/structure/closet/crate/large,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"mKm" = (
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "mKE" = (
 /obj/structure/cable{
@@ -12685,23 +15012,25 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
+"mKS" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/wall/f13/ruins,
+/area/f13/bunker)
 "mKY" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"mLa" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/biker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mLh" = (
 /mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"mLL" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/pillbottles,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "mLN" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -12728,31 +15057,30 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mMd" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "mMC" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"mNc" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "mNE" = (
 /obj/structure/barricade/bars,
 /turf/open/water,
 /area/f13/tunnel)
-"mNF" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/followers)
-"mNM" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = -3
-	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/followers)
 "mOm" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood{
@@ -12779,6 +15107,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/leisure)
+"mPK" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"mQO" = (
+/turf/open/water,
+/area/f13/bunker)
 "mQX" = (
 /obj/effect/spawner/lootdrop/trash,
 /mob/living/simple_animal/hostile/gecko,
@@ -12828,13 +15163,21 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
+"mSj" = (
+/obj/effect/decal/remains/human,
+/obj/effect/gibspawner/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
+"mSo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "mSs" = (
 /obj/structure/table,
-/obj/item/roller,
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
+/obj/item/book/granter/trait/chemistry,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -12848,7 +15191,8 @@
 /turf/open/water,
 /area/f13/caves)
 "mTq" = (
-/turf/closed/wall/f13/wood/house,
+/obj/structure/campfire,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "mTr" = (
 /obj/machinery/door/window/northright,
@@ -12869,6 +15213,20 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
+"mTN" = (
+/obj/machinery/door/poddoor{
+	name = "bunker door"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
+	},
+/area/f13/tunnel)
+"mTO" = (
+/turf/closed/indestructible/fakedoor{
+	desc = "An indestructible door. Hm.";
+	name = "Strong Door"
+	},
+/area/f13/bunker)
 "mUb" = (
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
@@ -12879,6 +15237,32 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
+/area/f13/tunnel)
+"mUw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/tunnel)
+"mVa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/tunnel)
+"mVo" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"mVr" = (
+/obj/structure/junk/small/bed2,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"mVU" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "mWD" = (
 /obj/structure/cable{
@@ -12925,12 +15309,29 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
-"mYV" = (
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+"mYN" = (
+/obj/item/clothing/head/helmet/f13/power_armor/t45b,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	dir = 10;
+	icon_state = "redmark"
 	},
 /area/f13/bunker)
+"mYV" = (
+/obj/machinery/workbench,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "mZq" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/machinery/light/small{
@@ -12939,12 +15340,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"mZH" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/followers)
 "mZU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -12952,36 +15347,73 @@
 	},
 /area/f13/tunnel)
 "naY" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Bar Backroom";
-	req_one_access_txt = "25"
-	},
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/item/stack/sheet/hay/fifty,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"nbx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "nbz" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/tunnel)
+"nbC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "ncx" = (
-/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"ncK" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"ncQ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/ore_box,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ndi" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/closed/wall/r_wall,
-/area/f13/tunnel)
-"ndk" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
+/obj/effect/landmark/start/f13/prospector,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"ndk" = (
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Oasis";
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "ndn" = (
 /obj/effect/decal/cleanable/dirt{
@@ -12995,6 +15427,11 @@
 "ndp" = (
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
+"ndr" = (
+/obj/structure/simple_door/wood,
+/obj/structure/barricade/wooden/planks,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "neu" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/outside/water,
@@ -13013,6 +15450,21 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
+"nfo" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"nfv" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "nfz" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -13027,9 +15479,10 @@
 	},
 /area/f13/tunnel)
 "nfM" = (
-/obj/structure/sign/poster/ripped{
-	pixel_x = 32
+/obj/structure/handrail/g_central{
+	pixel_y = -16
 	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nfW" = (
@@ -13040,16 +15493,28 @@
 	dir = 8
 	},
 /area/f13/tcoms)
+"ngv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/shotgun/improvised,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "ngP" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/hos,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "nha" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/box/white,
+/obj/structure/closet/crate/large,
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"nhq" = (
+/obj/machinery/door/airlock/grunge,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "nhE" = (
 /turf/open/floor/f13{
 	icon_state = "redmark"
@@ -13062,19 +15527,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "nhK" = (
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 1;
-	name = "light fixture"
-	},
+/obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"nhY" = (
-/obj/effect/landmark/start/f13/followersvolunteer,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "nim" = (
 /obj/structure/bed,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -13102,18 +15558,16 @@
 	},
 /area/f13/bunker)
 "njZ" = (
-/obj/machinery/autolathe,
-/turf/open/floor/f13/wood,
+/obj/machinery/light/fo13colored/Pink{
+	dir = 4;
+	name = "light tube"
+	},
+/obj/structure/wreck/trash/five_tires{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"nkf" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "nld" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13133,6 +15587,16 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"nmn" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"nmo" = (
+/obj/structure/glowshroom/single,
+/turf/open/water,
+/area/f13/caves)
 "nmE" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -13143,16 +15607,34 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"nmN" = (
+/turf/closed/wall/f13/supermart,
+/area/f13/tunnel)
+"nnn" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/f13{
+	dir = 8;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
 "nnx" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "nnz" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "clinicoutsideladder"
 	},
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"nnL" = (
+/obj/effect/landmark/start/f13/settler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nnN" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -13174,6 +15656,25 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"nof" = (
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"nox" = (
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "noI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13209,11 +15710,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "nqA" = (
-/obj/structure/barricade/bars,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/prospector,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nqE" = (
@@ -13235,24 +15732,25 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "nqV" = (
-/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "nrO" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "floor5-old"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "nsa" = (
-/obj/effect/decal/cleanable/generic,
+/obj/structure/sign/poster/contraband/pinup_pink{
+	pixel_y = 32
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/area/f13/tunnel)
+"nss" = (
+/mob/living/simple_animal/hostile/raider/legendary,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "nsw" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13{
@@ -13277,8 +15775,8 @@
 	},
 /area/f13/brotherhood/reactor)
 "nue" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/water,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nuy" = (
 /obj/machinery/light/small{
@@ -13303,6 +15801,15 @@
 	},
 /turf/closed/wall/f13/store,
 /area/f13/ncr)
+"nvn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul,
+/obj/item/pizzabox/meat,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "nvC" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -13325,6 +15832,13 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
+"nvT" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/abomhorror/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "nwf" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt,
@@ -13353,8 +15867,16 @@
 	},
 /area/f13/brotherhood/rnd)
 "nxH" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/indestructible/ground/inside/subway,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "prospector1open";
+	name = "gate shutters";
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nxT" = (
 /obj/structure/fence/handrail{
@@ -13367,6 +15889,17 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
+"nyb" = (
+/mob/living/simple_animal/hostile/handy/protectron/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"nyt" = (
+/obj/item/fusion_fuel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "nzl" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -13412,9 +15945,10 @@
 /obj/structure/timeddoor,
 /turf/closed/mineral/random/low_chance,
 /area/f13/tunnel)
-"nAJ" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/followers)
+"nAM" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "nAV" = (
 /obj/machinery/light{
 	dir = 1
@@ -13451,6 +15985,11 @@
 "nBk" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"nBr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/blackbox_recorder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "nBL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
@@ -13462,12 +16001,15 @@
 	name = "pool water"
 	},
 /area/f13/brotherhood/leisure)
-"nCD" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
+"nCS" = (
+/obj/machinery/computer/rdconsole{
+	dir = 4
 	},
-/area/f13/followers)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "nDb" = (
 /obj/structure/table/abductor{
 	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
@@ -13482,8 +16024,15 @@
 	},
 /turf/closed/indestructible/f13/matrix,
 /area/f13/ncr)
+"nEo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "nEr" = (
-/turf/open/indestructible/ground/inside/dirt,
+/obj/item/flag/oasis,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "nEt" = (
 /obj/effect/decal/cleanable/dirt{
@@ -13498,11 +16047,17 @@
 	},
 /area/f13/brotherhood/mining)
 "nEz" = (
-/obj/structure/campfire/barrel,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/glasses/sunglasses{
+	anchored = 1;
+	pixel_y = 26
 	},
-/area/f13/bunker)
+/obj/item/clothing/head/fedora/det_hat{
+	anchored = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "nEC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -13512,6 +16067,16 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"nEH" = (
+/obj/item/storage/trash_stack{
+	layer = 2
+	},
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 1;
+	name = "light fixture"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "nFr" = (
 /obj/structure/toilet{
 	dir = 4
@@ -13536,6 +16101,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"nGx" = (
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "nGN" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -13544,6 +16113,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"nHa" = (
+/obj/structure/junk/small/bed2,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "nHN" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -13581,20 +16156,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "nIP" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/bunker)
-"nJB" = (
-/obj/machinery/light/fo13colored/Pink{
-	name = "light tube"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"nJB" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nJV" = (
@@ -13615,13 +16183,29 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
+"nKL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"nKX" = (
+/obj/item/chair,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "nKZ" = (
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "nLK" = (
+/obj/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/flashlight/lamp,
+/obj/effect/decal/cleanable/chem_pile{
+	pixel_x = -12;
+	pixel_y = 10
+	},
+/obj/structure/sign/poster/prewar/poster92{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nLM" = (
@@ -13635,12 +16219,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
-"nMh" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "nMv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -13717,10 +16295,20 @@
 	},
 /area/f13/brotherhood/leisure)
 "nNR" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/autolathe,
+/obj/machinery/chem_heater,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"nOw" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/f13{
+	dir = 6;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
 "nOW" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -13757,16 +16345,13 @@
 /obj/structure/foamedmetal,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"nRh" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "nRP" = (
-/obj/structure/sink{
-	pixel_y = 19
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nSe" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -13806,17 +16391,9 @@
 	},
 /area/f13/brotherhood/rnd)
 "nTt" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/stack/f13Cash/random/med,
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 4;
-	light_color = "#800080";
-	name = "light fixture"
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nTN" = (
@@ -13832,6 +16409,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/offices2nd)
+"nTY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/deathclaw,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"nUx" = (
+/obj/structure/junk/small/bed2,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "nUF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -13905,6 +16493,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"nWY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nXj" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -13988,11 +16581,54 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"nZI" = (
-/obj/structure/girder,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+"nZb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"nZt" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = -7;
+	pixel_y = 5
 	},
+/obj/item/shard{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"nZu" = (
+/obj/structure/reagent_dispensers/barrel/three{
+	pixel_x = -14
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/caves)
+"nZI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Oasis";
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"nZZ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/mutagen,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/granter/trait/pa_wear,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/f13/bunker)
+"oaG" = (
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "oaW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14003,6 +16639,17 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/reactor)
+"obu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"obT" = (
+/obj/machinery/mineral/ore_redemption,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "obV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/bos{
@@ -14016,15 +16663,26 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/reactor)
+"ocI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "odj" = (
 /obj/structure/ore_box,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "odk" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_north"
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Prospector Entrance";
+	req_one_access_txt = "48"
 	},
-/turf/open/floor/f13/wood,
+/obj/machinery/door/poddoor/shutters{
+	id = "prospector1open"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "odq" = (
 /obj/structure/ladder/unbreakable{
@@ -14115,12 +16773,19 @@
 /obj/item/am_shielding_container,
 /turf/open/floor/plating,
 /area/f13/brotherhood/reactor)
+"ogz" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/item/wallframe/camera,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "ohv" = (
-/obj/structure/rack,
-/obj/item/ammo_box/a308,
-/obj/item/ammo_box/a308,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/ballistic/automatic/marksman/sniper,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "busladder"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "ohO" = (
@@ -14143,15 +16808,18 @@
 	},
 /area/f13/brotherhood/reactor)
 "oiy" = (
-/obj/item/storage/trash_stack,
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Oasis";
+	req_one_access_txt = "25"
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"ojq" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "okm" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/junglebush/b,
@@ -14175,14 +16843,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/enclave)
-"olw" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/followers)
 "olK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14217,10 +16877,18 @@
 	},
 /area/f13/brotherhood/rnd)
 "omq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/book/manual/wiki/cit/chemistry,
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/circuitry,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/glass/beaker/plastic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "omL" = (
@@ -14229,6 +16897,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"omU" = (
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "onL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14238,6 +16910,13 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"onS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/caves)
 "onY" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -14287,24 +16966,18 @@
 	},
 /area/f13/tunnel)
 "org" = (
-/obj/machinery/light/fo13colored/Pink{
-	dir = 4;
-	name = "light tube"
-	},
-/obj/structure/wreck/trash/five_tires{
-	layer = 3
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
-"oro" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowbottom"
+/obj/effect/decal/cleanable/chem_pile{
+	pixel_x = -19
 	},
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/f13/followersadministrator,
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "floordirtysolid"
 	},
-/area/f13/followers)
+/area/f13/tunnel)
 "orp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -14351,12 +17024,41 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"otk" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "otF" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"otJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder/reinforced,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"ouh" = (
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ouq" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -14366,11 +17068,8 @@
 	},
 /area/f13/enclave)
 "ouz" = (
-/obj/structure/sign/poster/contraband/pinup_pink{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/f13/supermart,
 /area/f13/tunnel)
 "ovr" = (
 /obj/structure/ladder/unbreakable{
@@ -14379,6 +17078,12 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"ovF" = (
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "ovL" = (
 /obj/structure/simple_door/bunker{
 	name = "Washroom/Dorms"
@@ -14391,22 +17096,6 @@
 /obj/structure/flora/junglebush,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"ovY" = (
-/obj/structure/closet{
-	name = "implants locker"
-	},
-/obj/item/organ/cyberimp/chest/nutriment,
-/obj/item/organ/cyberimp/chest/nutriment,
-/obj/item/organ/cyberimp/chest/nutriment,
-/obj/item/organ/cyberimp/chest/nutriment/plus,
-/obj/item/organ/cyberimp/eyes/hud/medical,
-/obj/item/organ/cyberimp/eyes/hud/medical,
-/obj/item/organ/cyberimp/eyes/hud/medical,
-/obj/item/organ/cyberimp/eyes/hud/medical,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "owa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -14437,6 +17126,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
+"oxm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/item/book/granter/trait/trekking,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "oxw" = (
 /obj/structure/table/wood/fancy/blackred,
 /obj/item/candle{
@@ -14462,10 +17160,19 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"oyo" = (
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "oyr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/turf/open/floor/f13/wood,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Private Bar"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "oyG" = (
 /obj/structure/simple_door/room,
@@ -14473,34 +17180,44 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"ozm" = (
-/obj/structure/sign/poster/prewar/poster92,
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
 "ozp" = (
+/obj/structure/billboard/cola/pristine,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/folder/white,
-/obj/item/folder/white,
-/obj/item/folder/white,
-/obj/item/folder/white,
-/obj/item/flashlight/pen,
-/obj/item/flashlight/pen,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ozN" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "prospector3open"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/water,
+/obj/structure/girder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"oAe" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/landmark/start/f13/prospector,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"oAm" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "oAt" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"oBa" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
+"oBz" = (
+/obj/structure/junk/small/bed2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "oBJ" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -14534,6 +17251,25 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"oDN" = (
+/mob/living/simple_animal/hostile/raider/tribal,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"oDY" = (
+/obj/structure/barricade/wooden,
+/obj/item/pickaxe{
+	anchored = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"oEi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/wasteplant/wild_fungus,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "oEt" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/spacevine{
@@ -14541,6 +17277,11 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"oEw" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "oEC" = (
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/f13{
@@ -14570,18 +17311,18 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"oFg" = (
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
 "oFh" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
-"oFi" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = -6
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"oFi" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "oFr" = (
@@ -14604,6 +17345,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
+"oGk" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "oGA" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -14637,12 +17384,11 @@
 	},
 /area/f13/brotherhood/mining)
 "oIo" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Pink{
+	dir = 4;
+	name = "light tube"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "oIJ" = (
@@ -14666,14 +17412,40 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "oJc" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/water,
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"oKH" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"oLu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"oLG" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/storage/box/strange_seeds_10pack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "oMb" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibleg"
@@ -14712,23 +17484,34 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"oOh" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"oOm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/obj/item/fermichem/pHmeter,
+/obj/item/storage/bag/chemistry,
+/obj/item/fermichem/pHmeter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "oOE" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"oOO" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "oOR" = (
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden{
-	layer = 2.5
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/effect/landmark/start/f13/followersdoctor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "oPp" = (
 /obj/structure/simple_door/metal/dirtystore,
@@ -14753,13 +17536,15 @@
 /turf/open/floor/carpet/red,
 /area/f13/brotherhood/offices2nd)
 "oQa" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/landmark/start/f13/prospector,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/followersvolunteer,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"oQd" = (
+/obj/machinery/door/poddoor{
+	id = "pain"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "oQf" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -14793,10 +17578,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "oRb" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/f13/wood,
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "133"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "oRZ" = (
 /obj/effect/decal/cleanable/dirt{
@@ -14823,6 +17609,12 @@
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"oSG" = (
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "oSZ" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
@@ -14832,6 +17624,18 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"oTR" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore";
+	tag = "icon-gibbearcore"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"oUg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "oUK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -14842,6 +17646,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
+"oUM" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/water,
+/area/f13/bunker)
 "oUO" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13{
@@ -14860,11 +17668,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"oVe" = (
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/followers)
 "oVh" = (
 /turf/closed/wall/r_wall/f13composite{
 	icon_state = "rubblepillar"
@@ -14932,23 +17735,12 @@
 	},
 /area/f13/enclave)
 "oXs" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/structure/bodycontainer/morgue{
+	dir = 8
 	},
-/obj/item/storage/box/matches,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"oXu" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/followers)
 "oXD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/wallmed{
@@ -14979,36 +17771,25 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
-"oZF" = (
+"oZe" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"oZF" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
-	name = "Bar Backroom";
+	name = "Oasis Housing";
 	req_one_access_txt = "25"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"oZJ" = (
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "pab" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/prewar,
-/obj/item/stack/sheet/prewar,
-/obj/item/stack/sheet/prewar,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/poster/contraband/revolver{
+	pixel_y = 32
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "paF" = (
 /obj/machinery/door/airlock/grunge{
@@ -15037,6 +17818,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"pbp" = (
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "pbr" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/decal/cleanable/dirt,
@@ -15044,10 +17830,27 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"pbu" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/handy/protectron/nsb,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"pcK" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/mutagen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/f13/bunker)
 "pdh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/workbench/forge,
-/turf/open/floor/f13/wood,
+/obj/structure/sign/poster/contraband/pinup_shower{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "pdz" = (
 /obj/effect/decal/cleanable/dirt{
@@ -15076,6 +17879,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
+"pdV" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "pez" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -15126,12 +17936,21 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"phA" = (
-/obj/structure/simple_door/bunker,
-/obj/structure/timeddoor,
+"pho" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"phq" = (
+/obj/effect/decal/remains/human,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
+/area/f13/bunker)
+"phA" = (
+/obj/structure/sign/warning,
+/obj/structure/timeddoor,
+/turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "phB" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -15146,11 +17965,21 @@
 	},
 /area/f13/tunnel)
 "phP" = (
+/obj/structure/chair/stool/retro,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"pip" = (
+/obj/structure/table/snooker{
+	dir = 6
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/item/dice{
+	pixel_x = 13;
+	pixel_y = -7
+	},
+/obj/item/dice,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "pis" = (
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
@@ -15177,17 +18006,31 @@
 	},
 /area/f13/brotherhood/mining)
 "pjj" = (
-/obj/structure/chair/office{
-	dir = 8
+/obj/structure/table/snooker{
+	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"pkL" = (
-/obj/effect/decal/cleanable/blood/old,
-/mob/living/simple_animal/hostile/raider/ranged,
+"pkv" = (
+/mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"pkH" = (
+/obj/structure/chair/stool/retro,
+/obj/item/instrument/guitar{
+	anchored = 1;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"pkL" = (
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "pkW" = (
@@ -15206,6 +18049,15 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"plF" = (
+/obj/structure/girder,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/tunnel)
 "plQ" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15218,12 +18070,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "pmU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/pinup_shower{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/radscorpion/black,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pmV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
@@ -15245,12 +18094,19 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
+"pnI" = (
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/caves)
 "pnL" = (
-/obj/structure/curtain{
-	open = 0
+/obj/effect/decal/waste{
+	icon_state = "goo5"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "pnV" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/fifty,
@@ -15280,10 +18136,12 @@
 /obj/structure/barricade/wooden/planks,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/tunnel)
-"poI" = (
-/obj/item/mining_scanner,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+"poJ" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "ppt" = (
 /obj/structure/lattice{
 	layer = 3
@@ -15296,14 +18154,6 @@
 	name = "floor"
 	},
 /area/f13/brotherhood/rnd)
-"ppv" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "pqi" = (
 /obj/structure/fluff/railing,
 /obj/structure/lattice{
@@ -15319,6 +18169,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"pqz" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
 "pqV" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -15374,10 +18231,7 @@
 	},
 /area/f13/tunnel)
 "ptQ" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibup1"
-	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -15420,16 +18274,13 @@
 	},
 /area/f13/bunker)
 "pvI" = (
-/obj/structure/chair/bench,
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/flashlight/lantern,
+/obj/item/mining_scanner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"pvV" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/followers)
 "pwH" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -15437,6 +18288,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"pwR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "pwY" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15466,11 +18324,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"pzu" = (
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/followers)
 "pzw" = (
 /obj/structure/table{
 	layer = 2.9
@@ -15521,11 +18374,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"pAI" = (
+/obj/item/pickaxe/mini,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
 "pAK" = (
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/mob/living/simple_animal/hostile/raider/ranged/boss,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "pBe" = (
@@ -15550,13 +18406,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "pCn" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	desc = "There is something on the wind. It.. it smells like... crime.";
-	name = "Detective Office";
-	req_one_access_txt = "4"
-	},
-/turf/open/floor/f13/wood,
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/flashlight/lantern,
+/obj/item/mining_scanner,
+/obj/item/pickaxe/drill,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "pDM" = (
 /obj/structure/flora/junglebush,
@@ -15573,7 +18429,7 @@
 	},
 /area/f13/brotherhood/mining)
 "pEF" = (
-/obj/item/instrument/piano_synth,
+/obj/item/instrument/harmonica,
 /obj/structure/rack,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
@@ -15587,6 +18443,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
+"pFb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "pFn" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/decal/cleanable/dirt,
@@ -15595,10 +18458,12 @@
 	},
 /area/f13/brotherhood/mining)
 "pGw" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "133"
-	},
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/flashlight/lantern,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "pHv" = (
@@ -15675,9 +18540,26 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "pMg" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/button/door{
+	id = "prospector3open";
+	name = "gate shutters";
+	pixel_x = 32
+	},
+/turf/open/water,
 /area/f13/tunnel)
+"pMj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/item/toy/plush/mr_buckety,
+/obj/item/reagent_containers/glass/bucket,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pMM" = (
 /obj/structure/table/optable/abductor,
 /obj/item/restraints/handcuffs,
@@ -15707,11 +18589,39 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"pOm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "pOB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
+/obj/structure/closet/crate/miningcar,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"pPj" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"pPr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/water,
+/area/f13/bunker)
+"pPs" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pPS" = (
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/glass/fifty,
@@ -15799,6 +18709,15 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"pVW" = (
+/obj/structure/closet/crate/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "pWc" = (
 /obj/machinery/light/sign{
 	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
@@ -15860,10 +18779,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
-"pXC" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plating/f13,
-/area/f13/followers)
 "pYd" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/rust,
@@ -15880,25 +18795,25 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "pYA" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/closet,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/storage/belt/medical,
+/obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"pZr" = (
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"pZt" = (
-/obj/structure/table,
+"pYE" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "redrustyfull"
 	},
-/area/f13/followers)
+/area/f13/bunker)
+"pZm" = (
+/obj/structure/girder/reinforced,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"pZr" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/f13/ruins,
+/area/f13/tunnel)
 "qaX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/handrail/g_central{
@@ -15907,6 +18822,16 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
+"qbi" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "qbZ" = (
 /obj/structure/rack,
 /obj/item/electropack/shockcollar{
@@ -15922,6 +18847,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"qcb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/mob_spawn/human/corpse/raider/tribal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "qci" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile/house{
@@ -15940,9 +18871,9 @@
 	},
 /area/f13/tunnel)
 "qcp" = (
-/obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qdj" = (
 /obj/structure/table/wood/fancy/black,
@@ -15955,9 +18886,8 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "qdZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/girder/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/landmark/start/f13/settler,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "qeh" = (
 /obj/structure/table{
@@ -15993,12 +18923,13 @@
 	},
 /area/f13/brotherhood/mining)
 "qez" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qeH" = (
@@ -16027,6 +18958,21 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"qfA" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "qfB" = (
 /obj/machinery/rnd/production/protolathe,
 /obj/effect/decal/cleanable/dirt,
@@ -16053,14 +18999,14 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "qgP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/dresser,
-/turf/open/floor/f13/wood,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qhk" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/followersscientist,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "qhm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -16080,23 +19026,12 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
-"qhB" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 8
-	},
+"qiA" = (
+/obj/machinery/door/window,
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "reddirtyfull"
 	},
-/area/f13/followers)
-"qhW" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
+/area/f13/bunker)
 "qiH" = (
 /obj/item/trash/f13/fancylads,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16105,27 +19040,22 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"qjd" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/followers)
 "qjs" = (
-/obj/machinery/button/door{
-	id = "oasisstorage";
-	name = "Oasis Storage Button";
-	pixel_x = 32;
-	req_one_access_txt = "62"
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/structure/closet,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/storage/belt/medical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "qju" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/machinery/light{
+	dir = 8
 	},
-/area/f13/bunker)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "qjT" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16146,11 +19076,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "qmV" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "house1ladder"
-	},
-/turf/open/floor/f13/wood,
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/generic,
+/obj/structure/curtain,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qmZ" = (
 /obj/structure/bookcase/random/reference,
@@ -16178,13 +19107,6 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"qoB" = (
-/obj/effect/landmark/start/f13/followersdoctor,
-/obj/structure/chair/stool/f13stool,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "qoF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/camera_advanced/abductor{
@@ -16227,31 +19149,32 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "qpe" = (
-/obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
 "qpG" = (
+/obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 5
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "qpI" = (
-/obj/item/instrument/eguitar,
-/obj/structure/rack,
-/turf/open/floor/plasteel/floorgrime,
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qpX" = (
 /obj/structure/flora/rock/jungle,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "qpY" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table/snooker{
+	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qqm" = (
@@ -16274,6 +19197,12 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
+"qrc" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qrJ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -16287,6 +19216,13 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
+"qrK" = (
+/obj/structure/junk/small/bed2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "qsa" = (
 /obj/structure/flora/rock/jungle,
 /obj/structure/spacevine{
@@ -16294,6 +19230,16 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"qsg" = (
+/obj/structure/table/snooker{
+	dir = 9
+	},
+/obj/item/toy/cards/deck{
+	pixel_x = -11;
+	pixel_y = 15
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "qsm" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibup1"
@@ -16302,13 +19248,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"qsr" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/syringes,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "qsM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -16349,7 +19288,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/space/basic,
+/turf/open/floor/carpet/black,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "quB" = (
@@ -16362,6 +19301,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/medical)
+"quL" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "quR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/ore_box,
@@ -16370,16 +19318,9 @@
 	},
 /area/f13/brotherhood/mining)
 "qvI" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/barricade/wooden{
-	layer = 2.5
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qvX" = (
 /obj/effect/decal/remains/human,
@@ -16388,18 +19329,29 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"qwy" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "qwP" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/tunnel)
 "qwV" = (
-/obj/structure/sign/poster/contraband/pinup_topless{
-	pixel_x = 32
+/obj/machinery/door/poddoor/shutters{
+	id = "prospector3open"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
 /area/f13/tunnel)
 "qxo" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -16408,14 +19360,40 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
+"qxv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/item/autosurgeon,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/item/clothing/head/helmet/f13/power_armor/t45d{
+	color = "#C1C1C1";
+	desc = "(IX) It's an old pre-War power armor helmet. It's pretty hot inside of it. Nice.";
+	item_color = "#C1C1C1"
+	},
+/obj/item/defibrillator/compact/combat/loaded,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "qxO" = (
 /obj/machinery/telecomms/server/presets/ncr,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "qyc" = (
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Oasis";
+	req_one_access_txt = "25"
 	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "qys" = (
 /obj/structure/chair/comfy/shuttle{
@@ -16431,17 +19409,39 @@
 /area/f13/brotherhood/offices1st)
 "qyC" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/structure/bonfire,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"qyI" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Town Forge";
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "qyW" = (
-/obj/item/instrument/trombone,
-/obj/structure/rack,
-/obj/item/instrument/trumpet,
-/turf/open/floor/plasteel/floorgrime,
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "133"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "clinicstorage";
+	name = "storage shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qzG" = (
-/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/folder/white,
+/obj/item/folder/white,
+/obj/item/folder/white,
+/obj/item/folder/white,
+/obj/item/flashlight/pen,
+/obj/item/flashlight/pen,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qzI" = (
@@ -16456,10 +19456,16 @@
 /area/f13/tunnel)
 "qAK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe,
-/obj/item/stack/sheet/glass/fifty,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"qBn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "qBQ" = (
 /obj/effect/landmark/start/f13/elder,
 /obj/structure/chair/comfy/shuttle{
@@ -16477,23 +19483,16 @@
 /area/f13/tunnel)
 "qDo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/structure/closet,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "qDR" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"qEf" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/followers)
 "qEg" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16519,10 +19518,7 @@
 	},
 /area/f13/brotherhood/rnd)
 "qFn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/smoke{
-	pixel_x = -32
-	},
+/obj/structure/table/optable,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qFP" = (
@@ -16543,6 +19539,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"qFX" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "qGe" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/effect/decal/cleanable/dirt,
@@ -16576,10 +19579,18 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
+"qGS" = (
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "qHc" = (
-/obj/structure/flora/wasteplant/wild_fungus,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "qHd" = (
 /obj/structure/mopbucket,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -16594,6 +19605,15 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
+"qHx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "qHZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -16602,6 +19622,11 @@
 	icon_state = "neutralrusty"
 	},
 /area/f13/tunnel)
+"qIw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "qIB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fence/handrail{
@@ -16623,13 +19648,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
-"qJM" = (
+"qJL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/item/storage/box/bodybags,
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard/twenty,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"qJM" = (
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "qJQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains{
@@ -16640,11 +19670,9 @@
 	},
 /area/f13/tunnel)
 "qLf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/revolver{
-	pixel_y = 32
-	},
-/turf/open/floor/f13/wood,
+/obj/structure/barricade/wooden,
+/obj/structure/curtain,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qLo" = (
 /obj/effect/decal/cleanable/dirt{
@@ -16660,6 +19688,15 @@
 "qLD" = (
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"qLE" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/machinery/door/poddoor{
+	id = "pain"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "qMm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16729,12 +19766,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"qOc" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/followers)
 "qOD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16850,19 +19881,49 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"qRG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"qSf" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
+"qSZ" = (
+/obj/machinery/door/keycard{
+	puzzle_id = "library"
+	},
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "qTb" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"qTL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"qUn" = (
+/obj/structure/nest/ghoul,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/sewer)
 "qUw" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "qUx" = (
-/obj/structure/closet/cabinet,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/structure/chair/bench,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qUL" = (
@@ -16872,16 +19933,6 @@
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
-"qUO" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters{
-	id = "followersadminshutters";
-	name = "followers shutters"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/followers)
 "qUR" = (
 /obj/structure/lattice{
 	density = 1
@@ -16926,7 +19977,7 @@
 	},
 /area/f13/brotherhood/rnd)
 "qVG" = (
-/obj/structure/table/wood,
+/obj/effect/landmark/start/f13/followersguard,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qWa" = (
@@ -16940,12 +19991,14 @@
 	},
 /area/f13/brotherhood/rnd)
 "qWm" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Oasis Housing";
-	req_one_access_txt = "25"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "clinicstorage";
+	name = "shutters button";
+	pixel_x = 32
 	},
-/turf/open/floor/f13/wood,
+/obj/machinery/vending/medical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qWx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16960,10 +20013,17 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"qXq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "qXr" = (
-/obj/structure/barricade/wooden,
-/obj/structure/curtain,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/table/wood,
+/obj/item/chair/stool,
+/obj/item/chair/stool,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "qXN" = (
 /obj/structure/barricade/bars,
@@ -16972,14 +20032,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices1st)
-"qYq" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "qYA" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/cigarettes/cigars/havana{
@@ -17000,15 +20052,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"qZq" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "124"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "qZt" = (
 /obj/structure/lattice{
 	density = 1
@@ -17027,6 +20070,15 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"qZB" = (
+/obj/effect/decal/fakelattice,
+/obj/item/storage/toolbox/emergency/old,
+/obj/item/storage/toolbox/emergency/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "qZY" = (
 /obj/machinery/autolathe/ammo,
 /obj/machinery/light/small{
@@ -17051,56 +20103,56 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rbg" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/ruins,
-/area/f13/tunnel)
-"rbt" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "shopladder"
+/obj/structure/table/snooker{
+	dir = 6
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"rbo" = (
+/obj/structure/table/snooker{
+	dir = 10
+	},
+/obj/item/melee/baseball_bat{
+	pixel_x = -7;
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"rbt" = (
+/obj/structure/simple_door/metal/barred,
+/obj/structure/simple_door/metal/barred,
+/turf/open/water,
 /area/f13/tunnel)
 "rbE" = (
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "rca" = (
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 8;
-	light_color = "#800080";
-	name = "light fixture"
-	},
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
-/area/f13/caves)
+/area/f13/tunnel)
 "rce" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "rcf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/structure/decoration/vent{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/tunnel)
 "rcv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
@@ -17116,11 +20168,38 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
+"rcM" = (
+/obj/structure/junk/small/bed2,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "rcU" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whitedirtysolid"
 	},
+/area/f13/tunnel)
+"rde" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/f13/yumyum,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"rdM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"rei" = (
+/mob/living/simple_animal/hostile/stalker,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "rex" = (
 /turf/closed/indestructible/rock,
@@ -17135,6 +20214,13 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
+"rfo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rfs" = (
 /obj/machinery/light{
 	dir = 1
@@ -17152,12 +20238,11 @@
 	},
 /area/f13/brotherhood/mining)
 "rfH" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "clinicladder"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rgt" = (
@@ -17181,6 +20266,23 @@
 /obj/structure/table,
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"rha" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "malice";
+	name = "Door Control"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"rhn" = (
+/obj/machinery/power/tesla_coil/research{
+	desc = "A modified military-grade tesla coil constantly exchanging energy throughout. It looks to be recently used.";
+	name = "tesla charge inducer"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "rhP" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_cannabis,
@@ -17220,27 +20322,33 @@
 	},
 /area/f13/brotherhood/mining)
 "riT" = (
-/obj/structure/mirror{
-	pixel_x = 32
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rjq" = (
-/obj/structure/toilet{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"rjs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "rjz" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "rjG" = (
-/obj/structure/simple_door/metal/barred,
+/obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "rjQ" = (
 /obj/effect/decal/cleanable/dirt{
@@ -17267,15 +20375,18 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"rln" = (
-/obj/structure/rack,
-/obj/item/storage/box/masks,
-/obj/item/storage/box/gloves,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+"rmb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
 	},
-/area/f13/followers)
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/item/gun/ballistic/automatic/pistol/pistol127/compact,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rmf" = (
 /obj/item/stack/sheet/metal/twenty,
 /turf/open/indestructible/ground/inside/subway,
@@ -17306,6 +20417,10 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"rog" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rpI" = (
 /obj/structure/chair/right,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -17314,13 +20429,19 @@
 	},
 /area/f13/tunnel)
 "rqc" = (
-/obj/machinery/smartfridge/chemistry,
+/obj/structure/table/snooker{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rqF" = (
-/obj/item/flag/oasis,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/structure/table/snooker{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "rrh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
@@ -17329,15 +20450,17 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "rrm" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/prewar/poster79{
+	pixel_y = -32
 	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
-"rrq" = (
-/obj/structure/curtain,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"rrq" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rrE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -17347,16 +20470,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"rsf" = (
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/item/stack/sheet/hay/fifty,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
+"rrQ" = (
+/mob/living/simple_animal/hostile/handy/protectron/nsb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
+"rsf" = (
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rsj" = (
 /obj/structure/table{
 	layer = 2.9
@@ -17379,14 +20500,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"rsB" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "rsM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
@@ -17418,29 +20531,20 @@
 	icon_state = "rubblepillar"
 	},
 /area/f13/tunnel)
-"rtO" = (
-/obj/structure/closet/fridge,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/followers)
 "rtX" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "run" = (
-/obj/machinery/light/fo13colored/Aqua{
-	name = "light fixture"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "rux" = (
-/obj/structure/closet/crate/large,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/curtain,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "ruX" = (
 /obj/effect/decal/remains/human,
@@ -17469,14 +20573,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"rvI" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "rwf" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue{
@@ -17504,6 +20600,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"rwI" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "rwQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
@@ -17602,19 +20703,50 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"rAs" = (
+/obj/structure/closet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "rAt" = (
 /turf/open/floor/circuit/f13_red,
 /area/f13/brotherhood/rnd)
 "rAx" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 5
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/tunnel)
+"rBa" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"rBn" = (
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rBS" = (
-/obj/structure/sign/warning,
+/obj/structure/simple_door/bunker,
 /obj/structure/timeddoor,
-/turf/closed/wall/r_wall/rust,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/tunnel)
 "rBT" = (
 /obj/structure/table/reinforced,
@@ -17623,20 +20755,49 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
-"rCv" = (
-/obj/structure/wreck/trash/five_tires{
-	pixel_x = 3;
-	pixel_y = -13
+"rBX" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/flag/oasis,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"rCv" = (
+/obj/item/defibrillator/loaded,
+/obj/item/storage/box/syringes,
+/obj/item/cane,
+/obj/item/soap,
+/obj/effect/turf_decal/box/white,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/defibrillator/loaded,
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/gloves,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"rCV" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "rDc" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"rDn" = (
+/obj/item/clothing/head/radiation,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rDr" = (
 /obj/machinery/light{
 	dir = 1
@@ -17695,10 +20856,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"rFQ" = (
-/obj/structure/rack,
-/turf/open/floor/plating/f13,
-/area/f13/followers)
 "rFR" = (
 /obj/machinery/light{
 	dir = 4
@@ -17707,13 +20864,40 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"rGw" = (
-/obj/structure/chair/stool/f13stool,
-/obj/effect/landmark/start/f13/followersvolunteer,
+"rGn" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/unique,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "redrustyfull"
 	},
-/area/f13/followers)
+/area/f13/bunker)
+"rHL" = (
+/obj/item/storage/firstaid/ancient,
+/obj/item/storage/firstaid/ancient,
+/obj/item/storage/firstaid/ancient,
+/obj/effect/turf_decal/box/white,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/silver_sulf,
+/obj/item/reagent_containers/medspray/silver_sulf,
+/obj/item/reagent_containers/medspray/styptic,
+/obj/item/reagent_containers/medspray/styptic,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/storage/pill_bottle/chem_tin/fixer,
+/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/storage/pill_bottle/mannitol,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "rHV" = (
 /obj/structure/table{
 	layer = 2.9
@@ -17734,6 +20918,13 @@
 /obj/machinery/newscaster,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
+"rIA" = (
+/obj/structure/reagent_dispensers/barrel/explosive,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "rIL" = (
 /obj/structure/table/greyscale,
 /obj/item/book/granter/trait/lowsurgery,
@@ -17898,6 +21089,12 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"rMc" = (
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rMk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -17907,6 +21104,15 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
+"rMp" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"rMG" = (
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "rNi" = (
 /obj/structure/window/reinforced/spawner{
 	color = "#777777";
@@ -17930,6 +21136,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"rNs" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/baseball,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rOb" = (
 /obj/structure/flora/junglebush/b,
 /turf/closed/mineral/random/low_chance,
@@ -17951,6 +21165,20 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"rOO" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"rOZ" = (
+/obj/structure/barricade/bars,
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rPi" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -18008,6 +21236,16 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"rRT" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rSw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -18020,9 +21258,12 @@
 	},
 /area/f13/caves)
 "rTh" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/prewar/poster69{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "rTI" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -18069,6 +21310,18 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"rWl" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"rWG" = (
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "rWY" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
@@ -18080,25 +21333,16 @@
 	},
 /area/f13/tunnel)
 "rXg" = (
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/backpack/duffelbag/med,
-/obj/item/clothing/accessory/medal/ribbon/medical_doctor{
-	desc = "A faded award from long ago";
-	name = "faded medical award"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rXl" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rXA" = (
-/obj/structure/timeddoor,
-/obj/structure/timeddoor,
-/turf/closed/wall/r_wall/rust,
+/turf/closed/mineral/random/low_chance,
 /area/f13/bunker)
 "rXR" = (
 /obj/structure/flora/junglebush/large,
@@ -18106,15 +21350,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rXS" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "rZw" = (
 /mob/living/simple_animal/hostile/radroach,
@@ -18125,16 +21363,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "rZZ" = (
-/obj/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/chem_pile{
-	pixel_x = -12;
-	pixel_y = 10
-	},
-/obj/structure/sign/poster/prewar/poster92{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "sam" = (
 /obj/structure/spacevine{
@@ -18153,7 +21385,7 @@
 	pixel_x = 0
 	},
 /obj/structure/flora/rock/jungle,
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/water,
 /area/f13/caves)
 "saC" = (
 /obj/structure/sink{
@@ -18168,6 +21400,19 @@
 /obj/structure/flora/junglebush/large,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"sbl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"sbY" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "scG" = (
 /obj/structure/spider/stickyweb,
 /mob/living/simple_animal/hostile/poison/giant_spider,
@@ -18178,9 +21423,8 @@
 /turf/open/floor/carpet/blue,
 /area/f13/brotherhood/offices2nd)
 "sdI" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "sdJ" = (
@@ -18188,6 +21432,13 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
 /area/f13/caves)
+"sdN" = (
+/obj/effect/decal/remains/human{
+	name = "Remains of a ranger"
+	},
+/obj/item/clothing/head/helmet/f13/ncr/rangercombat/desert,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "sef" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/rock/jungle,
@@ -18227,16 +21478,10 @@
 	},
 /area/f13/bunker)
 "sfm" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/poster/contraband/pinup_funk{
+	pixel_y = -32
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "sfu" = (
 /obj/machinery/light{
@@ -18257,17 +21502,12 @@
 	},
 /area/f13/tunnel)
 "sfI" = (
-/obj/structure/table/snooker{
-	dir = 9
-	},
-/obj/item/toy/cards/deck{
-	pixel_x = -11;
-	pixel_y = 15
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/supermart,
 /area/f13/tunnel)
 "sgd" = (
-/mob/living/simple_animal/hostile/raider/thief,
+/obj/effect/decal/cleanable/blood/innards,
+/obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -18287,6 +21527,12 @@
 /obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"sgL" = (
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "shc" = (
 /obj/structure/simple_door/bunker{
 	name = "Star Paladin Office";
@@ -18303,7 +21549,9 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "shF" = (
-/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	open = 0
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "shO" = (
@@ -18312,14 +21560,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "sic" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "S5"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "sie" = (
 /obj/structure/simple_door/bunker,
@@ -18337,15 +21579,19 @@
 	},
 /area/f13/clinic)
 "siK" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "cornerladder"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "siP" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Bar Backroom";
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "sjA" = (
 /obj/structure/flora/junglebush,
@@ -18357,7 +21603,7 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "ska" = (
-/obj/machinery/mineral/equipment_vendor,
+/obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "skG" = (
@@ -18416,13 +21662,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "smm" = (
-/obj/structure/sink{
-	pixel_y = 19
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "smq" = (
 /obj/structure/table{
@@ -18436,10 +21678,23 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"smu" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	name = "microwave"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
 "smy" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
+"sne" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "snf" = (
 /obj/machinery/vending/hydroseeds,
@@ -18447,6 +21702,12 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"snF" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "snP" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /turf/open/floor/f13{
@@ -18476,6 +21737,15 @@
 /obj/effect/decal/cleanable/blood/innards,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"srd" = (
+/mob/living/simple_animal/hostile/handy/sentrybot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/caves)
+"srz" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "srD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -18491,14 +21761,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ssQ" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowhorizontal"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/followers)
 "stt" = (
 /obj/structure/sink{
 	dir = 4;
@@ -18521,6 +21783,23 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
+"suB" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"suJ" = (
+/obj/item/trash/f13/yumyum,
+/obj/effect/mob_spawn/human/corpse/raider,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "suZ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/cups,
@@ -18528,6 +21807,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
+"svD" = (
+/obj/structure/table,
+/obj/item/healthanalyzer/advanced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "svI" = (
 /obj/machinery/door/airlock/abandoned{
 	req_one_access_txt = "134"
@@ -18536,6 +21822,13 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"swh" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "swY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18545,10 +21838,23 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
+"swZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/corner,
+/obj/item/paper_bin/bundlenatural,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"sxm" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "sxA" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier9,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -18562,6 +21868,13 @@
 /obj/item/reagent_containers/syringe/medx,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"syJ" = (
+/obj/machinery/chem_master/advanced,
+/obj/machinery/chem_master/advanced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
 "szW" = (
@@ -18585,12 +21898,15 @@
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sBm" = (
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 8;
-	name = "light fixture"
+"sAl" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"sBm" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "sBu" = (
 /obj/structure/wreck/trash/engine,
@@ -18614,11 +21930,13 @@
 	},
 /area/f13/brotherhood/leisure)
 "sCZ" = (
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bottomcellghoul"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/water,
 /area/f13/tunnel)
 "sDo" = (
 /obj/structure/table/booth,
@@ -18636,6 +21954,19 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"sEL" = (
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
+"sFr" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "sGx" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -18649,12 +21980,15 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
-"sHo" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+"sHb" = (
+/obj/structure/barricade/bars{
+	layer = 5
 	},
-/area/f13/followers)
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/turf/open/water,
+/area/f13/tunnel)
 "sHv" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -18668,6 +22002,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"sIq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "sIN" = (
 /obj/effect/decal/cleanable/cobweb,
 /mob/living/simple_animal/hostile/poison/giant_spider,
@@ -18718,34 +22059,34 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"sMc" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Armory";
-	req_one_access_txt = "62"
+"sLS" = (
+/obj/machinery/light/small{
+	dir = 8
 	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
+"sMc" = (
+/obj/machinery/autolathe,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "sMr" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"sMy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"sMQ" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/followers)
-"sNu" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/followers)
 "sNB" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
@@ -18764,6 +22105,13 @@
 	icon_state = "whiterustysolid"
 	},
 /area/f13/tunnel)
+"sNT" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5;
+	tag = "icon-tracks (NORTHEAST)"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sNX" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
@@ -18789,6 +22137,21 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
+"sOB" = (
+/mob/living/simple_animal/hostile/enclave/soldier{
+	desc = "A former Enclave soldier, mutated by the forced evolutionary virus and grafted to the interior of his suit.";
+	extra_projectiles = 1;
+	faction = list("wastebot");
+	loot = null;
+	name = "mutated enclave soldier";
+	speak = list("AUUGHGHHH!");
+	speak_emote = list("shouts")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "sON" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -18798,18 +22161,28 @@
 	},
 /area/f13/tunnel)
 "sPK" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/f13/battlecoat,
-/obj/item/circuitboard/machine/autolathe/ammo,
-/obj/item/circuitboard/machine/autolathe/ammo,
-/obj/item/circuitboard/machine/autolathe/ammo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "sPY" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"sRw" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"sRL" = (
+/obj/structure/girder/reinforced,
+/obj/structure/decoration/rag,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "sSP" = (
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
@@ -18835,8 +22208,10 @@
 /area/f13/tunnel)
 "sUl" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "sUs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -18847,6 +22222,23 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"sVw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"sVN" = (
+/obj/machinery/door/airlock/grunge,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"sVV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/ranged/legendary,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "sWp" = (
 /obj/structure/table{
 	layer = 2.9
@@ -18860,6 +22252,13 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"sWM" = (
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "sWT" = (
 /obj/structure/table/reinforced,
 /obj/item/pen/fountain{
@@ -18906,14 +22305,30 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "sXV" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/r_wall/rust,
-/area/f13/tunnel)
-"sZJ" = (
-/obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"sYw" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"sZJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"tau" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/area/f13/tunnel)
 "taI" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -18922,21 +22337,26 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "tbE" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Town Forge";
-	req_one_access_txt = "25"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"tcC" = (
-/obj/structure/chair/stool/retro,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/prewar/poster79{
-	pixel_y = -32
-	},
+/obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"tcC" = (
+/obj/machinery/light/fo13colored/Aqua{
+	bulb_colour = "#800080";
+	dir = 8;
+	light_color = "#800080";
+	name = "light fixture"
+	},
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"tcT" = (
+/obj/effect/decal/fakelattice,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "tda" = (
 /obj/structure/toilet{
 	dir = 8
@@ -18947,6 +22367,21 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"tdC" = (
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"tdY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/booth,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"tei" = (
+/obj/machinery/door/window,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "tem" = (
 /obj/structure/table{
 	layer = 2.9
@@ -18979,32 +22414,26 @@
 	},
 /area/f13/clinic)
 "teW" = (
-/obj/machinery/door/airlock/vault{
-	autoclose = "TRUE";
-	layer = 2;
-	name = "Oasis Storage";
-	req_one_access_txt = "25"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/ert{
-	id = "oasisstorage";
-	layer = 5;
-	name = "Oasis Storage"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"tfi" = (
+/obj/machinery/autolathe/ammo,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "tfw" = (
-/obj/effect/decal/cleanable/blood/innards,
-/obj/effect/decal/cleanable/blood/gibs,
+/obj/structure/barricade/sandbags,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"tfB" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/followers)
+"tfZ" = (
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "tgC" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13{
@@ -19025,11 +22454,10 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "thH" = (
-/obj/structure/table/snooker{
-	dir = 9
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "tiS" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -19042,6 +22470,8 @@
 	},
 /area/f13/clinic)
 "tjd" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "tjt" = (
@@ -19059,12 +22489,26 @@
 /area/f13/building)
 "tjA" = (
 /obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "tjI" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"tkz" = (
+/obj/structure/closet/crate/large,
+/obj/item/circuitboard/machine/protolathe,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "tkS" = (
 /obj/machinery/door/airlock/hatch{
 	name = "NCR War Room";
@@ -19082,6 +22526,10 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
+"tlH" = (
+/obj/item/clothing/suit/radiation,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "tlS" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/small{
@@ -19097,14 +22545,12 @@
 	},
 /area/f13/brotherhood/rnd)
 "tmM" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
+/obj/machinery/shower{
+	dir = 8
 	},
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/tunnel)
 "tmO" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -19126,10 +22572,8 @@
 /area/f13/sewer)
 "toA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/autolathe/ammo,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "toP" = (
 /obj/structure/rack,
@@ -19153,21 +22597,28 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"tqH" = (
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"tqZ" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
-	},
-/obj/structure/sign/poster/contraband/punch_shit{
-	pixel_y = 32
-	},
+"tqF" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"tqH" = (
+/obj/structure/wreck/trash/five_tires{
+	pixel_x = 3;
+	pixel_y = -13
+	},
+/obj/item/flag/oasis,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"tqZ" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_north_middle"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "tse" = (
 /obj/structure/closet/cabinet,
@@ -19183,13 +22634,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
-"tsK" = (
-/obj/structure/table,
-/obj/item/pen,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/followers)
 "ttp" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -19208,6 +22652,17 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"ttJ" = (
+/obj/machinery/door/poddoor/preopen{
+	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70);
+	id = eairlock
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "bluemark"
+	},
+/area/f13/bunker)
 "ttW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -19254,15 +22709,20 @@
 	},
 /area/f13/tunnel)
 "twj" = (
-/obj/item/instrument/saxophone,
+/obj/item/instrument/trombone,
 /obj/structure/rack,
+/obj/item/instrument/trumpet,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "twy" = (
-/obj/item/instrument/glockenspiel,
+/obj/item/instrument/eguitar,
 /obj/structure/rack,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
+"twG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/caves)
 "txg" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -19280,15 +22740,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"tzH" = (
-/obj/structure/table/reinforced,
-/obj/item/folder{
-	pixel_x = -4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "tzJ" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/rust,
@@ -19299,6 +22750,37 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/tunnel)
+"tAd" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/machinery/door/poddoor{
+	id = "okay"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"tAr" = (
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/storage/backpack/duffelbag/med,
+/obj/item/clothing/accessory/medal/ribbon/medical_doctor{
+	desc = "A faded award from long ago";
+	name = "faded medical award"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"tAO" = (
+/obj/item/storage/trash_stack,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	name = "Repaired Turret";
+	scan_range = 9;
+	throw_range = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "tBZ" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -19308,23 +22790,35 @@
 "tCe" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/f13/brotherhood/rnd)
-"tCt" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "followerlabladder"
+"tCo" = (
+/obj/structure/fluff/paper/stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"tCC" = (
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/item/clothing/suit/armor/f13/power_armor/t45d{
+	color = "#C1C1C1";
+	desc = "(IX) Originally developed and manufactured for the United States Army by American defense contractor West Tek, the T-45d power armor was the first version of power armor to be successfully deployed in battle. This set looks somewhat bashed up and worn";
+	item_color = "#C1C1C1"
 	},
-/area/f13/followers)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tDc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "tDl" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
+/obj/item/book/manual/wiki/cit/chemistry,
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/circuitry,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "tDo" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/lootdrop/trash,
@@ -19333,24 +22827,47 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"tDW" = (
-/obj/structure/closet/crate/large,
-/obj/structure/handrail/g_central{
-	pixel_y = -16
+"tDv" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "redmark"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/area/f13/bunker)
+"tDW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_north_middle"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "tEm" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"tEo" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "tEu" = (
-/obj/structure/simple_door/metal/barred,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "oasisstorage";
+	name = "Oasis Storage Button";
+	pixel_x = 32;
+	req_one_access_txt = "62"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"tEv" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "tEG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -19358,23 +22875,17 @@
 	},
 /area/f13/brotherhood/offices1st)
 "tEH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/bodybags,
-/obj/structure/table,
-/obj/item/stack/sheet/cardboard/twenty,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/rack,
+/obj/item/twohanded/sledgehammer,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "tEW" = (
-/obj/structure/girder,
-/obj/structure/barricade/wooden/planks,
+/obj/machinery/photocopier,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"tFc" = (
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/followers)
 "tFF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -19398,6 +22909,25 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"tGP" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"tGU" = (
+/obj/item/storage/trash_stack,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "tHb" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -19409,6 +22939,21 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"tHF" = (
+/obj/structure/table,
+/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/tunnel)
+"tHM" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw/mother{
+	speed = -1.5
+	},
+/turf/open/water,
+/area/f13/caves)
 "tID" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -19419,18 +22964,20 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
+"tIG" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/f13/yumyum,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "tII" = (
-/obj/effect/decal/waste{
-	icon_state = "goo10"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/structure/rack,
+/obj/item/circuitboard/machine/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "tJD" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 8
-	},
+/obj/item/storage/box/drinkingglasses,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "tJE" = (
@@ -19456,14 +23003,8 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/effect/landmark/start/f13/ncrcaptain,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"tKU" = (
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "tLd" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor4-old"
@@ -19472,6 +23013,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"tMn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "tMw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -19497,6 +23045,16 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
+"tNc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/paper/crumpled/bloody/docsdeathnote{
+	info = "it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns it burns "
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "tNq" = (
 /obj/machinery/telecomms/server/presets/bos,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -19537,9 +23095,9 @@
 	},
 /area/f13/tunnel)
 "tPY" = (
-/obj/structure/curtain,
+/obj/structure/table/wood,
 /turf/open/floor/f13/wood,
-/area/f13/caves)
+/area/f13/tunnel)
 "tQw" = (
 /obj/structure/table,
 /obj/item/storage/fancy/ammobox/slugshot,
@@ -19552,6 +23110,12 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"tRH" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "tRS" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13{
@@ -19585,10 +23149,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "tTm" = (
-/obj/structure/curtain,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/caves)
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "tTt" = (
 /obj/machinery/light{
 	dir = 1
@@ -19598,6 +23161,13 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"tUi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "tUk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/chips,
@@ -19606,18 +23176,38 @@
 	},
 /area/f13/tunnel)
 "tUT" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/tunnel)
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tVu" = (
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
+"tWP" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	dir = 6;
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
+"tWZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "pain";
+	name = "Door Control"
+	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "tXh" = (
 /obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/tunnel)
+"tXj" = (
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "tXq" = (
@@ -19656,12 +23246,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "tZf" = (
-/obj/structure/sink{
-	pixel_y = 19
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/area/f13/caves)
 "tZg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -19670,8 +23257,9 @@
 	},
 /area/f13/bunker)
 "tZq" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/curtain,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
 /area/f13/tunnel)
 "tZE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19680,6 +23268,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
+	},
+/area/f13/tunnel)
+"tZO" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenfull"
 	},
 /area/f13/tunnel)
 "tZW" = (
@@ -19698,30 +23291,43 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"ubj" = (
+/obj/item/crowbar,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "ubN" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "ubW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_north_middle"
-	},
+/obj/machinery/workbench,
 /turf/open/floor/f13/wood,
-/area/f13/caves)
+/area/f13/tunnel)
 "ucS" = (
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"uel" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/terminal{
-	dir = 1
+"udr" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
+"udH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/workbench/forge,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"uee" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw{
+	speed = -2
 	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/followers)
+/turf/open/water,
+/area/f13/caves)
+"uei" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "ueZ" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -19730,19 +23336,12 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "ufo" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "prospector2open"
-	},
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Prospector Entrance";
-	req_one_access_txt = "48"
-	},
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/closet/crate/large,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ufQ" = (
-/obj/structure/decoration/warning,
-/turf/closed/wall/rust,
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ufR" = (
 /obj/structure/rack,
@@ -19759,6 +23358,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"ugu" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ugU" = (
 /obj/structure/bookcase/random/adult,
 /obj/machinery/light{
@@ -19774,32 +23379,64 @@
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"uhG" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "uhW" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"uif" = (
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/followers)
 "uig" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
+"uio" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"uis" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"uiz" = (
+/obj/structure/chair/f13chair2,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
+"uiT" = (
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "uiV" = (
 /obj/structure/nest/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ujx" = (
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/followers)
+"uiW" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"ujL" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "ukv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table{
@@ -19810,12 +23447,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"ukI" = (
-/obj/structure/dresser,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "ulr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/terminal{
@@ -19845,29 +23476,45 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/tunnel)
-"ulE" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
 "umG" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "busladder"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
-"unV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/wasteplant/wild_fungus,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/landmark/start/f13/settler,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"unJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"unV" = (
+/obj/machinery/door/airlock/vault{
+	autoclose = "TRUE";
+	layer = 2;
+	name = "Oasis Storage";
+	req_one_access_txt = "25"
+	},
+/obj/machinery/door/poddoor/ert{
+	id = "oasisstorage";
+	layer = 5;
+	name = "Oasis Storage"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "uoo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Bar Backroom";
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"uop" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "uoq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -19885,10 +23532,14 @@
 "uoO" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"upC" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+"uoR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper/crumpled,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"upC" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "uqk" = (
 /obj/item/flashlight,
@@ -19941,19 +23592,43 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/leisure)
-"urM" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	max_integrity = 500;
-	name = "Store Backroom";
-	req_one_access_txt = "34"
+"urt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"urI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"urM" = (
+/obj/effect/landmark/start/f13/settler,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "urZ" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/machinery/light/fo13colored/Aqua{
+	bulb_colour = "#800080";
+	dir = 8;
+	light_color = "#800080";
+	name = "light fixture"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"usv" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "usN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -19961,10 +23636,15 @@
 	},
 /area/f13/brotherhood/rnd)
 "utr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/structure/rack,
+/obj/item/stack/sheet/plastic/five,
+/obj/item/stack/sheet/plastic/five,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "utz" = (
 /obj/structure/sink/kitchen,
 /turf/closed/wall/rust,
@@ -19977,17 +23657,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
-"uub" = (
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
-"uug" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/followers)
 "uuo" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/ammo,
@@ -20005,6 +23674,11 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"uvV" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "uwd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/vent{
@@ -20017,9 +23691,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "uwt" = (
-/mob/living/simple_animal/hostile/ghoul/glowing,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "uwA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line,
@@ -20057,34 +23739,67 @@
 	},
 /area/f13/brotherhood/medical)
 "uyz" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_7"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"uyQ" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/generic,
-/obj/structure/curtain,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"uzc" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/tunnel)
-"uzO" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"uAb" = (
-/obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"uyQ" = (
+/obj/item/clothing/head/hardhat,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"uzc" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"uzr" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"uzO" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"uAb" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/light/fo13colored/Pink{
+	dir = 1;
+	name = "light tube"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "uAc" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/mining)
+"uAs" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"uAK" = (
+/obj/structure/bed,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
+"uBN" = (
+/obj/structure/closet/wardrobe/virology_white,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
 "uBO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -20116,6 +23831,15 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/tunnel)
+"uCN" = (
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"uDS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/dresser,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "uEb" = (
 /obj/machinery/telecomms/processor/preset_two,
@@ -20152,8 +23876,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "uFj" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "uFm" = (
 /obj/structure/rack,
@@ -20179,6 +23906,20 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"uFR" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"uGl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste,
+/mob/living/simple_animal/hostile/abomhorror/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "uGR" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -20188,20 +23929,14 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
+"uHb" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "uHt" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/glass/beaker/plastic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/nest/ghoul,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "uHT" = (
 /obj/machinery/vending/cola/red,
@@ -20233,36 +23968,77 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
+"uJt" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"uJx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "uJD" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/tunnel)
-"uKB" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/warning,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"uKP" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_north_middle"
+"uKg" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/mob/living/simple_animal/hostile/raider/ranged/legendary,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"uKj" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = -4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
-"uKU" = (
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 8;
-	light_color = "#800080";
-	name = "light fixture"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
-"uLn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/sandbags,
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"uKB" = (
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"uKE" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"uKP" = (
+/obj/effect/decal/waste,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"uKU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/wood/house,
+/area/f13/tunnel)
+"uKW" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"uLn" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Oasis Housing";
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "uLp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -20279,16 +24055,34 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/tunnel)
-"uMi" = (
-/obj/structure/rack,
+"uMe" = (
+/obj/structure/frame/machine,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"uMi" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "mine"
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/caves)
+"uMm" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/mutagen,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/f13/bunker)
 "uMu" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress6"
@@ -20298,29 +24092,18 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
+"uMz" = (
+/obj/effect/decal/cleanable/robot_debris/old,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
 "uMA" = (
-/obj/item/storage/firstaid/ancient,
-/obj/item/storage/firstaid/ancient,
-/obj/item/storage/firstaid/ancient,
-/obj/effect/turf_decal/box/white,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/silver_sulf,
-/obj/item/reagent_containers/medspray/silver_sulf,
-/obj/item/reagent_containers/medspray/styptic,
-/obj/item/reagent_containers/medspray/styptic,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/storage/pill_bottle/chem_tin/fixer,
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/storage/pill_bottle/mannitol,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "uMD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20334,42 +24117,38 @@
 	},
 /area/f13/tunnel)
 "uNS" = (
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uOE" = (
-/obj/structure/table/wood/poker,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 9;
-	pixel_y = 10
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/tunnel)
 "uPu" = (
-/obj/machinery/chem_heater,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "uPv" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "uQO" = (
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 8;
-	name = "light fixture"
+/obj/structure/toilet{
+	dir = 4;
+	pixel_x = -3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
 /area/f13/tunnel)
 "uRG" = (
 /obj/structure/bed/mattress{
@@ -20379,17 +24158,28 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
-"uRL" = (
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/followers)
-"uRY" = (
-/obj/structure/chair/booth,
+"uRW" = (
+/obj/structure/reagent_dispensers/barrel/two,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"uRY" = (
+/obj/structure/sink{
+	pixel_y = 19
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
 /area/f13/tunnel)
+"uSi" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "uSI" = (
 /obj/structure/chair/wood,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -20419,42 +24209,29 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"uUO" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/sentrybot/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "uVp" = (
 /obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"uVr" = (
-/obj/structure/table/glass,
-/obj/item/fermichem/pHmeter,
-/obj/item/fermichem/pHmeter,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "uVN" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"uVY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "followersadminshutters";
-	name = "desk shutters";
-	pixel_x = 6
-	},
-/obj/machinery/button/door{
-	id = "fadmin";
-	name = "Door lockdown button";
-	pixel_x = -5
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
+"uWl" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "uWC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20464,18 +24241,33 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"uWH" = (
+/obj/structure/flora/wasteplant/wild_fungus,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "uXs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"uZy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/workbench/forge,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"uYD" = (
+/obj/effect/decal/fakelattice,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"uZy" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/caves)
 "uZG" = (
 /obj/structure/rack,
 /obj/item/shield/riot/bullet_proof,
@@ -20497,21 +24289,18 @@
 	},
 /area/f13/brotherhood/operations)
 "vaf" = (
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 8;
-	light_color = "#800080";
-	name = "light fixture"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"vat" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "gatehouseladder"
-	},
+/obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/tunnel)
+"vag" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"vat" = (
+/obj/effect/decal/cleanable/generic,
+/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "vaH" = (
 /obj/structure/rack,
@@ -20530,6 +24319,13 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"vbI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "vbV" = (
 /obj/structure/handrail/g_central{
 	dir = 4;
@@ -20540,6 +24336,17 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"vbY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/tunnel)
+"vcc" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vcL" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -20554,17 +24361,15 @@
 	},
 /area/f13/clinic)
 "ven" = (
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/tunnel)
 "veq" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/flashlight/lantern,
-/obj/item/mining_scanner,
-/obj/item/pickaxe/drill,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/curtain,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
 /area/f13/tunnel)
 "veO" = (
 /obj/structure/table,
@@ -20591,10 +24396,15 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
+"vfh" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "vfi" = (
-/obj/machinery/jukebox,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/stage_tr,
+/obj/structure/table/booth,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "vfj" = (
 /obj/structure/handrail/g_central{
@@ -20612,16 +24422,34 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/offices2nd)
 "vfL" = (
-/obj/machinery/mineral/ore_redemption,
+/obj/structure/chair/office{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "vgo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/tools{
-	pixel_x = 32
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/stack/f13Cash/random/med,
+/obj/machinery/light/fo13colored/Aqua{
+	bulb_colour = "#800080";
+	dir = 4;
+	light_color = "#800080";
+	name = "light fixture"
 	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"vgS" = (
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/turf/open/water,
 /area/f13/tunnel)
 "vgW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20632,6 +24460,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"vgZ" = (
+/obj/structure/junk/small/bed,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "vhO" = (
 /obj/structure/table/wood/settler,
 /obj/item/storage/toolbox/mechanical/old,
@@ -20642,6 +24474,27 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
+"vii" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"viw" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"viS" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"vja" = (
+/obj/effect/mob_spawn/human/corpse,
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vkb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dresser,
@@ -20667,60 +24520,39 @@
 	},
 /area/f13/sewer)
 "vkD" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "vkL" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 6
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"vlo" = (
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "vmm" = (
-/turf/closed/wall{
-	icon_state = "fwall_opening"
-	},
+/obj/structure/simple_door/metal/barred,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "vnJ" = (
-/obj/item/instrument/guitar,
+/obj/item/instrument/glockenspiel,
 /obj/structure/rack,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "vnW" = (
-/obj/structure/rack,
-/obj/item/advanced_crafting_components/receiver,
-/obj/item/advanced_crafting_components/receiver,
-/obj/item/advanced_crafting_components/receiver,
-/obj/item/advanced_crafting_components/lenses,
-/obj/item/advanced_crafting_components/lenses,
-/obj/item/advanced_crafting_components/lenses,
-/obj/item/advanced_crafting_components/flux,
-/obj/item/advanced_crafting_components/flux,
-/obj/item/advanced_crafting_components/flux,
-/obj/item/advanced_crafting_components/conductors,
-/obj/item/advanced_crafting_components/conductors,
-/obj/item/advanced_crafting_components/conductors,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/alloys,
-/obj/item/advanced_crafting_components/alloys,
-/obj/item/advanced_crafting_components/alloys,
-/obj/item/advanced_crafting_components/alloys,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/conductors,
-/obj/item/advanced_crafting_components/flux,
-/obj/item/advanced_crafting_components/lenses,
-/obj/item/advanced_crafting_components/receiver,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "vnY" = (
 /obj/structure/rack,
@@ -20748,14 +24580,29 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"vpb" = (
+/obj/structure/reagent_dispensers/barrel,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vpz" = (
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
 	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "vqb" = (
-/obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/floorgrime,
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/tunnel)
+"vqj" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "vqo" = (
 /obj/structure/simple_door/bunker{
@@ -20769,11 +24616,12 @@
 	},
 /area/f13/brotherhood/offices1st)
 "vra" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
+/obj/structure/mirror{
+	pixel_x = 32
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
 /area/f13/tunnel)
 "vrD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20787,6 +24635,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
+"vsG" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "vsI" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water,
@@ -20811,16 +24667,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "vuf" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/fo13colored/Aqua{
+	bulb_colour = "#800080";
+	dir = 8;
+	light_color = "#800080";
+	name = "light fixture"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "vuj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vuv" = (
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
@@ -20860,6 +24721,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
+"vxb" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "vxm" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -20879,27 +24748,31 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"vyt" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "vyN" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "vzL" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/chair/booth{
+	icon_state = "booth_east_middle"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack{
-	layer = 2
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/tunnel)
-"vzR" = (
-/obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"vzR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"vAp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vAM" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -20907,10 +24780,31 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"vBf" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"vBz" = (
+/turf/closed/indestructible/fakeglass,
+/area/f13/bunker)
 "vBA" = (
-/obj/machinery/photocopier,
+/obj/structure/closet/cabinet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"vBG" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vBO" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20945,19 +24839,20 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"vCM" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "vDl" = (
-/obj/structure/ore_box,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"vDq" = (
+/obj/structure/sink{
+	pixel_y = 19
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/tunnel)
 "vDC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20970,6 +24865,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"vEc" = (
+/obj/item/paper/crumpled,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vEd" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
@@ -21015,12 +24914,6 @@
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vGI" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "vGT" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -21045,6 +24938,17 @@
 	icon_state = "grass2"
 	},
 /area/f13/clinic)
+"vIr" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/abomhorror/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"vJw" = (
+/obj/structure/reagent_dispensers/barrel/four,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vJC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
@@ -21057,11 +24961,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "vKh" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flashlight/lamp,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "vKm" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -21075,13 +24978,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/brotherhood/offices2nd)
-"vLg" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/effect/landmark/start/f13/followersadministrator,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
+"vLy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "vLO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -21091,6 +24992,11 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"vMc" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
 "vMm" = (
 /obj/structure/simple_door/bunker,
 /obj/effect/decal/cleanable/dirt,
@@ -21105,14 +25011,6 @@
 	name = "pool water"
 	},
 /area/f13/brotherhood/leisure)
-"vMO" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "vNw" = (
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood{
@@ -21132,6 +25030,12 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"vPm" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greendirtysolid"
+	},
+/area/f13/tunnel)
 "vPn" = (
 /obj/structure/table/greyscale,
 /turf/open/floor/f13{
@@ -21162,16 +25066,24 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"vQn" = (
-/obj/effect/decal/waste{
-	icon_state = "goo10"
+"vPH" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/machinery/door/poddoor{
+	id = "pain"
 	},
-/obj/machinery/shower{
-	dir = 8
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/obj/effect/decal/cleanable/dirt,
+/area/f13/bunker)
+"vPN" = (
+/obj/structure/nest/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/area/f13/caves)
+"vQn" = (
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vQx" = (
 /obj/item/reagent_containers/food/snacks/grown/poppy{
 	pixel_x = 4;
@@ -21205,19 +25117,40 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"vSd" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
-"vTa" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+"vRe" = (
+/obj/structure/chair/f13chair2{
+	dir = 1
 	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/followers)
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"vSd" = (
+/obj/structure/closet/crate/miningcar,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"vSC" = (
+/obj/item/stack/cable_coil/random/five,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"vSD" = (
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/caves)
+"vTd" = (
+/obj/item/stack/cable_coil/cut/random,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "vTH" = (
-/obj/structure/girder/reinforced,
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "vTY" = (
@@ -21229,6 +25162,17 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
+"vUs" = (
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
+"vUz" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vUM" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
@@ -21239,9 +25183,8 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "vVz" = (
-/obj/structure/bookcase,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "vVE" = (
 /obj/effect/decal/remains/human,
@@ -21251,15 +25194,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vWg" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
 /obj/structure/barricade/wooden,
-/obj/structure/decoration/warning,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "vWj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21270,43 +25207,29 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"vWr" = (
-/obj/structure/chalkboard,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/followers)
 "vWN" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vWZ" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/f13/wood,
+/obj/structure/girder,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "vXh" = (
-/obj/structure/chair/stool,
-/obj/machinery/button/door{
-	id = "bottomcellghoul";
-	name = "Bottom cell shutters";
-	pixel_x = -6;
-	pixel_y = 32
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "topcellghoul";
-	name = "Top cell shutters";
-	pixel_x = 6;
-	pixel_y = 32
-	},
-/turf/open/floor/wood/f13/stage_t,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "vXF" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/structure/chair/booth,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/pinup_couch{
+	pixel_y = 32
 	},
-/area/f13/bunker)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "vXU" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -21329,9 +25252,17 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
 "vYC" = (
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/chair/booth,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"vYJ" = (
+/obj/machinery/button/door{
+	id = "okay";
+	name = "Door Control"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "vZj" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -21370,7 +25301,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vZW" = (
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "wac" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21378,6 +25313,13 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"waj" = (
+/obj/machinery/button/door{
+	id = "hell";
+	name = "Door Control"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/caves)
 "waU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21398,15 +25340,16 @@
 	},
 /area/f13/clinic)
 "wcm" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "wcF" = (
-/obj/machinery/light/small,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "wdF" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -21414,6 +25357,14 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
+/area/f13/tunnel)
+"wdT" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/structure/sign/poster/contraband/pinup_bed{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "weF" = (
 /obj/item/clothing/under/f13/bosformsilver_m,
@@ -21433,36 +25384,37 @@
 "weW" = (
 /turf/open/water,
 /area/f13/tunnel)
-"wfh" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+"wfe" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "bluefull"
+	},
+/area/f13/tunnel)
+"wfn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paperplane/origami,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wfE" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "floordirtysolid"
 	},
-/area/f13/followers)
-"wfE" = (
-/obj/structure/rack,
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/item/crafting/abraxo,
-/obj/item/crafting/sensor,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/radio,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "wfG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/settler,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/tunnel)
 "wgg" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -21475,24 +25427,40 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"wgT" = (
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "whp" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"wiq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "soup";
+	name = "Door Control"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "wiz" = (
-/obj/structure/table/wood,
-/obj/item/clothing/glasses/heat,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"wjU" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "wjW" = (
-/obj/structure/billboard/cola/pristine,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "wkx" = (
 /turf/closed/mineral/random/low_chance{
@@ -21501,13 +25469,40 @@
 	},
 /area/f13/caves)
 "wkN" = (
-/obj/structure/barricade/wooden,
-/obj/machinery/light/fo13colored/Pink{
-	dir = 1;
-	name = "light tube"
+/obj/structure/decoration/warning{
+	pixel_y = -2
 	},
-/turf/open/floor/f13/wood,
+/obj/structure/sign/warning{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
+"wkZ" = (
+/obj/effect/decal/cleanable/glass,
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"wle" = (
+/obj/machinery/light/small,
+/obj/structure/table/wood/settler,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/tunnel)
+"wmf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/wallframe/camera,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wmI" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "wmT" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -21517,12 +25512,39 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"wnT" = (
+/obj/structure/chair/f13chair2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wol" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper,
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "hate";
+	name = "Door Control"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "wom" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "dark"
+	},
+/area/f13/bunker)
+"wox" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wpi" = (
+/obj/effect/decal/fakelattice,
+/obj/structure/wreck/trash/engine,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
 "wpj" = (
@@ -21533,36 +25555,30 @@
 	},
 /area/f13/enclave)
 "wpJ" = (
-/obj/structure/barricade/bars,
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/structure/handrail/g_central{
+	pixel_y = -16
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/water,
 /area/f13/tunnel)
-"wqi" = (
-/obj/structure/bodycontainer/morgue,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+"wql" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/area/f13/followers)
+/area/f13/bunker)
 "wqW" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
 "wrg" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/f13/wood,
+/obj/machinery/light/fo13colored/Aqua{
+	bulb_colour = "#800080";
+	dir = 8;
+	light_color = "#800080";
+	name = "light fixture"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"wry" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "wrJ" = (
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
@@ -21571,19 +25587,19 @@
 /obj/item/stock_parts/cell/ammo/ec,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
-"wsK" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
+"wsv" = (
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"wsK" = (
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"wtj" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "wtp" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/inside/mountain,
@@ -21592,11 +25608,18 @@
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wus" = (
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+"wum" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old";
+	tag = "icon-gib2-old"
 	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"wus" = (
+/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "wut" = (
 /obj/structure/rack,
@@ -21605,13 +25628,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "wuM" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"wuY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
 "wvi" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -21626,13 +25645,26 @@
 /obj/item/flashlight/flare/torch,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"wyl" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
+"wyc" = (
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"wyL" = (
+/obj/item/chair,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "bluedirtyfull"
 	},
-/area/f13/followers)
+/area/f13/bunker)
+"wzs" = (
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/tunnel)
+"wzt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "wAe" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	icon_state = "neutralrusty"
@@ -21650,6 +25682,11 @@
 /obj/structure/wreck/trash/engine,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"wAX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "wDm" = (
 /obj/structure/lattice{
 	layer = 2
@@ -21669,9 +25706,12 @@
 	},
 /area/f13/bunker)
 "wDO" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/structure/sink{
+	pixel_y = 19
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "wDR" = (
 /obj/item/clothing/suit/armor/f13/combatrusted,
 /obj/item/clothing/head/helmet/f13/hoodedmask,
@@ -21699,8 +25739,19 @@
 	},
 /area/f13/brotherhood/medical)
 "wFx" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/supermart,
+/obj/structure/sign/warning{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/structure/decoration/warning{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/structure/decoration/warning{
+	pixel_x = -3;
+	pixel_y = -5
+	},
+/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "wFL" = (
 /obj/structure/chair{
@@ -21710,14 +25761,58 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"wHf" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/supermart,
-/area/f13/tunnel)
-"wHB" = (
-/obj/structure/chair/wood,
+"wGy" = (
+/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"wHf" = (
+/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"wHt" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"wHB" = (
+/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"wHP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/securitron/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"wHV" = (
+/obj/structure/barricade/bars,
+/obj/structure/table/wood,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"wIb" = (
+/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "wIM" = (
 /obj/structure/handrail/g_central{
@@ -21726,6 +25821,17 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
+/area/f13/tunnel)
+"wJk" = (
+/mob/living/simple_animal/hostile/handy/securitron/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wJm" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "wJQ" = (
 /obj/machinery/door/airlock/grunge{
@@ -21748,13 +25854,29 @@
 	},
 /area/f13/bunker)
 "wKH" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wKL" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"wLp" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/machinery/door/poddoor{
+	id = "pain"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "wLM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -21771,6 +25893,12 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
+"wMa" = (
+/obj/machinery/light/broken,
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "wMr" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -21778,11 +25906,27 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "wMy" = (
-/obj/machinery/light/small{
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/obj/machinery/shower{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"wMX" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"wND" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/caves)
 "wNG" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -21791,11 +25935,16 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
-"wOg" = (
-/obj/structure/chair/wood{
+"wNN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
 	dir = 1
 	},
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"wOg" = (
+/obj/structure/barricade/wooden/planks,
+/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "wOp" = (
 /obj/structure/cable{
@@ -21806,11 +25955,29 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"wPo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/mob/living/simple_animal/hostile/deathclaw/legendary{
+	speed = -1.5
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wQb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wQm" = (
+/obj/machinery/power/tesla_coil/research{
+	desc = "A modified military-grade tesla coil constantly exchanging energy throughout. It looks to be recently used.";
+	name = "tesla charge inducer"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/f13/bunker)
 "wQB" = (
 /obj/structure/chair{
 	dir = 4
@@ -21821,12 +25988,8 @@
 /area/f13/clinic)
 "wQC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Oasis";
-	req_one_access_txt = "25"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
 /area/f13/tunnel)
 "wQS" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
@@ -21834,6 +25997,31 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"wRb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper_bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wRj" = (
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/obj/item/storage/trash_stack{
+	layer = 2
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/tunnel)
+"wSg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "wTF" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = null;
@@ -21851,11 +26039,16 @@
 	},
 /area/f13/enclave)
 "wUi" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/flashlight/lantern,
-/obj/item/mining_scanner,
+/obj/structure/wreck/trash/four_barrels,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"wUo" = (
+/obj/machinery/light/fo13colored/Pink{
+	name = "light tube"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "wUv" = (
@@ -21863,13 +26056,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "wUB" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier9,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier9,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "wVl" = (
 /turf/open/floor/f13/wood{
@@ -21882,14 +26071,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"wWc" = (
-/obj/machinery/button/crematorium{
-	pixel_y = 19
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/followers)
 "wWF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -21903,14 +26084,8 @@
 	},
 /area/f13/enclave)
 "wXG" = (
-/obj/structure/decoration/warning{
-	pixel_y = -2
-	},
-/obj/structure/sign/warning{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/turf/closed/wall/f13/wood,
+/obj/structure/decoration/warning,
+/turf/closed/wall/rust,
 /area/f13/tunnel)
 "wYl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21951,13 +26126,23 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xbP" = (
-/obj/structure/table,
-/obj/item/storage/belt/utility/full,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
+"xbg" = (
+/mob/living/simple_animal/hostile/ghoul/wyomingghost{
+	desc = "A happily proud Enclave commander, mutated and boiled alive by the forced evolutionary virus. His armor looks to be sunken into his flesh.";
+	faction = list("wastebot");
+	health = 1500;
+	maxHealth = 1500;
+	name = "Commander Dirsk";
+	speak = list("For the Enclave!","Long live America!","Die, mutie!","AAAAAGGH!!","AUGUHGHHH!"));
+	speak_chance = 10;
+	speed = -1;
+	unarmed_attack_speed = 2
 	},
-/area/f13/followers)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "xcm" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -21975,16 +26160,9 @@
 /turf/open/water,
 /area/f13/caves)
 "xcH" = (
-/obj/structure/noticeboard{
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Oasis";
-	req_one_access_txt = "25"
-	},
-/turf/open/floor/f13/wood,
+/obj/structure/closet/crate/miningcar,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xdi" = (
 /obj/structure/chair/bench,
@@ -21993,6 +26171,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"xdM" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "xdS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -22030,15 +26214,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "xfu" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/barricade/wooden,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/tunnel)
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xgi" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -22049,6 +26227,19 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
+"xgx" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbear1";
+	tag = "icon-gibbear1"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"xgQ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "xgY" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibtorso"
@@ -22073,9 +26264,13 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "xhF" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old";
+	tag = "icon-gib5-old"
+	},
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xig" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowrustyfull"
@@ -22115,12 +26310,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"xkd" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "xkh" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood{
@@ -22129,7 +26318,7 @@
 /area/f13/sewer)
 "xkk" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
@@ -22197,6 +26386,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"xpJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/shovel/spade,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "xqa" = (
 /obj/machinery/light{
 	dir = 1
@@ -22221,12 +26416,36 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"xsc" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "xsL" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"xuH" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"xuW" = (
+/mob/living/simple_animal/hostile/enclave/soldier{
+	desc = "A former Enclave soldier, mutated by the forced evolutionary virus and grafted to the interior of his suit.";
+	extra_projectiles = 1;
+	faction = list("wastebot");
+	loot = null;
+	name = "mutated enclave soldier";
+	speak = list("AUUGHGHHH!");
+	speak_emote = list("shouts")
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "xvg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -22236,18 +26455,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"xvS" = (
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/fire,
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "xxn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -22260,19 +26467,34 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"xxV" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier10,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "xyk" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xyx" = (
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"xyR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"xyU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "xyW" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -22285,14 +26507,6 @@
 "xyX" = (
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"xzh" = (
-/obj/machinery/button/door{
-	id = "prospector3open";
-	name = "gate shutters";
-	pixel_x = 32
-	},
-/turf/open/water,
 /area/f13/tunnel)
 "xzX" = (
 /obj/item/storage/trash_stack,
@@ -22319,83 +26533,40 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
-"xAw" = (
+"xAy" = (
+/obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood/house,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/f13/bunker)
 "xCd" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xCv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_east_south"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "xCN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"xDr" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/followers)
-"xEd" = (
-/obj/structure/closet/crate/freezer{
-	storage_capacity = 30
-	},
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/followers)
-"xEg" = (
+"xEM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "clinicstorage";
-	name = "shutters button";
-	pixel_x = 32
+/mob/living/simple_animal/hostile/handy/assaultron{
+	aggro_vision_range = 30;
+	desc = "A prototype assaultron with (visibly) upgraded leg motors and hydraulics. It's painted in Enclave markings.";
+	dir = 4;
+	health = 1500;
+	maxHealth = 1500;
+	name = "PCU-11";
+	speed = -0.5
 	},
-/obj/machinery/vending/medical,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"xFI" = (
+/mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "xFN" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -22417,6 +26588,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"xGO" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xGV" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
@@ -22427,10 +26604,10 @@
 	icon_state = "whiterustysolid"
 	},
 /area/f13/tunnel)
-"xHZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+"xHv" = (
+/obj/structure/decoration/rag,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "xIk" = (
 /obj/item/paper_bin{
 	pixel_y = 6
@@ -22455,16 +26632,22 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"xLd" = (
-/obj/structure/table/snooker{
-	dir = 10
-	},
-/obj/item/melee/baseball_bat{
-	pixel_x = -7;
-	pixel_y = -8
+"xLN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "xMx" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
@@ -22492,22 +26675,32 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
-"xOj" = (
+"xNP" = (
+/obj/structure/reagent_dispensers/barrel,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/glasses/sunglasses{
-	anchored = 1;
-	pixel_y = 26
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/item/clothing/head/fedora/det_hat{
-	anchored = 1;
-	pixel_y = 32
+/area/f13/bunker)
+"xOE" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"xOJ" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
-"xPz" = (
-/obj/effect/decal/cleanable/generic,
-/turf/closed/wall/f13/wood,
-/area/f13/tunnel)
+/area/f13/bunker)
+"xPs" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "xPN" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -22552,18 +26745,21 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"xSb" = (
-/obj/structure/bookcase/manuals,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "xSi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"xSA" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "xSY" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -22576,23 +26772,37 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
-"xTR" = (
-/obj/structure/bookcase/manuals/medical,
+"xUb" = (
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/obj/item/gun/ballistic/revolver/m29/alt,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"xUX" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/obj/item/shard{
+	pixel_x = 8;
+	pixel_y = 5
+	},
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "reddirtyfull"
 	},
-/area/f13/followers)
-"xVt" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/structure/sign/poster/contraband/pinup_bed{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "xVz" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xVR" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greendirtysolid"
+	},
+/area/f13/tunnel)
 "xVW" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/f13{
@@ -22615,26 +26825,6 @@
 	dir = 8;
 	icon_state = "neutralrusty"
 	},
-/area/f13/tunnel)
-"xYz" = (
-/obj/item/wirecutters/basic,
-/obj/item/screwdriver/crude,
-/obj/structure/table/wood,
-/obj/item/storage/box/handcuffs,
-/obj/item/lock_construct,
-/obj/item/key,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/stack/f13Cash/random/med,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"xYV" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "xZd" = (
 /obj/effect/decal/waste{
@@ -22664,23 +26854,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/f13/tcoms)
-"ycj" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/followers)
 "ycl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"ydV" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+"ydr" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "yej" = (
 /obj/machinery/door/window/northleft,
 /obj/effect/decal/cleanable/dirt,
@@ -22695,14 +26879,37 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"yeZ" = (
-/obj/structure/table/booth,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+"yeT" = (
+/obj/machinery/door/airlock/grunge,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/machinery/door/poddoor{
+	id = "hell"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"yfd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "yfe" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"yfm" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/wrench/power,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "yfz" = (
 /obj/structure/nest/ghoul,
 /turf/open/floor/f13{
@@ -22713,27 +26920,12 @@
 /obj/item/flashlight,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"ygp" = (
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 8;
-	name = "light fixture"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "ygu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/tunnel)
-"ygC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "yhd" = (
 /obj/structure/cable{
@@ -22747,6 +26939,21 @@
 "yhT" = (
 /turf/closed/indestructible/opshuttle,
 /area/f13/caves)
+"yjB" = (
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ykL" = (
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ylz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 
 (1,1,1) = {"
 eLE
@@ -23435,27 +27642,27 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -23591,7 +27798,7 @@ uoO
 uoO
 eoy
 uoO
-buV
+uoO
 eoy
 uoO
 uoO
@@ -23683,42 +27890,42 @@ aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+eLE
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -23848,7 +28055,7 @@ uoO
 uoO
 eoy
 uoO
-nBk
+pAI
 eoy
 uoO
 uoO
@@ -23940,41 +28147,6 @@ aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 aoj
 uoO
 uoO
@@ -23982,22 +28154,57 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -24043,7 +28250,7 @@ hDw
 hDw
 adO
 hDw
-aBI
+qpe
 kxd
 uoO
 uoO
@@ -24197,66 +28404,22 @@ aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
 aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
+eLE
+eLE
+eLE
+eLE
+fAq
+fAq
+fAq
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -24280,8 +28443,52 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -24454,67 +28661,23 @@ aoj
 uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
 aoj
 uoO
 uoO
 uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
+eLE
+eLE
+eLE
+fAq
+fAq
+fAq
+tEo
+fAq
+fAq
+fAq
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -24537,8 +28700,52 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -24711,6 +28918,38 @@ uoO
 aoj
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
+eLE
+eLE
+fAq
+fAq
+vlo
+eBg
+eBg
+pkL
+vlo
+fAq
+fAq
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -24741,15 +28980,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -24770,33 +29000,10 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -24968,10 +29175,45 @@ uoO
 aoj
 uoO
 aoj
+aoj
+uoO
+uoO
+uoO
+eLE
+rex
+fAq
+pkL
+pAK
+eBg
+eBg
+phq
+fTt
+fTt
+fAq
+rex
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -25002,11 +29244,6 @@ aoj
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -25024,36 +29261,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -25225,6 +29432,53 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+eLE
+fAq
+fAq
+tRH
+fTt
+mGY
+eJq
+mlW
+fTt
+pkL
+fAq
+fAq
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -25237,68 +29491,6 @@ uoO
 uoO
 uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-lnr
-lnr
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 aoj
@@ -25309,8 +29501,23 @@ aoj
 aoj
 aoj
 aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -25485,38 +29692,25 @@ uoO
 aoj
 uoO
 uoO
+eLE
+eLE
+fAq
+oGk
+mNc
+pAK
+blF
+mYN
+qiA
+fTt
+eBg
+tEo
+fAq
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-lnr
-aoj
-aoj
-vWN
-lnr
-lnr
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -25541,24 +29735,12 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -25568,6 +29750,31 @@ uoO
 aoj
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -25742,6 +29949,56 @@ uoO
 aoj
 uoO
 uoO
+eLE
+eLE
+fAq
+fAq
+rWl
+aNQ
+uhG
+hLh
+sYw
+nyt
+pkL
+fAq
+fAq
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
 aoj
 uoO
 uoO
@@ -25757,58 +30014,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-lnr
-lnr
-aoj
-lnr
-lnr
-uzO
-lnr
-lnr
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
 uoO
 uoO
 uoO
@@ -25816,16 +30021,18 @@ uoO
 aoj
 aoj
 aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -25999,7 +30206,21 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+eLE
+eLE
+fAq
+kHi
+kHi
+sVw
+rWl
+pAK
+pAK
+eBg
+fAq
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -26007,7 +30228,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -26015,32 +30235,16 @@ uoO
 uoO
 uoO
 uoO
-lnr
-mot
-lnr
-lnr
-lnr
-lnr
-lnr
-lnr
-lnr
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 aoj
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -26051,7 +30255,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
 aoj
 aoj
 uoO
@@ -26060,9 +30263,10 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+xVz
+xVz
 uoO
 aoj
 uoO
@@ -26072,17 +30276,20 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -26257,71 +30464,25 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+fAq
+fAq
+irY
+kHi
+tdC
+bxQ
+igG
+fAq
+fAq
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-lnr
-lnr
-mLh
-lnr
-lnr
-aoj
-aoj
-lnr
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -26338,8 +30499,54 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+aoj
+aoj
+mlz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -26513,28 +30720,23 @@ aoj
 uoO
 uoO
 uoO
+eLE
+eLE
+eLE
+eLE
+fAq
+fAq
+vBz
+kne
+vBz
+fAq
+fAq
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-lnr
-lnr
-lnr
-bHA
-lnr
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -26546,37 +30748,7 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -26593,10 +30765,45 @@ uoO
 aoj
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+aoj
+uoO
+xVz
+xVz
+aoj
+xVz
+xVz
+sne
+xVz
+xVz
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -26770,41 +30977,25 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+fAq
+pkL
+eBg
+jKq
+fAq
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-lnr
-lnr
-lnr
-qHc
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -26821,27 +31012,6 @@ uoO
 uoO
 uoO
 aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -26854,6 +31024,43 @@ uoO
 uoO
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+xVz
+lah
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -27027,90 +31234,90 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+fAq
+eBg
+eBg
+sOB
+fAq
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+aoj
+aoj
+aoj
+jPC
+aoj
+aoj
+uoO
+uoO
+xVz
+xVz
+pmU
+xVz
+xVz
+aoj
+aoj
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+aoj
+aoj
 aoj
 aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-lnr
-lnr
-lnr
-lnr
-lnr
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -27283,68 +31490,25 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-lnr
-mLh
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+fAq
+cxU
+pAK
+pkL
+fAq
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -27368,6 +31532,49 @@ uoO
 uoO
 aoj
 aoj
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+wKH
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+ouh
+xVz
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -27540,53 +31747,31 @@ uoO
 uoO
 uoO
 uoO
+eLE
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+pkL
+sOB
+pkL
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-lnr
-lnr
-lnr
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -27603,22 +31788,44 @@ aoj
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uWH
+uoO
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -27795,55 +32002,33 @@ uoO
 uoO
 aoj
 aoj
-aoj
+uoO
+eLE
+eLE
+fAq
+nHa
+nUx
+imY
+vgZ
+fAq
+wHt
+pkL
+ifT
+fAq
+mqi
+lUJ
+mVr
+gNR
+fAq
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-lnr
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -27857,6 +32042,38 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
 aoj
 uoO
 uoO
@@ -27864,18 +32081,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -28053,46 +32260,27 @@ aoj
 aoj
 aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
+eLE
+eLE
+fAq
+iVc
+pkL
+clP
+kHi
+fAq
+eBg
+iGR
+eBg
+fAq
+aNQ
+oOO
+pAK
+pAK
+fAq
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -28112,28 +32300,47 @@ uoO
 aoj
 aoj
 uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+pmU
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -28309,88 +32516,88 @@ aoj
 aoj
 aoj
 aoj
+uoO
+eLE
+eLE
+fAq
+eBg
+wmI
+pkL
+obu
+tWP
+eBg
+eBg
+pkL
+tDv
+eoL
+eoL
+fTt
+lhT
+fAq
+eLE
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+buV
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+buV
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -28567,32 +32774,26 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-iOJ
-lnr
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+fAq
+urI
+wmI
+eoL
+kYy
+fAq
+lBR
+eBg
+vRe
+fAq
+uis
+eoL
+dyS
+rCV
+fAq
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -28605,25 +32806,23 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
@@ -28632,22 +32831,30 @@ aoj
 uoO
 uoO
 uoO
-uoO
-aoj
-uoO
+xVz
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -28824,6 +33031,26 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+fAq
+qrK
+mtA
+rcM
+nHa
+fAq
+pAK
+oLu
+vRe
+fAq
+nHa
+iuU
+oBz
+hPk
+fAq
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -28835,52 +33062,17 @@ uoO
 uoO
 uoO
 uoO
-lnr
-sNX
-lnr
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -28891,9 +33083,6 @@ uoO
 uoO
 uoO
 aoj
-uoO
-uoO
-uoO
 aoj
 aoj
 uoO
@@ -28901,6 +33090,24 @@ uoO
 uoO
 uoO
 uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -29081,59 +33288,25 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-lnr
-lnr
-sNX
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
+eLE
+eLE
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+mKg
+pkL
+lKF
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -29152,11 +33325,22 @@ uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+jPC
 uoO
 uoO
 uoO
@@ -29165,7 +33349,30 @@ uoO
 uoO
 uoO
 aoj
+uoO
+eLE
+eLE
+eLE
+eAQ
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -29338,6 +33545,75 @@ uoO
 uoO
 uoO
 uoO
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+dbg
+fAq
+fAq
+fAq
+rex
+rex
+rex
+rex
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+xVz
+buV
+xVz
+xVz
+xVz
+xVz
+xVz
+wKH
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -29345,55 +33621,7 @@ uoO
 uoO
 uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -29404,27 +33632,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -29556,7 +33763,7 @@ eUk
 bcN
 rQA
 bcN
-bcN
+itz
 dZF
 eLE
 uoO
@@ -29595,19 +33802,83 @@ uoO
 uoO
 uoO
 uoO
+fAq
+uiT
+kJI
+eEE
+fAq
+fAq
+fAq
+iRA
+vlo
+pkL
+xPs
+loO
+fAq
+fAq
+fAq
+fAq
+fAq
+mKS
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+azs
+xVz
+xVz
 uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+vQn
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -29617,70 +33888,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -29851,20 +34058,84 @@ uoO
 uoO
 uoO
 uoO
+aoj
+fAq
+pkL
+yfd
+pAK
+eBg
+evS
+fAq
+pkv
+eBg
+azz
+tRH
+fTt
+fAq
+nnn
+eoL
+dYA
+tRH
+mKS
+azs
+azs
+swh
+azs
+azs
+azs
+azs
+azs
+azs
+azs
+uio
+azs
+azs
+azs
+azs
+azs
+azs
+swh
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+xVz
+mlz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+tUT
+jPC
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -29874,70 +34145,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -30109,7 +34316,77 @@ aoj
 uoO
 uoO
 uoO
+fAq
+pkL
+xbg
+pkL
+azz
+pAK
+fVn
+pAK
+eBg
+mDZ
+pAK
+cOo
+nOw
+pkL
+eBg
+eoL
+lBR
+lpa
+azs
+azs
+azs
+azs
+azs
+uio
+azs
+azs
+azs
+azs
+azs
+azs
+azs
+azs
+azs
+azs
+azs
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
+uoO
+mlz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+buV
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+xVz
+mlz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -30120,80 +34397,10 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 aoj
 aoj
 aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -30366,6 +34573,83 @@ uoO
 uoO
 uoO
 uoO
+fAq
+rAs
+pkL
+pAK
+pAK
+mqF
+fAq
+gGS
+pkL
+kjo
+eBg
+qHx
+fAq
+loO
+eoL
+pPj
+pkL
+lpa
+ubj
+azs
+nKX
+azs
+azs
+azs
+azs
+azs
+azs
+azs
+azs
+azs
+azs
+azs
+azs
+azs
+azs
+bWq
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -30373,84 +34657,7 @@ uoO
 uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -30623,57 +34830,44 @@ uoO
 uoO
 aoj
 uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-sUl
+fAq
+tNc
+ksw
+mIx
+fAq
+fAq
+fAq
+iRA
+sMy
+pkL
+sMy
+iRA
+fAq
+fAq
+fAq
+fAq
+fAq
+mKS
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+gFg
+xVz
+xVz
+xVz
 xVz
 uoO
 uoO
@@ -30703,7 +34897,15 @@ uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -30711,6 +34913,11 @@ uoO
 uoO
 uoO
 aoj
+aoj
+aoj
+aoj
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -30880,6 +35087,51 @@ uoO
 uoO
 uoO
 uoO
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+pqz
+fAq
+fAq
+fAq
+rex
+rex
+rex
+rex
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -30893,60 +35145,24 @@ uoO
 uoO
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 xVz
-sUl
-sUl
-pOB
-eoy
-eoy
-eoy
-eoy
-eoy
-eoy
-eoy
-eoy
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -30957,15 +35173,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -31137,44 +35344,31 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+xyx
+eBg
+vlo
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-mLh
-lnr
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -31188,21 +35382,10 @@ uoO
 uoO
 xVz
 xVz
-sUl
 xVz
-pOB
-eoy
-aCu
-beY
-vuj
-wKH
-qpY
-wUi
-eoy
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -31214,15 +35397,39 @@ aoj
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-aoj
 aoj
 uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+jPC
+uoO
+uoO
+xVz
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -31394,43 +35601,30 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+fAq
+uMe
+nCS
+qbi
+qwy
+fAq
+ojq
+bxQ
+eoL
+fAq
+pYE
+fWI
+xNP
+dSW
+fAq
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-lnr
-lnr
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -31444,18 +35638,11 @@ uoO
 uoO
 uoO
 xVz
-sUl
-sUl
 xVz
-vDl
-eoy
-aCu
-aCu
-vuj
-gza
-wKH
-veq
-eoy
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -31474,12 +35661,32 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
 uoO
 uoO
+uoO
+xVz
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -31651,42 +35858,29 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-lnr
-pNK
-mLh
-lnr
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
+eLE
+eLE
+fAq
+sbY
+suB
+icW
+pkL
+fAq
+kHi
+rWl
+lGO
+fAq
+dPM
+eoL
+ecZ
+rIA
+fAq
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -31701,18 +35895,8 @@ uoO
 uoO
 uoO
 xVz
-sUl
 xVz
-rjz
-eAQ
-eoy
-aCu
-aCu
-vuj
-vuj
-vuj
-wUi
-eoy
+xVz
 uoO
 uoO
 uoO
@@ -31723,6 +35907,35 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -31730,13 +35943,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -31901,7 +36108,6 @@ uoO
 aoj
 aoj
 aoj
-aoj
 uoO
 uoO
 uoO
@@ -31910,82 +36116,83 @@ uoO
 uoO
 uoO
 uoO
-aoj
+eLE
+fAq
+eBg
+eoL
+pAK
+pAK
+tWP
+mNc
+tdC
+eBg
+jTg
+pAK
+hae
+lOq
+ecZ
+fAq
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+uoO
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-lnr
-lnr
-lnr
-lnr
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 xVz
-rqF
-eAQ
-eAQ
-uoO
-eoy
-dyQ
-dyQ
-gJz
-wKH
-wKH
-fPj
-eoy
+xVz
+tUT
+jPC
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
+jPC
+qrc
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -31993,7 +36200,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -32158,6 +36365,68 @@ uoO
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+fAq
+pkL
+icW
+fTt
+vSC
+fAq
+pkL
+eoL
+pkL
+fAq
+hJs
+pdV
+fTt
+pVW
+fAq
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 aoj
 aoj
 uoO
@@ -32167,36 +36436,15 @@ uoO
 uoO
 uoO
 uoO
+qDR
+qDR
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-gtY
-qHc
-uoO
-uoO
+xVz
 uoO
 uoO
 uoO
@@ -32209,52 +36457,11 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
 aoj
 uoO
 uoO
-rjz
-eAQ
-epH
-uoO
-eoy
-eoy
-eoy
-ouz
-vfL
-vuj
-fPj
-eoy
 uoO
 uoO
-uoO
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
 eLE
 "}
 (38,1,1) = {"
@@ -32415,6 +36622,89 @@ uoO
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+fAq
+hlb
+dKt
+tkz
+acY
+fAq
+vBf
+eBg
+lGl
+fAq
+eeY
+tGP
+rGn
+bGf
+fAq
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
 aoj
 aoj
 uoO
@@ -32424,94 +36714,11 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
 aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-tur
-tur
-tur
-ufo
-tur
-tur
-tur
-tur
-wKH
-vuj
-vuj
-wKH
-tur
-tur
-tur
-tur
-tur
-tur
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-lYE
-iHB
-lYE
-weW
-weW
-weW
-weW
-weW
-mCL
 eLE
 "}
 (39,1,1) = {"
@@ -32672,13 +36879,91 @@ uoO
 aoj
 aoj
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+fAq
+fAq
+fAq
+fAq
+fAq
+fAq
+pkL
+pkL
+lcG
+fAq
+fAq
+fAq
+qSZ
+fAq
+fAq
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+fAq
+iTk
+hbd
+gjk
+chC
+dpx
+fAq
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+jPC
+uoO
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -32687,88 +36972,10 @@ aoj
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-bIh
-dgy
-weW
-nue
-weW
-weW
-weW
-weW
-qzG
-weW
-qzG
-xzh
-ozN
-weW
-mAa
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-lYE
-weW
-lYE
-weW
-weW
-weW
-weW
-weW
-mCL
 eLE
 "}
 (40,1,1) = {"
@@ -32790,7 +36997,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -32929,50 +37136,6 @@ uoO
 aoj
 aoj
 aoj
-aoj
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -32984,48 +37147,92 @@ uoO
 eLE
 eLE
 eLE
-tur
-tur
-tur
-tur
-tur
-tur
-eoy
-tur
+eLE
+eLE
+eLE
+fAq
+xuW
+pkL
+mNc
+fAq
+eLE
+lYf
+lDm
+pnI
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+fAq
+uMm
+maE
+iZl
+gfP
+kfU
+fAq
+eLE
+eLE
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 wKH
-wKH
-vuj
-vuj
-tur
-tur
-tur
-tur
-tur
-tur
-oJc
-pBk
-pBk
-pBk
-wWF
-wWF
-kjW
-kjW
-kjW
-wWF
-wWF
-bcM
-bcM
-nuA
-nuA
-bcM
-bcM
-bcM
-vzL
-pBk
-pBk
-pBk
-pBk
-mCL
+xVz
+xVz
+xVz
+vSd
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 eLE
 "}
 (41,1,1) = {"
@@ -33051,8 +37258,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -33186,47 +37393,6 @@ uoO
 uoO
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -33239,6 +37405,40 @@ uoO
 eLE
 eLE
 eLE
+eLE
+eLE
+fAq
+pkL
+eoL
+eBg
+fAq
+eLE
+vJw
+hyd
+lDm
+gxe
+wND
+eLE
+fAq
+fAq
+fAq
+fAq
+fAq
+maE
+sbl
+hsY
+kjV
+nZZ
+fAq
+eLE
+eLE
+uoO
+uoO
+xVz
+xVz
+xVz
+mlz
+xVz
 uoO
 uoO
 uoO
@@ -33247,42 +37447,49 @@ uoO
 uoO
 uoO
 uoO
-eoy
-vuj
-flP
-eAk
-vuj
-oQa
-vuj
-eoy
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
-tur
-gWt
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tEW
-wKH
-vuj
-fGO
-weW
-weW
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 eLE
 "}
 (42,1,1) = {"
@@ -33301,14 +37508,14 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -33443,46 +37650,6 @@ uoO
 uoO
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -33494,48 +37661,88 @@ uoO
 uoO
 eLE
 eLE
+eLE
+eLE
+eLE
+fAq
+pkL
+pkL
+oOh
+fAq
+eLE
+eLE
+azs
+hyd
+lDm
+lDm
+xVz
+fAq
+wQm
+sLS
+rhn
+vBz
+maE
+xEM
+lGG
+aBk
+lHu
+fAq
+eLE
+eLE
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
-rjz
-bjF
-rjz
-eAQ
-eAQ
-eAQ
-uoO
-eoy
-iRE
-vuj
-eoy
-wKH
-eoy
-ska
-eoy
-uoO
-wDO
-loc
-jFx
-lVr
-lVr
-tTm
-lVr
-cSY
-jPC
-lnr
-ckx
-tEu
-ckx
-rxG
-hOR
-fGO
-weW
-weW
-tur
 uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+bRX
+xfu
+pmU
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -33558,14 +37765,14 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -33700,48 +37907,8 @@ aoj
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -33750,49 +37917,89 @@ uoO
 uoO
 uoO
 eLE
+eLE
+eLE
+eLE
+fAq
+fAq
+vBz
+sOB
+nZt
+fAq
+fAq
+eLE
+eLE
+pnI
+nmn
+lDm
+azs
+hEv
+ocI
+ljX
+ocI
+iff
+maE
+lGG
+ocI
+ebs
+xAy
+fAq
+eLE
+eLE
 uoO
 uoO
 xVz
-rTh
+xVz
+xVz
+xVz
+xVz
 xVz
 uoO
 uoO
-rjz
-wqW
-fbC
-mTq
-eoy
-eoy
-eoy
-eoy
-miy
-eoy
-rbg
-eoy
-uoO
-uoO
-eAQ
-eAQ
-jPC
-buJ
-jPC
-buJ
-cSY
-jPC
-rxG
 uoO
 uoO
 uoO
 uoO
-tur
-fGO
-weW
-weW
-tur
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xhF
+xVz
 uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -33815,14 +38022,14 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -33957,48 +38164,10 @@ aoj
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -34007,51 +38176,89 @@ uoO
 uoO
 eLE
 eLE
+fAq
+fAq
+vlo
+pkL
+eBg
+pkL
+cJZ
+fAq
+fAq
+eLE
+eLE
+eLE
+vpb
+eBh
+fAq
+rhn
+cxy
+wQm
+vBz
+xAy
+xAy
+maE
+maE
+knU
+fAq
+eLE
+eLE
+uoO
 uoO
 xVz
-rjz
-mTq
-mTq
-mTq
-mTq
-mTq
-mTq
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+xVz
+buV
+xVz
+uoO
+uoO
+jPC
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+mlz
+xVz
+xgx
 eAQ
-eeG
-eAQ
-rjz
-vuv
-vuv
-rjz
-cTz
 pOB
-vuv
-uoO
-jrm
-tPY
-mMC
-jPC
-jPC
-jPC
-jPC
-jPC
-jPC
-ckx
-xPz
-vuv
-vuv
-vuv
-tur
-fGO
-weW
-weW
-iYF
-uoO
-uoO
+xVz
+xVz
 xVz
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -34072,14 +38279,14 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -34224,92 +38431,92 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+fAq
+jBe
+jKx
+pkL
+xOJ
+pkL
+tdC
+cAq
+fAq
+eLE
+eLE
+eLE
+eLE
+eLE
+fAq
+fAq
+fAq
+fAq
+fAq
+bFU
+maE
+xAy
+wyL
+pcK
+fAq
+eLE
 eLE
 uoO
 uoO
-eAQ
 xVz
-mTq
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 ckx
-pCn
-ckx
-tjd
-mTq
-pCn
-mTq
-eAQ
-gPe
-vuv
-rjz
-rjz
-eAQ
-eAQ
-eeT
-rjz
-rjz
-rjz
-eAQ
-eAQ
-eAQ
-rjz
-rjz
-eAQ
-jPC
-ckx
-vuv
-vaf
-tjd
-bEw
-tur
-fGO
-weW
-weW
-rxG
+xVz
+qDR
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xfu
+xVz
 xVz
 xVz
 xVz
 uoO
 uoO
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 eLE
 "}
@@ -34331,14 +38538,14 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 eLE
@@ -34481,92 +38688,92 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+fAq
+fAq
+pkL
+pkL
+xOJ
+uKj
+xUX
+hhc
+bxQ
+fAq
+fAq
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+fAq
+mHW
+btV
+ocI
+ocI
+bdL
+fAq
+eLE
 eLE
 uoO
-eAQ
-eAQ
-mTq
-mTq
-ckx
-uJD
-ckx
-tjd
-ckx
-ckx
-efa
-eAQ
-rjz
-mTq
-rqF
-rjz
-eAQ
-pOB
-vuv
-vuv
 uoO
-tbE
-qXr
-vuv
-vuv
-rjz
-rjz
+xVz
+xVz
+xVz
+buV
+xVz
+xVz
+xVz
+xVz
+xVz
 eAQ
-vaf
-tjd
-tjd
-tjd
-tjd
-tjd
-tur
-fGO
-weW
-weW
-iYF
+xVz
+xVz
+xVz
+xVz
+xVz
+qDR
 uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+pmU
 xVz
 xVz
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 eLE
 "}
@@ -34591,11 +38798,11 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 eLE
@@ -34738,92 +38945,92 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+fAq
+tEo
+hbh
+xOJ
+wkZ
+iMh
+tei
+pkL
+eXP
+aJX
+fAq
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+fAq
+lbN
+maE
+ocI
+ebs
+xAy
+fAq
+eLE
 eLE
 uoO
-eAQ
-eAQ
-mTq
-xYz
-ckx
-uJD
-ckx
-ckx
-tjd
-ckx
-mTq
-eAQ
-eAQ
+uoO
+xVz
+xVz
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+jPC
+uoO
+uoO
+uoO
+uoO
+jPC
+uoO
+uoO
 xcH
-eAQ
-umG
-eAQ
-eAQ
-dJV
-vuv
-bEw
-tjd
-tjd
-njZ
-egg
-vuv
-vuv
-eAQ
-tjd
-tjd
-tjd
-tjd
-tjd
-ckx
-tur
-fGO
-weW
-weW
-iYF
-uoO
-xyk
+xVz
+kjz
+xVz
 xVz
 xVz
 uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+xVz
+mlz
+xVz
+uoO
+uoO
+uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 eLE
 "}
@@ -34851,8 +39058,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 eLE
@@ -34995,91 +39202,91 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+fAq
+fAq
+eBg
+eBg
+usv
+hLh
+dQD
+vxb
+bxQ
+fAq
+fAq
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+fAq
+gpr
+gpr
+ttJ
+ttJ
+gpr
+fAq
+eLE
 eLE
 uoO
+uoO
+uoO
+uoO
+uoO
 xVz
-eAQ
-mTq
-shF
-rjG
-uJD
-nhK
-tjd
-wOg
-run
-mTq
-mTq
-mTq
-mTq
-xOj
-rjz
-unV
-vuv
-vuv
-vuv
-tjd
-ckx
-ckx
-ckx
-ckx
-cQf
-vuv
-eAQ
-tjd
-tjd
-tjd
-tjd
-tjd
-ckx
-tur
-fGO
-weW
-weW
-tur
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+mlz
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
 aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -35108,16 +39315,16 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 eLE
 uoO
 gpM
 lnr
+rKx
 lnr
-hQG
 uoO
 uoO
 uoO
@@ -35249,91 +39456,91 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
 eLE
+eLE
+fAq
+pkL
+pkL
+pkL
+pkL
+pkL
+eBg
+pkL
+hEv
+azs
+rDn
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+fAq
+lbN
+maE
+ocI
+mGf
+lws
+fAq
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 xVz
 xVz
-mTq
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
 vuj
-wKH
-uJD
-jWC
-kZR
-siK
-ckx
-jcf
-mTq
-mTq
-mTq
-bBZ
-eAQ
-vuv
-vuv
-vuv
-tjd
-tjd
-ckx
-aMg
-crg
-ckx
-ckx
-tbE
-eAQ
-tjd
-tjd
-ckx
-ckx
-tjd
-ckx
-tur
-wIM
-weW
-weW
-tur
+xVz
+xVz
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xgQ
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -35365,8 +39572,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 eLE
@@ -35506,91 +39713,91 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
 eLE
+eLE
+fAq
+fAq
+pPj
+eBg
+pkL
+vTd
+rBX
+fAq
+fAq
+nZu
+azs
+gxe
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+fAq
+gpr
+gpr
+ttJ
+ttJ
+gpr
+fAq
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 xVz
-mTq
-uXs
-qwP
-uJD
-jmA
-uNS
-ckx
-vVz
-vVz
-mTq
-mTq
-mTq
-mTq
-krt
-vuv
-vuv
-vuv
-tjd
-tjd
-ckx
-bmj
-crg
-ckx
-pdh
-vuv
-eAQ
-vuv
-tjd
-kpk
-cid
-tjd
-ckx
-tur
-wIM
-weW
-weW
-tur
+xVz
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+jPC
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+buV
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -35623,7 +39830,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 eLE
@@ -35759,43 +39966,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -35805,48 +39975,85 @@ uoO
 uoO
 uoO
 eLE
+rex
+fAq
+fAq
+fAq
+eec
+fAq
+fAq
+fAq
+xVz
+lDm
+lDm
+pnI
+azs
+wND
+eLE
+eLE
+eLE
+pnI
+lDm
+pnI
+azs
+eCA
+pnI
+xVz
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 xVz
-mTq
-mTq
-mTq
-mTq
-efa
-mTq
-mTq
-mTq
-mTq
-mTq
-ivm
-rjz
-rjz
-eAQ
-ivm
-vSd
-tbE
-tjd
-tjd
-tjd
-tjd
-tjd
-tjd
-ckx
-vuv
-rjz
-rjz
-vuv
-hIq
-mKh
-cIG
-vuv
-tur
-wIM
-weW
-weW
-tur
+xVz
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 aoj
 uoO
 uoO
@@ -35880,7 +40087,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -36016,43 +40223,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -36062,48 +40232,85 @@ uoO
 uoO
 uoO
 eLE
+eLE
+eLE
+eLE
+jQU
+jQU
+jQU
+eLE
+vpb
+tlH
+qTL
+lDm
+pnI
+azs
+azs
+vpb
+uRW
+kqY
+lDm
+hyd
+nmn
+xVz
+vJw
+azs
+eLE
+eLE
 uoO
 uoO
-sUl
-eAQ
-sUl
-mbX
-eAQ
-eAQ
-dWi
-eAQ
-rjz
-eAQ
-rjz
-eAQ
-rjz
-eAQ
-eAQ
-jPC
-vuv
-vuv
-tjd
-ckx
-tjd
-lPs
-vuv
-vuv
-vuv
-vuv
-rjz
-ven
-vuv
-vuv
-vuv
-vuv
-vuv
-tur
-miI
-weW
-weW
-tur
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+lqy
+xVz
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 aoj
 uoO
 uoO
@@ -36277,92 +40484,92 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
 uoO
 uoO
 eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+vpb
+lLh
+lDm
+liB
+srd
+azs
+lDm
+twG
+lDm
+azs
+uiW
+pnI
+eLE
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 xVz
-vZW
-vZW
-jmN
-jmN
-tUT
-tUT
-ndi
-ndi
-vZW
-eAQ
-rjz
-eAQ
-rjz
-eAQ
-unV
+xVz
+xVz
 uoO
-vuv
-tjd
-ckx
-tjd
-vuv
-vuv
-vuv
-rjz
-uAb
-rjz
-rjz
-kBD
-vuv
-vuv
-vuv
-vuv
-tur
-miI
-weW
-weW
-tur
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
 aoj
+aoj
+uoO
+xVz
+rZw
+xVz
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -36534,91 +40741,91 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
 uoO
 eLE
-uoO
-rjz
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+axC
+jwF
 xVz
-vZW
-bgu
-dJx
-bqs
-ckx
-lUq
-fZO
-ehY
-vZW
-eAQ
-rjz
-rjz
-eAQ
-rjz
-cWn
-uoO
-uoO
-vuv
-tjd
-tjd
-vuv
-rjz
-ivm
-rjz
-eAQ
-rjz
-vuv
-gmL
-ghw
-iWH
-vuv
-vuv
-hOR
-ezl
-weW
-weW
-tur
+srd
+azs
+uFR
+gua
+pnI
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+xVz
+xVz
+rZw
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -36664,8 +40871,8 @@ eLE
 uoO
 uoO
 uoO
-lnr
-lnr
+gpM
+gpM
 lnr
 uoO
 uoO
@@ -36787,95 +40994,95 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
 uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
 aoj
 aoj
-uoO
-uoO
 uoO
 uoO
 uoO
 eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
-eAQ
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+jPC
+qrc
 xVz
-ajk
-ckx
-ckx
-ckx
-ckx
-tjd
-tjd
-tjd
-vZW
-ftV
-nsa
-cFR
-jFx
-rjz
-eAQ
-rjz
-uoO
-uoO
-vuv
-tbE
-vuv
-rjz
-eAQ
-rjz
-eAQ
-rjz
-vuv
-nRP
-qyc
-riT
-vuv
-vuv
-hOR
-fGO
-weW
-weW
-tur
+xVz
+xVz
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -36908,8 +41115,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -36921,9 +41128,9 @@ eLE
 eLE
 eLE
 uoO
+gpM
 lnr
 lnr
-rKx
 lnr
 uoO
 eLE
@@ -37051,20 +41258,6 @@ uoO
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -37072,67 +41265,81 @@ aoj
 aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
-eAQ
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 xVz
-vZW
-ohv
-ipw
-jwp
-fAs
-gSQ
-ckx
-tjd
-vZW
-ftV
-icj
-tDW
-rjz
-eAQ
-rjz
-rjz
-rjz
-rjz
-ivm
-rjz
-rjz
-rjz
-rjz
-eAQ
-eAQ
-rjz
-vuv
-vuv
-wus
-vuv
-vuv
-vuv
-vuv
-fGO
-weW
-weW
-tur
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -37165,8 +41372,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -37309,90 +41516,90 @@ aoj
 aoj
 aoj
 aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
 aoj
-aoj
-aoj
-aoj
+uoO
 uoO
 uoO
 uoO
 uoO
 uoO
 eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
-uyz
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-tjd
-jmN
-ftV
-fBi
-sZJ
 uoO
-eAQ
-eAQ
-jFx
-rjz
-eAQ
-rjz
-eAQ
-rjz
-eAQ
-rCv
-rjz
-rjz
-rjz
-vuv
-ckx
-ckx
-vuv
-vuj
-hsH
-nqA
-fGO
-weW
-weW
-tur
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 aoj
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+jPC
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -37422,8 +41629,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -37562,12 +41769,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -37579,10 +41780,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -37593,63 +41790,73 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-eLE
 uoO
-qpG
-lOt
+uoO
+uoO
+uoO
+uoO
+uoO
+jPC
+lsl
+azs
+xVz
+xVz
+xVz
+xVz
+xVz
+mlz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+wKH
+xVz
+xVz
+xVz
+xVz
+xVz
 xVz
 uoO
 uoO
 uoO
 uoO
-vZW
-jmN
-sMc
-jmN
-ftV
-dUC
-org
+aoj
 uoO
-eAQ
-rjz
-rjz
-rjz
-rjz
-jFx
-rjz
-rjz
-eAQ
-rjz
-eAQ
-eAQ
-rrm
-vuv
-ckx
-ckx
-ask
-vuj
-vuj
-wpJ
-fGO
-weW
-weW
-tur
 uoO
 uoO
 uoO
 aoj
+uoO
 aoj
 aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -37679,8 +41886,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -37820,7 +42027,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -37835,14 +42041,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -37851,63 +42049,72 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-eLE
-uoO
-sUl
-jmN
-jmN
-jmN
-vZW
-vZW
-vZW
-vZW
-jmN
-tjd
-jmN
-eAQ
 uoO
 uoO
 uoO
-eAQ
-gsQ
-eAQ
-eAQ
-eAQ
-gsQ
-rjz
-rjz
-eAQ
-eAQ
-rjz
-eAQ
-vuv
-vuv
-tjd
-ckx
-tjd
-wKH
-wKH
-nqA
-fGO
-weW
-weW
-tur
+uoO
+azs
+azs
+azs
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
 uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+aoj
+uoO
 aoj
 aoj
+uoO
 aoj
+aoj
+uoO
 uoO
 eLE
 "}
@@ -38069,10 +42276,6 @@ uoO
 uoO
 aoj
 uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -38093,13 +42296,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -38110,61 +42306,72 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-eLE
 uoO
-sUl
-jmN
-tqZ
-wKH
-iDt
-bMq
-xYV
-sCZ
-vat
-tjd
-sXV
-fxN
 uoO
-dMQ
-dMQ
-dMQ
-dMQ
-dMQ
-lKT
-dMQ
-dMQ
-dMQ
-dMQ
-rjz
-eAQ
-rjz
-eAQ
-qWm
-tjd
-tjd
-ckx
-vuv
-jdP
-gyZ
-nqA
-fGO
-weW
-weW
-tur
+uoO
+azs
+azs
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+jPC
+uoO
 uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+aoj
+uoO
 aoj
 aoj
+uoO
 aoj
+aoj
+uoO
 uoO
 eLE
 "}
@@ -38196,8 +42403,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -38327,15 +42534,6 @@ uoO
 aoj
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -38350,13 +42548,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -38367,61 +42558,77 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-eLE
 uoO
-dmH
-jmN
-xYV
-wKH
-iDt
-vuj
-vuj
-sCZ
-ckx
-tjd
-jmN
-sUl
 uoO
-dMQ
-jHN
-uHt
-rqc
-dzJ
-vuj
-wKH
-ekK
-dYV
-wHf
-oFh
-uKP
-rjz
-frh
-vuv
-vuv
-ydV
-ckx
-vuv
-uRY
-dML
-hhe
-fGO
-weW
-weW
-tur
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+azs
+azs
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+buV
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
 uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+aoj
+uoO
 aoj
 aoj
+uoO
 aoj
+aoj
+uoO
 uoO
 eLE
 "}
@@ -38453,8 +42660,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -38592,28 +42799,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -38631,54 +42816,76 @@ uoO
 uoO
 uoO
 uoO
-eLE
 uoO
-eAQ
-jmN
-bWk
-ePk
-kWK
-sCZ
-fuE
-sCZ
-ckx
-gFu
-jmN
-tDl
-eUp
-dMQ
-rZZ
-jOe
-ghw
-ghw
-ghw
-wKH
-wKH
-wKH
-dMQ
-phP
-uKP
-eAQ
-eAQ
-rjz
-vuv
-doL
-hvw
-hfb
-vuv
-vuv
-vuv
-fGO
-weW
-weW
-tur
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+azs
+azs
+azs
+xVz
+vQn
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
 uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+aoj
+uoO
 aoj
 aoj
+uoO
 aoj
+aoj
+uoO
 uoO
 eLE
 "}
@@ -38710,8 +42917,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -38849,28 +43056,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -38888,53 +43073,75 @@ uoO
 uoO
 uoO
 uoO
-eLE
 uoO
-aLy
-sXV
-fEB
-gbH
-vpz
-tjd
-tjd
-tjd
-ckx
-lcn
-vZW
-ajM
-afj
-dMQ
-uPu
-ghw
-bsw
-pMg
-ozp
-wKH
-wKH
-wKH
-dMQ
-qDo
-uKP
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+azs
+azs
+azs
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+vuj
+xVz
+mlz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+buV
+xVz
+xVz
+xVz
+xVz
 eAQ
-rjz
-rjz
-vuv
-vuv
-vuv
-vuv
-vuv
+xVz
+xVz
+xVz
 uoO
-tEW
-wWF
-weW
-weW
-tur
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
+uoO
 aoj
 aoj
-aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -39100,98 +43307,98 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+azs
+azs
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+jPC
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+vQn
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 aoj
 aoj
 aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-eLE
-uoO
-eAQ
-jmN
-vXh
-uOE
-shF
-shF
-wuM
-shF
-tjd
-tjd
-vZW
-euY
-hyj
-dMQ
-tZq
-ghw
-vuj
-aGO
-toA
-gyB
-wKH
-hqg
-dMQ
-qJM
-rjz
-rjz
-rrm
-eAQ
-mTq
-mTq
-mTq
-mTq
-mTq
-mTq
-tur
-wWF
-lUI
-mNE
-tur
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 eLE
@@ -39394,6 +43601,13 @@ uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+tUT
+jPC
 uoO
 uoO
 uoO
@@ -39402,50 +43616,43 @@ uoO
 uoO
 uoO
 uoO
-eLE
-uoO
-eAQ
-jmN
-adY
-jej
-shF
-qwP
-wKH
-shF
-tjd
-oIo
-vZW
-eAQ
-uoo
-dMQ
-qAK
-ghw
-vuj
-vuj
-vuj
-wKH
-wKH
-hNq
-dMQ
-wHf
-dMQ
-dMQ
-wHf
-rjz
-xAw
-ckx
-odk
-gxq
-xCv
-mTq
-tur
-fGO
-weW
-weW
-tur
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+mlz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -39651,6 +43858,12 @@ uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -39659,50 +43872,44 @@ uoO
 uoO
 uoO
 uoO
-eLE
 uoO
-eAQ
-jmN
-vfi
-aCq
-gRa
-nfM
-awR
-shF
-tjd
-pjj
-vZW
-kTJ
 uoO
-dMQ
-dMQ
-rce
-wKH
-vuj
-wKH
-vuj
-wKH
-uMA
-dMQ
-kVD
-rXg
-rux
-wHf
-rjz
-qWm
-ckx
-yeZ
-kkU
-jak
-mTq
-tur
-fGO
-weW
-weW
-tur
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
+aoj
+aoj
+aoj
+aoj
 uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -39727,9 +43934,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -39749,6 +43953,9 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+eLE
 uoO
 uoO
 uoO
@@ -39881,6 +44088,53 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
@@ -39888,78 +44142,31 @@ aoj
 aoj
 aoj
 aoj
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-eLE
-uoO
-sUl
-jmN
-tUT
-tUT
-tUT
-jmN
-jmN
-vZW
-vZW
-vZW
-vZW
-vZW
-uoO
-bWl
-dMQ
-dMQ
-wKH
-pYA
-dEh
-xEg
-vuj
-wKH
-pnL
-vuj
-vuj
-wKH
-wHf
-eAQ
-mTq
-ckx
-ckx
-tjd
-tjd
-tjd
-hhe
-fGO
-weW
-weW
-tur
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -39982,19 +44189,19 @@ aoj
 aoj
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -40016,7 +44223,7 @@ lnr
 lnr
 uoO
 uoO
-lnr
+gpM
 uoO
 eLE
 uoO
@@ -40138,82 +44345,82 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+jPC
+qrc
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-eLE
 uoO
 xVz
 xVz
 xVz
-sUl
-dcV
-dcV
-ato
-vkD
-jeM
-imj
-xHZ
-urM
-xHZ
-xHZ
-xHZ
-dMQ
-pGw
-dMQ
-dMQ
-dMQ
-lKT
-dMQ
-dMQ
-nLK
-omq
-jgP
-dMQ
-rjz
-mTq
-ckx
-ckx
-ckx
-tjd
-tjd
-hhe
-fGO
-weW
-weW
-tur
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -40236,28 +44443,22 @@ uoO
 aoj
 uoO
 aoj
+uoO
+uoO
+eLE
+eLE
+uoO
+aoj
+aoj
 aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -40270,10 +44471,16 @@ uoO
 eLE
 uoO
 uoO
-lnr
 uoO
 uoO
-lnr
+uoO
+eLE
+uoO
+uoO
+gpM
+xVz
+uoO
+gpM
 uoO
 eLE
 uoO
@@ -40395,14 +44602,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -40426,51 +44625,17 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-eLE
 uoO
 uoO
 xVz
-eWV
-vZW
-vZW
-jmN
-jmN
-jmN
-jmN
-jmN
-urM
-jmN
-jmN
-jmN
-wQC
-dMQ
-vuj
-rAx
-pZr
-dMQ
-vuj
-nha
-wHf
-dMQ
-dMQ
-dMQ
-dMQ
-rjz
-mTq
-mTq
-tjd
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 ckx
-ckx
-tjd
-hhe
-fGO
-weW
-weW
-tur
 uoO
 uoO
 uoO
@@ -40478,6 +44643,48 @@ uoO
 uoO
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 eLE
 "}
@@ -40490,17 +44697,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -40515,6 +44711,13 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -40529,17 +44732,21 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-jiL
 uoO
 uoO
 uoO
@@ -40677,64 +44884,64 @@ uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-eLE
-eLE
 uoO
 xVz
 xVz
-vZW
-uZy
-qpY
-qFn
-vuj
-wKH
-wKH
-wKH
-wMy
-uFj
-jmN
-xHZ
-wFx
-vuj
-wKH
-tEH
-dMQ
-bud
-nha
-dMQ
-rca
-uKP
-eAQ
-uKU
-rjz
-vuv
-mTq
-hfb
-tjd
-ydV
-mTq
-tur
-fGO
-weW
-weW
-tur
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
 aoj
 aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 eLE
 "}
@@ -40747,17 +44954,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -40770,6 +44966,15 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+eLE
+blc
+blc
+blc
+blc
+blc
+eLE
 uoO
 uoO
 uoO
@@ -40785,12 +44990,14 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
 uoO
+xVz
+xVz
+xVz
 uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -40932,66 +45139,66 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-eLE
 uoO
 xVz
-ala
-vZW
-vuj
-vuj
-rXS
-vuj
-qez
-wKH
-acT
-wKH
-cNz
-jmN
-xHZ
-dMQ
-vuf
-vuf
-ehk
-dMQ
-jrV
-lAW
-dMQ
-rcf
-ubW
-wfG
-eAQ
-eAQ
-vuv
-mTq
-mTq
-mTq
-mTq
-mTq
-tur
-wIM
-weW
-weW
-tur
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
-aoj
 uoO
 aoj
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 eLE
 "}
@@ -41004,17 +45211,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -41029,7 +45225,13 @@ uoO
 uoO
 uoO
 uoO
-uoO
+eLE
+blc
+jiL
+eOt
+tUi
+blc
+eLE
 uoO
 uoO
 uoO
@@ -41045,15 +45247,20 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+uoO
+xVz
+xVz
+uoO
+uoO
+eLE
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
 eLE
 eLE
 eLE
@@ -41189,66 +45396,66 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-eLE
 uoO
 xVz
 xVz
-vZW
-vuj
-vuj
-wsK
-vuj
-ias
-wKH
-xxV
-vuj
-rsf
-jmN
-aNI
-dMQ
-dMQ
-dMQ
-dMQ
-dMQ
-dMQ
-dMQ
-dMQ
-rjz
-rjz
-rjz
-rjz
-rjz
-vuv
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
 uoO
 uoO
-tur
-wIM
-weW
-weW
-tur
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
-aoj
 uoO
-aoj
-aoj
+uoO
+uoO
 uoO
 eLE
 "}
@@ -41261,17 +45468,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -41286,7 +45482,13 @@ uoO
 uoO
 uoO
 uoO
-uoO
+eLE
+blc
+mot
+uGl
+oLG
+blc
+eLE
 uoO
 uoO
 uoO
@@ -41303,13 +45505,18 @@ uoO
 uoO
 uoO
 uoO
+eLE
+uoO
+uoO
+xVz
+uoO
+uoO
+eLE
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -41410,16 +45617,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -41444,14 +45641,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -41459,46 +45648,64 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 xVz
-ajk
-pab
-vuj
-aGv
-vuj
-rfH
-wKH
-lev
-vuj
-rsf
-sXV
-aNI
-sBm
-eAQ
-rjz
-rjz
-eAQ
-kSa
-eAQ
-eAQ
-rjz
-rjz
-rjz
-rjz
-rjz
-vuv
-vuv
-vuv
+xVz
+xVz
 uoO
 uoO
 uoO
-tur
-wIM
-weW
-weW
-tur
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
@@ -41518,17 +45725,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -41543,7 +45739,13 @@ uoO
 uoO
 uoO
 uoO
-uoO
+eLE
+blc
+mot
+eOt
+tWZ
+blc
+eLE
 uoO
 uoO
 uoO
@@ -41560,13 +45762,18 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
 uoO
+xVz
+xVz
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 gpM
 gpM
@@ -41667,16 +45874,81 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+tUT
+jPC
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -41690,72 +45962,7 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-eLE
-eLE
-uoO
-uoO
-vZW
-jZf
-vuj
-uMi
-vuj
-vnW
-vuj
-wfE
-vuj
-rsf
-jmN
-aNI
-aNI
-rjz
-eAQ
-rjz
-rjz
-rjz
-rjz
-rjz
-rrm
-qjs
-rjz
-rrm
-rjz
-jwm
-wKH
-vuv
-vuv
-vuv
-vuv
-tur
-fGO
-weW
-weW
-tur
 uoO
 uoO
 aoj
@@ -41775,17 +45982,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -41800,7 +45996,13 @@ uoO
 uoO
 uoO
 uoO
-uoO
+eLE
+blc
+mot
+eOt
+mot
+blc
+eLE
 uoO
 uoO
 uoO
@@ -41818,6 +46020,10 @@ uoO
 uoO
 uoO
 uoO
+eLE
+uoO
+uoO
+xVz
 uoO
 uoO
 uoO
@@ -41826,6 +46032,7 @@ uoO
 uoO
 uoO
 uoO
+xVz
 lnr
 uoO
 lnr
@@ -41924,95 +46131,95 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+mlz
+uoO
+uoO
+uoO
+uoO
+uoO
+mlz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-eLE
-uoO
-utr
-vZW
-hIy
-wKH
-abi
-wKH
-sPK
-vuj
-wUB
-vuj
-iER
-jmN
-aNI
-xHZ
-rjz
-eAQ
-eAQ
-eAQ
-eAQ
-eAQ
-eAQ
-sXV
-jmN
-teW
-jmN
-sXV
-vuv
-wKH
-vuj
-qUx
-ahB
-vuv
-hOR
-fGO
-weW
-weW
-tur
 uoO
 uoO
 aoj
@@ -42038,11 +46245,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -42051,38 +46253,43 @@ uoO
 uoO
 uoO
 uoO
+eLE
+blc
+pnL
+uop
+aKV
+blc
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+uoO
+xVz
+xVz
 uoO
 uoO
+xVz
+xVz
+xVz
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
 lnr
 lnr
 lnr
@@ -42151,14 +46358,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 uoO
 uoO
@@ -42183,31 +46382,6 @@ uoO
 uoO
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
 uoO
 uoO
 uoO
@@ -42222,56 +46396,89 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 aoj
 uoO
 uoO
+aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-eLE
-uoO
-alO
-vZW
-mHM
-wcm
-rbt
-vuj
-vuj
-vuj
-vgo
-hYr
-llV
-jmN
-aNI
-vuv
-vuv
-uyQ
-qXr
-jPC
-jPC
-vuv
-mzR
-jmN
-mba
-wKH
-bjr
-jmN
-vuv
-vuj
-vuj
-vuj
-vuj
-wHB
-ffJ
-miI
-weW
-weW
-tur
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -42303,6 +46510,24 @@ uoO
 uoO
 uoO
 uoO
+eLE
+blc
+qxv
+vIr
+gvW
+blc
+blc
+blc
+blc
+vYJ
+blc
+blc
+blc
+blc
+blc
+blc
+blc
+eLE
 uoO
 uoO
 uoO
@@ -42310,36 +46535,18 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+pmU
+xVz
+xVz
+xVz
+xVz
+xVz
 lnr
 lnr
 lnr
@@ -42411,128 +46618,128 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 eLE
 eLE
-bmc
-vZW
-jmN
-jmN
-wKH
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-urZ
-aNI
-qWm
-tjd
-tjd
-tjd
-tjd
-tjd
-vuv
-jmN
-vBA
-wKH
-wKH
-jmN
-vuv
-vuj
-ndk
-ndk
-vuj
-vuv
-hOR
-miI
-weW
-weW
-tur
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+mlz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
 uoO
 uoO
 aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -42560,6 +46767,24 @@ uoO
 uoO
 uoO
 uoO
+eLE
+blc
+qHc
+uop
+vIr
+blc
+jXq
+chC
+gEd
+mMd
+tAd
+qGS
+eAm
+iaz
+iaz
+rdM
+blc
+eLE
 uoO
 uoO
 uoO
@@ -42567,32 +46792,14 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -42668,126 +46875,126 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-oFg
-oFg
-oFg
-gED
-oFg
-oFg
-oFg
-gED
-oFg
-oFg
-oFg
-aCf
 eLE
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
 eLE
-bmc
-jmN
-urM
-jmN
-xHZ
-xHZ
-xHZ
-fmf
-xHZ
-aNI
-aNI
-vuv
-qLf
-ckx
-tjd
-tjd
-ckx
-ihg
-vuv
-jmN
-tZq
-wKH
-hqg
-jmN
-vuv
-vuj
-nTt
-upC
-xVt
-vuv
-tur
-miI
-weW
-weW
-tur
 uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
 aoj
 uoO
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+eAQ
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -42817,6 +47024,24 @@ uoO
 uoO
 uoO
 uoO
+eLE
+blc
+uzO
+eOt
+gUj
+jdH
+dns
+nvT
+icB
+wMX
+blc
+fdA
+gCz
+quL
+eAm
+syJ
+blc
+eLE
 uoO
 uoO
 uoO
@@ -42825,34 +47050,16 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -42922,129 +47129,129 @@ aoj
 aoj
 aoj
 uoO
-aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-sHo
-jFU
-klZ
-vMO
-bcv
-eGX
-ozm
-tKU
-vMO
-tKU
-xTR
-oFg
-oFg
-oFg
-wuY
+eLE
 jmN
-wKH
+bSS
+bSS
+bud
+bSS
+mSj
 jmN
-vuv
-gaf
-vuv
-vuv
-wKH
-aNI
-aNI
-vuv
-jKY
-hhi
-fkv
-kAp
-oRb
-ckx
-jPC
+dML
+dML
 jmN
-wKH
-wKH
-wKH
-jmN
-vuv
-vuj
-vuv
-vuv
-vuv
-vuv
-tur
-wWF
-weW
-weW
-tur
+eLE
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
+uoO
+uoO
 aoj
+aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+hQE
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -43074,6 +47281,24 @@ uoO
 uoO
 uoO
 uoO
+eLE
+blc
+blc
+cnA
+gMS
+blc
+blc
+blc
+blc
+blc
+blc
+krm
+sAl
+eAm
+wzt
+jXC
+blc
+eLE
 uoO
 uoO
 uoO
@@ -43083,32 +47308,14 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 eLE
 eLE
@@ -43178,133 +47385,133 @@ uoO
 aoj
 aoj
 aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-pvV
-iot
-wqi
-wqi
-wqi
-tFc
-oFg
-mLL
-bis
-tKU
-tKU
-tKU
-tKU
-kQO
-tKU
-tKU
-tKU
-xTR
-oFg
-ili
-dpV
-wuY
+eLE
 jmN
-vuj
+bSS
+aTr
+aWF
+bWl
+bSS
+dzJ
+bSS
+bSS
 jmN
-vuv
-miw
-vzR
-vuv
-xHZ
-aNI
-aNI
-vuv
-vuv
-vuv
-vuv
-vuv
-vuv
-vuv
-eug
-jmN
-nNR
-shF
-sfm
-jmN
-vuv
-vuj
-vuv
-smm
-gmL
-vuv
-tur
-wWF
-weW
-weW
-tur
+eLE
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
 aoj
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+tUT
+hQE
+uoO
+wKH
+xVz
+xVz
+uoO
+jPC
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+buV
+xVz
+xVz
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 eLE
 "}
@@ -43331,24 +47538,24 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+blc
+rfo
+aYg
+wtj
+wtj
+pPs
+dWJ
+ijq
+dEt
+rWG
+eAm
+rwI
+rwI
+cOk
+blc
+eLE
 uoO
 uoO
 uoO
@@ -43435,130 +47642,130 @@ uoO
 uoO
 aoj
 aoj
-aoj
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-gED
-guL
-tFc
-tFc
-tFc
-tFc
-tFc
-oFg
-lAR
-bjw
-tKU
-tKU
-kCx
-uVr
-jxG
-tKU
-tCt
-tKU
-evD
-oFg
-cxu
-dpV
-hmZ
+eLE
+eLE
+eLE
+eLE
+eLE
 jmN
-vuj
+bSS
+aWF
+buJ
+cid
+cQf
 jmN
-vuv
-tjd
-tjd
-vuv
-xHZ
-aNI
-aNI
-sBm
-aNI
-aNI
-aNI
-sBm
-aNI
-aNI
-aNI
+dMQ
+bSS
 jmN
-jmN
-jmN
-jmN
-jmN
-vuv
-vuj
-wus
-qyc
-jeE
-vuv
-tur
-wWF
-weW
-weW
-tur
+eLE
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+hQE
+qrc
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+bRX
+tUT
+hQE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -43589,23 +47796,23 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+blc
+cGV
+rrQ
+ijq
+ijq
+evP
+ijq
+wtj
+mTO
+dmy
+eAm
+rwI
+lyc
+jEt
+blc
+eLE
 uoO
 uoO
 uoO
@@ -43692,129 +47899,129 @@ uoO
 uoO
 aoj
 aoj
-aoj
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-oFg
-wWc
-tFc
-tFc
-tFc
-tFc
-tFc
-oFg
-mln
-tKU
-tKU
-tKU
-qYq
-qsr
-feB
-tKU
-tKU
-tKU
-xSb
-oFg
-rFQ
-dpV
-oFg
+eLE
 jmN
-vuj
 jmN
-vuv
-qmV
-oXs
-vuv
-dnu
-aNI
-gaf
-vuv
-vuv
-vuv
-vuv
-vuv
-vuv
-vuv
-vuv
-vuv
-vuv
-vuv
-vuv
-vuv
-vuv
-jro
-vuv
-vuv
-vuv
-vuv
-tur
-wWF
-weW
-weW
-tur
+jmN
+jmN
+jmN
+bSS
+bcv
+aWF
+ckZ
+cWd
+dAK
+dUC
+wjU
+jmN
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+uyQ
+xVz
+xVz
+xVz
+xVz
+vSd
+mlz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -43838,7 +48045,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -43847,22 +48053,23 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+blc
+wtj
+wSg
+vag
+ijq
+cGV
+rBa
+viS
+fLU
+eAm
+aIH
+oxm
+svD
+eup
+blc
+eLE
 uoO
 uoO
 uoO
@@ -43949,128 +48156,128 @@ aoj
 uoO
 aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-oFg
-pvV
-tFc
-jlt
-jlt
-oXu
-tFc
-oFg
-tKU
-tKU
-tKU
-aeS
-aeS
-aeS
-vCM
-tKU
-tKU
-tKU
-lWy
-oFg
-hHz
-dpV
-oFg
+eLE
 jmN
-vuj
+ahB
+alO
+ask
 jmN
-vuv
-vuv
-vuv
-vuv
-xHZ
-urZ
-wKH
-cIA
-pmU
-ygp
-wKH
-wKH
-uQO
-kRE
-naY
-xkd
-ckx
-oZF
-ygC
-qgP
-vuv
-rxG
-rxG
-mBn
-rxG
-cqT
-tur
-miI
-weW
-weW
-tur
+awR
+bSS
+bBf
+bSS
+qSf
+jmN
+lsJ
+bSS
+jmN
+eLE
+eLE
+eLE
+eLE
+eLE
+uoO
+uoO
 uoO
 aoj
+aoj
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uzc
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -44089,13 +48296,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -44110,16 +48310,23 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+blc
+gui
+kHi
+uvV
+fLU
+fLU
+fLU
+ovF
+fLU
+juj
+fLU
+fLU
+xyU
+ovF
+blc
+eLE
 uoO
 uoO
 uoO
@@ -44206,128 +48413,128 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-boc
-oFg
-nkf
-adx
-kQO
-hOz
-nkf
-adx
-oFg
-nMh
-nkf
-adx
-oFg
-oFg
-oFg
-pXC
-oFg
+eLE
 jmN
-lzW
+ajk
+ajk
+ajk
+aty
+bSS
+aTr
+aWF
+bWl
+kJJ
+dAK
+dWi
+wjU
 jmN
-eeX
-eeX
-eeX
-fXm
-aNI
-aNI
-vuv
-vuv
-ncx
-ncx
-wKH
-ncx
-ncx
-iWE
-vuv
-tjd
-sdI
-vuv
-tjd
-ckx
-vuv
-lnr
-weW
-weW
-weW
-cqT
-tur
-miI
-weW
-weW
-rwQ
+jmN
+jmN
+jmN
+jmN
+eLE
+uoO
+uoO
 uoO
 aoj
+aoj
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+hQE
+hQE
+hQE
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+jPC
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -44346,11 +48553,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -44365,18 +48567,23 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+blc
+ujL
+baE
+erD
+ovF
+wql
+tGU
+dUz
+mjq
+dyS
+nfo
+uAs
+wql
+epS
+blc
+eLE
 uoO
 uoO
 uoO
@@ -44463,132 +48670,132 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+eLE
+jmN
+ajk
+ajk
+ajk
+jmN
+bSS
+bek
+buJ
+cid
+cWn
+jmN
+dYV
+bSS
+vbY
+bSS
+ecf
+smu
+jmN
+eLE
 uoO
 uoO
 uoO
 aoj
 aoj
+uoO
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
 aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 xVz
-pQq
-iaO
-oFg
-lYZ
-ppv
-lYZ
-uif
-lYZ
-lYZ
-lYZ
-lYZ
-lYZ
-lYZ
-lYZ
-lYZ
-lYZ
-mFW
-lYZ
-lYZ
-ppv
-lYZ
-oFg
-jmN
-wKH
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-eeX
-vuv
-wjW
-ikD
-ckZ
-pvI
-esG
-gUm
-vuj
-qVG
-ckx
-tjA
-vuv
-tjd
-ckx
-vuv
-cqT
-weW
-cqT
-weW
-cqT
-tur
-wIM
-weW
-weW
-rwQ
+xVz
+xVz
+hQE
+uMi
+uZy
+xVz
+tUT
+hQE
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
 uoO
 aoj
+aoj
+aoj
+uoO
 uoO
 aoj
+aoj
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -44603,11 +48810,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -44622,18 +48824,23 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+blc
+baE
+baE
+pPr
+blc
+fLU
+fLU
+qLE
+fLU
+wHP
+fLU
+fLU
+fLU
+fLU
+blc
+eLE
 uoO
 uoO
 uoO
@@ -44720,129 +48927,129 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-xVz
-xVz
-xVz
-xVz
-qZq
-lYZ
-lYZ
-lYZ
-uif
-lYZ
-lYZ
-wfh
-lYZ
-lYZ
-lYZ
-wfh
-lYZ
-lYZ
-mFW
-lYZ
-lYZ
-lYZ
-lYZ
-oFg
+eLE
 jmN
-wKH
-hgP
-tjd
-tjd
-tjd
-kvL
+ajM
+ajk
+ato
 jmN
-eeX
-vuv
-vuj
-giA
-sfI
-pvI
-xLd
-thH
-vuj
-jSJ
-iNY
-gni
-vuv
-hfb
-kfQ
-vuv
-cqT
-weW
-cqT
-weW
-cqT
-tur
-ezl
-weW
-weW
-rwQ
+bSS
+bcv
+aWF
+ckZ
+bSS
+dzJ
+bSS
+bSS
+vbY
+bSS
+bSS
+jwv
+jmN
+eLE
+uoO
+uoO
 uoO
 uoO
 aoj
+uoO
+aoj
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+hQE
+hQE
+hQE
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+xVz
+xVz
+tUT
+jPC
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -44857,15 +49064,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -44883,14 +49081,23 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+blc
+hqw
+pPr
+mQO
+blc
+wox
+ieG
+gbx
+fLU
+ioV
+fLU
+wiq
+pMj
+jJO
+blc
+eLE
 uoO
 uoO
 uoO
@@ -44977,6 +49184,26 @@ uoO
 uoO
 uoO
 uoO
+eLE
+jmN
+ala
+anB
+ala
+jmN
+bSS
+bSS
+bBZ
+bSS
+bSS
+jmN
+qFX
+bSS
+vbY
+sEL
+bSS
+eIS
+jmN
+eLE
 uoO
 uoO
 uoO
@@ -44984,39 +49211,7 @@ uoO
 aoj
 aoj
 aoj
-aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 aoj
 uoO
 uoO
@@ -45038,65 +49233,77 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-poI
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 xVz
-wcF
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-sMQ
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-lYZ
-cBH
-lYZ
-lYZ
-oFg
-jmN
-urM
-jmN
-doL
-tjd
-qwV
-hfb
-jmN
-eeX
-vuv
-vuv
-jYt
-jug
-vuj
-jug
-tcC
-vuv
-vuv
-tJD
-vuv
-vuv
-vuv
-vuv
-vuv
-cqT
-gev
-cqT
-eCE
-cqT
-tur
-wIM
-lUI
-mNE
-tur
+xVz
+ckx
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -45114,15 +49321,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -45140,14 +49338,23 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+blc
+aLk
+baE
+mQO
+blc
+nKL
+tCo
+wtj
+fLU
+wql
+fLU
+oZe
+gON
+jSc
+blc
+eLE
 uoO
 uoO
 uoO
@@ -45234,134 +49441,134 @@ lnr
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-xVz
-dfO
-xVz
-uoO
-uoO
-oFg
-xbP
-fNk
-idi
-pzu
-pzu
-oFg
-czF
-lYZ
-edM
-edM
-oFg
-lYZ
-igD
-lYZ
-lYZ
-oFg
+eLE
 jmN
-vTH
 jmN
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-hOR
-ldZ
-jQU
-jQU
-jQU
-jQU
-hOR
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-miI
-weW
-weW
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+coe
+dcV
+jmN
+jmN
+wjU
+jmN
+eom
+bSS
+tHF
+jmN
+eLE
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+hQE
+qrc
+xVz
+xVz
+xVz
+mlz
+xVz
+uzc
+uyQ
+xVz
+xVz
+uoO
+jPC
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 eLE
 "}
 (89,1,1) = {"
@@ -45371,15 +49578,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -45397,14 +49595,23 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+blc
+wNN
+uei
+kHi
+blc
+wol
+rog
+swZ
+fLU
+baX
+fLU
+cSU
+xpJ
+jJO
+fLU
+eLE
 uoO
 uoO
 uoO
@@ -45491,46 +49698,34 @@ lnr
 lnr
 lnr
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+jmN
+azr
+azr
+azr
+azr
+azr
+dEh
+jmN
+bSS
+bSS
+eoC
+xsc
+bSS
+jmN
+jmN
+jmN
+jmN
+jmN
 uoO
 uoO
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
 aoj
 uoO
 uoO
@@ -45542,7 +49737,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -45552,73 +49746,86 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+vuj
+uoO
+uoO
+uoO
+vuj
+xVz
+xVz
+tUT
+hQE
+xVz
+uoO
+uoO
+xVz
 xVz
 uoO
 uoO
 uoO
-oFg
-pzu
-pzu
-pzu
-pzu
-pzu
-oFg
-ljj
-lYZ
-lYZ
-lYZ
-nCD
-lYZ
-igD
-lYZ
-lYZ
-gED
-jmN
-vTH
-vTH
-dLJ
-weW
-weW
-weW
-weW
-iHB
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-nuA
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-mCL
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 eLE
 "}
 (90,1,1) = {"
@@ -45628,11 +49835,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -45650,18 +49852,23 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+blc
+oUM
+mQO
+mHc
+blc
+lvL
+vEc
+jQK
+fLU
+mNc
+ovF
+ijq
+viS
+eIo
+blc
+eLE
 uoO
 uoO
 uoO
@@ -45751,131 +49958,131 @@ lnr
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-mNF
-pzu
-pzu
-pzu
-tfB
-oFg
-xvS
-lYZ
-lYZ
-eBn
-oFg
-lYZ
-igD
-lYZ
-lYZ
-oFg
+eLE
 jmN
-bBf
-qdZ
-oOR
-weW
-weW
-weW
-weW
-iHB
-weW
-weW
-weW
-iHB
-weW
-weW
-iHB
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-nuA
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-mCL
+azr
+beY
+bEw
+crg
+dgy
+azr
+dcV
+bSS
+bSS
+bSS
+bSS
+qSf
+jmN
+fbC
+aNG
+fuE
+jmN
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+hQE
+uoO
+uoO
+uoO
+hQE
+xVz
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 eLE
 "}
 (91,1,1) = {"
@@ -45885,11 +50092,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -45907,18 +50109,23 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+blc
+mQO
+kHi
+wtj
+blc
+vAp
+wtj
+wfn
+fLU
+byb
+fLU
+max
+ijq
+jJO
+blc
+eLE
 uoO
 uoO
 uoO
@@ -46008,131 +50215,131 @@ lnr
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-pzu
-pzu
-pzu
-pzu
-pzu
-oFg
-dEG
-lYZ
-lYZ
-lYZ
-nCD
-lYZ
-efX
-lYZ
-lYZ
-oFg
+eLE
 jmN
-qdZ
-qdZ
-gBq
-miI
-qvI
-qvI
-miI
-mGg
-bcM
-pBk
-jFB
-jFB
-wWF
-wWF
-mGg
-bcM
-bcM
-pBk
-pBk
-pBk
-pBk
-bcM
-bcM
-bcM
-bcM
-xfu
-vWg
-xfu
-mGg
-nnz
-nZI
-eoC
-bcM
-bcM
-eoC
-xfu
-bcM
-bcM
-bcM
-bcM
-mCL
+aCf
+bgu
+bSS
+crt
+dkZ
+dFC
+dcV
+bSS
+bSS
+jqg
+bSS
+bSS
+jmN
+gOB
+fkv
+jmN
+jmN
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 eLE
 "}
 (92,1,1) = {"
@@ -46141,12 +50348,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -46165,17 +50366,23 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+blc
+dQk
+baE
+aaM
+blc
+dOI
+wRb
+uoR
+fLU
+jZI
+fLU
+ehS
+hhI
+acJ
+blc
+rex
 uoO
 uoO
 uoO
@@ -46265,131 +50472,131 @@ lnr
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-hsK
-hsK
-dYr
-xEd
-iPr
-oFg
-czF
-lYZ
-lYZ
-rln
-oFg
-mDK
-lYZ
-lYZ
-lYZ
-oFg
+eLE
 jmN
-rwQ
-rwQ
-rwQ
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-nue
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-wXG
-epZ
-tur
-ufQ
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
+azr
+bis
+bSS
+cuz
+dkZ
+azr
+dcV
+xsc
+bSS
+bSS
+bSS
+xsc
+wjU
+fbD
+flP
+mTN
+fAs
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 eLE
 "}
 (93,1,1) = {"
@@ -46398,12 +50605,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -46421,36 +50622,42 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+blc
+kHi
+mSo
+anL
+tEv
+blc
+sVN
+oBa
+blc
+vPH
+cKK
+blc
+caS
+blc
+blc
+udr
+wzs
+wzs
+hkD
+jmN
+jmN
+eoy
+hkD
+hkD
+eoy
+eoy
+eoy
+eoy
+eoy
+eoy
+eoy
+eoy
+eoy
+eoy
 eoy
 eoy
 eoy
@@ -46522,50 +50729,33 @@ tur
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+eLE
+jmN
+azr
+bjr
+bHz
+cAb
+dmH
+azr
+jmN
+bSS
+mSj
+sEL
+sEL
+bSS
+jmN
+gOB
+fkv
+jmN
+jmN
+xVz
+xVz
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -46578,6 +50768,9 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -46588,60 +50781,74 @@ uoO
 uoO
 uoO
 uoO
-oFg
-oFg
-oFg
-gED
-oFg
-oFg
-oFg
-oFg
-bEp
-oro
-oFg
-oFg
-oFg
-oFg
-mZH
-mZH
-oFg
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-tur
-iHB
-tur
 uoO
 uoO
 uoO
-tur
-xhF
-nEr
-fTt
-gFV
-cOn
-tjd
-igH
-bEw
-bEw
-dFC
-tur
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -46655,13 +50862,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -46679,35 +50879,42 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+rXA
+kHi
+rXA
+xSA
+qIw
+jgR
+wtj
+ijq
+rRT
+wtj
+wtj
+hLw
+kHi
+rXA
+rXA
+gTa
+nBk
+nBk
+nBk
+nBk
+nBk
+nBk
+nBk
+mcH
+nBk
+nBk
+mRT
+nBk
+nBk
+nBk
+nBk
+nBk
+nBk
+dyv
 nBk
 nBk
 nBk
@@ -46780,125 +50987,125 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-uub
-mmL
-uub
-uub
-uub
-uub
-mmL
-uub
-lwc
-oVe
-uRL
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-uoO
-uoO
 eLE
-tur
-iHB
-tur
+jmN
+azr
+azr
+aWF
+cFR
+azr
+azr
+jmN
+eeX
+uiz
+epH
+adc
+qSf
+jmN
+ffJ
+fmf
+cyT
+jmN
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
-tur
-xhF
-nEr
-fKq
-fNr
-qyC
-gWc
-ckx
-ckx
-tII
-vuj
-tur
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -46929,42 +51136,42 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+rXA
+rXA
+uzr
+jEg
+lcr
+cgm
+wtj
+wtj
+wtj
+gZL
+vag
+iFe
+rXA
+uKE
+kHi
+eth
+bMb
+nBk
+nBk
+nBk
+nBk
+mRT
+dhi
+dhi
+nBk
+nBk
+nBk
+nBk
+nBk
+nBk
+nBk
+nBk
+nBk
+nBk
 nBk
 nBk
 nBk
@@ -47037,129 +51244,129 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-uub
-gAz
-dJQ
-bof
-gAz
-dJQ
-bof
-uub
-ssQ
-oVe
-oVe
-oFg
-xSb
-hIl
-llv
-tKU
-ovY
-oFg
-uug
-lhQ
-uel
-lhQ
-tsK
-olw
-tsK
-olw
-hMA
-oFg
-aoj
-uoO
 eLE
-tur
-iHB
-tur
+jmN
+aCf
+azr
+aCq
+azr
+azr
+dJc
+jmN
+bSS
+uiz
+epZ
+eCx
+eLb
+jmN
+jmN
+jmN
+jmN
+jmN
+aoj
+aoj
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
-tur
-bEw
-nEr
-nEr
-nEr
-cOn
-cOn
-wrg
-tjd
-ckx
-nJB
-tur
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
 uoO
 uoO
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+aoj
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 eLE
 "}
@@ -47186,42 +51393,42 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+rXA
+itL
+koJ
+wtj
+ijq
+ijq
+ijq
+mLa
+rBa
+gKv
+wtj
+oDN
+ydr
+iau
+kgo
+gTa
+nBk
+nBk
+nBk
+nBk
+nBk
+nBk
+dhi
+vqj
+nBk
+nBk
+nBk
+nBk
+nBk
+nBk
+nBk
+nBk
+nBk
+mRT
 nBk
 nBk
 nBk
@@ -47294,129 +51501,129 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-uub
-gAz
-dJQ
-bof
-gAz
-dJQ
-bof
-uub
-ssQ
-oVe
-oVe
-qUO
-tKU
-vLg
-dpt
-rvI
-tKU
-oFg
-vWr
-ycj
-jQV
-lhQ
-tsK
-olw
-tsK
-olw
-lhQ
-oFg
-uoO
-uoO
 eLE
-tur
-iHB
-tur
-tur
-tur
-tur
-tur
-wkN
-cOn
-cOn
-vuj
-ioO
-vra
-wKH
-vWZ
-eom
-gNZ
-tur
+jmN
+azr
+azr
+aWF
+aWF
+azr
+azr
+dzJ
+bSS
+bSS
+eoC
+eoC
+bSS
+jmN
+eLE
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+qDR
+xVz
+uoO
 uoO
 aoj
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+vuj
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+mlz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 eLE
 "}
@@ -47443,42 +51650,42 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
+blc
+jkJ
+iFe
+ijq
+fLU
+fLU
+fLU
+uCN
+fLU
+fLU
+fLU
+ogz
+snF
+fLU
+rXA
+gTa
 uoO
+hQE
 uoO
+hQE
+hQE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+hQE
+hQE
+hQE
+gFg
+eoy
+eoy
+eoy
+mVU
+eoy
+eoy
+eoy
+eoy
 eoy
 eoy
 eoy
@@ -47551,129 +51758,129 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-uub
-gAz
-dJQ
-bof
-gAz
-dJQ
-bof
-uub
-ssQ
-oVe
-oVe
-qUO
-tKU
-uVY
-tzH
-tKU
-tKU
-oFg
-lhQ
-lhQ
-kwJ
-lhQ
-lhQ
-lhQ
-lhQ
-lhQ
-lhQ
-oFg
-uoO
-uoO
 eLE
-tur
-iHB
-uKB
-xhF
-xhF
-xhF
-wKH
-tjd
-wKH
-xhF
-xhF
-xhF
-hEp
-tur
-rrq
-tur
-tur
-tur
+jmN
+aCq
+bjw
+bIh
+bIh
+dnu
+azr
+jmN
+efa
+bSS
+bSS
+bSS
+bSS
+jmN
+eLE
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+jPC
+aoj
+aoj
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 eLE
 "}
@@ -47700,6 +51907,24 @@ uoO
 uoO
 uoO
 uoO
+eLE
+uoO
+blc
+luy
+ijq
+wtj
+fLU
+xFI
+avY
+ijq
+avY
+geL
+fLU
+pOm
+jAL
+wql
+blc
+eLE
 uoO
 uoO
 uoO
@@ -47710,31 +51935,13 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eoy
+leM
+dxj
+dxj
+dxj
+hyn
+eoy
 uoO
 uoO
 uoO
@@ -47804,128 +52011,128 @@ weW
 weW
 drV
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-uub
-gAz
-dJQ
-bof
-gAz
-dJQ
-bof
-uub
-ssQ
-oVe
-oVe
-qUO
-tKU
-tKU
-tKU
-tKU
-tKU
-kot
-lhQ
-lhQ
-lhQ
-lhQ
-tsK
-olw
-tsK
-olw
-lhQ
-oFg
 uoO
 uoO
 eLE
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tjd
-siP
-vuj
-vuj
-oyr
-xhF
-tur
-ghw
-rjq
-tur
+jmN
+azr
+bjF
+bJG
+bSS
+dkZ
+azr
+jmN
+jmN
+vbY
+vbY
+xVR
+jmN
+jmN
+eLE
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -47957,6 +52164,24 @@ uoO
 uoO
 uoO
 uoO
+eLE
+uoO
+blc
+bFl
+ijq
+wtj
+snF
+rfo
+aiI
+mLa
+xFI
+omU
+fLU
+fLU
+fLU
+eBj
+blc
+eLE
 uoO
 uoO
 uoO
@@ -47967,31 +52192,13 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eoy
+jlp
+rei
+jel
+rei
+wle
+eoy
 uoO
 uoO
 uoO
@@ -48061,133 +52268,133 @@ weW
 weW
 wmT
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-uub
-uub
-uub
-uub
-uub
-uub
-uub
-uub
-sNu
-oVe
-oVe
-oFg
-jKM
-cyG
-emX
-jYL
-tKU
-oFg
-lhQ
-xDr
-lhQ
-lhQ
-tsK
-olw
-tsK
-olw
-lhQ
-oFg
 uoO
 uoO
 eLE
+jmN
+aCf
+bis
+bMq
+cIa
+doL
+dFC
+dcV
+tZO
+tZO
+tZO
+tZO
+tZO
+jmN
 eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-tur
-tur
-kFg
-qcp
-jKY
-fbD
-aGH
-tur
-tZf
-vQn
-tur
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 eLE
 "}
@@ -48202,9 +52409,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -48217,6 +52421,24 @@ uoO
 uoO
 uoO
 uoO
+eLE
+blc
+blc
+wtj
+vcc
+acJ
+fLU
+sFr
+ijq
+vBG
+eQZ
+sFr
+fLU
+hKR
+jJA
+eph
+blc
+eLE
 uoO
 uoO
 uoO
@@ -48227,28 +52449,13 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eoy
+tXj
+dxj
+dxj
+dxj
+ccU
+eoy
 uoO
 uoO
 uoO
@@ -48322,129 +52529,129 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-mZH
-oFg
-pZt
-pZt
-pZt
-oFg
-oFg
-ulE
-oFg
-qEf
-oVe
-oFg
-oFg
-oFg
-oFg
-oFg
-gct
-oFg
-qjd
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
 eLE
+jmN
+azr
+bmc
+bRs
+cIA
+doZ
+azr
+dcV
+tZO
+ekK
+vPm
+vPm
+ikX
+jmN
 eLE
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-lnr
-tur
-tur
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 eLE
 "}
@@ -48459,9 +52666,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -48474,6 +52678,24 @@ uoO
 uoO
 uoO
 uoO
+eLE
+blc
+xLN
+ijq
+wAX
+wtj
+fLU
+oEw
+eVp
+wtj
+gIH
+wtj
+fLU
+qZB
+fNu
+aGz
+blc
+eLE
 uoO
 uoO
 uoO
@@ -48484,28 +52706,13 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eoy
+eoy
+eoy
+eoy
+eoy
+eoy
+eoy
 uoO
 aoj
 aoj
@@ -48579,128 +52786,128 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+jmN
+aCu
+azr
+bSL
+azr
+azr
+azr
+jmN
+egg
+vPm
+esG
+tZO
+tZO
+jmN
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
 aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-oVe
-oVe
-oVe
-oVe
-oVe
-rtO
-oFg
-oVe
-mFW
-oVe
-oVe
-mFW
-oVe
-oVe
-oVe
-oVe
-oVe
-oVe
-oVe
-oVe
-mFW
-nAJ
-oFg
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-uoO
-uoO
+xVz
+xVz
 xVz
 uoO
 uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -48716,9 +52923,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -48731,37 +52935,40 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+blc
+ykL
+ijq
+sFr
+wtj
+aZo
+fLU
+fLU
+fLU
+fLU
+ovF
+fLU
+wpi
+poJ
+wql
+blc
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 aoj
@@ -48836,125 +53043,125 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-ldY
-oVe
-oVe
-oVe
-oVe
-qOc
-oFg
-oVe
-mFW
-oVe
-oVe
-mFW
-oVe
-oVe
-kss
-oVe
-oVe
-oVe
-oVe
-oVe
-izq
-nAJ
-oFg
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+ehk
+jmN
+jmN
+jmN
+jmN
+jmN
 eLE
 uoO
-vYC
-qhk
+uoO
+uoO
+uoO
+uoO
+aoj
+xVz
+xVz
 xVz
 uoO
-tiS
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -48973,9 +53180,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -48988,37 +53192,40 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+blc
+lcr
+ijq
+vag
+akZ
+fLU
+nof
+rNs
+wtj
+ovF
+baX
+fLU
+fLU
+fLU
+sIq
+blc
+blc
+blc
+blc
+cKK
+blc
+blc
+blc
+blc
+blc
+blc
+blc
+blc
+blc
+blc
+blc
+blc
+eLE
 uoO
 uoO
 aoj
@@ -49093,31 +53300,31 @@ uoO
 uoO
 uoO
 uoO
+eLE
+jmN
+aGv
+bmj
+aNI
+cIG
+dpD
+dJx
+jmN
+ehY
+wfe
+jDW
+euY
+uBN
+jmN
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -49156,41 +53363,14 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-oFg
-bAz
-hMQ
-ifD
-qhB
-dOF
-oFg
-oFg
-oFg
-oVe
-uRL
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-vGI
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -49204,14 +53384,41 @@ uoO
 uoO
 uoO
 aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
 uoO
 eLE
 uoO
-hLd
-xVz
-qhk
-xVz
-xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -49230,9 +53437,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -49245,37 +53449,40 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+frc
+qfA
+kHi
+oUM
+kHi
+uCN
+wtj
+rMc
+nBr
+xHv
+dUz
+mjq
+bSU
+viw
+rWl
+hlu
+vsG
+mAf
+ijb
+lhg
+dyn
+lhg
+lhg
+ajn
+kvE
+ioV
+fLU
+bmv
+dAb
+suJ
+yjB
+fLU
+eLE
 uoO
 uoO
 aoj
@@ -49350,6 +53557,30 @@ uoO
 uoO
 uoO
 uoO
+eLE
+jmN
+aGH
+bqs
+bmj
+bmj
+dvZ
+dJV
+jmN
+wfe
+bvH
+wfe
+ezl
+wfe
+jmN
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -49366,32 +53597,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -49413,39 +53620,14 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-iPO
-oFg
-oVe
-oVe
-oFg
-ahe
-hCb
-iQC
-kSn
-lYZ
-lYZ
-lYZ
-oFg
-lec
-fGA
-bWY
-vTa
-mNM
-oFg
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -49458,17 +53640,42 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 eLE
 uoO
 uoO
-xVz
-uwt
-xVz
-wuf
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -49487,9 +53694,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -49502,37 +53706,40 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+blc
+mQO
+iFe
+kHi
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+nfv
+fLU
+snF
+fLU
+vLy
+hCT
+fmj
+eJU
+cQn
+dMb
+fTA
+nbC
+juj
+ijq
+qcb
+xyR
+mPK
+fLU
+eLE
 uoO
 uoO
 aoj
@@ -49607,128 +53814,128 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-oFg
-oFg
-nMh
-oFg
-oFg
-hBU
-lYZ
-lYZ
-lYZ
-lYZ
-fJM
-lYZ
-oFg
-lec
-fGA
-oFg
-mng
-ujx
-oFg
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-aoj
+eLE
+jmN
+aGO
+bmj
+bWa
+bmj
+dwF
+dLJ
+jmN
+wfe
+wfe
+wfe
+wfe
+ePe
+jmN
 eLE
 uoO
 uoO
-tiS
-gZF
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
 uoO
 aoj
+aoj
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -49756,40 +53963,40 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+hXB
+mQO
+kHi
+wtj
+ijq
+gtH
+wtj
+tMn
+ijq
+vcc
+wtj
+fLU
+wmf
+sFr
+wAX
+gsM
+fLU
+ifn
+ciN
+nss
+lhg
+qXq
+crx
+kvE
+baX
+dTO
+rrQ
+jHU
+uJx
+tIG
+fLU
+eLE
 uoO
 uoO
 aoj
@@ -49864,30 +54071,30 @@ uoO
 uoO
 uoO
 uoO
+eLE
+jmN
+aLy
+bmj
+bmj
+cNz
+bmj
+bWa
+eeG
+wfe
+uMz
+uAK
+eAk
+uAK
+jmN
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -49904,6 +54111,8 @@ uoO
 uoO
 aoj
 aoj
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -49940,26 +54149,6 @@ uoO
 uoO
 uoO
 uoO
-oFg
-jvg
-tKU
-tKU
-jvg
-oFg
-rsB
-qoB
-rGw
-qoB
-nhY
-lYZ
-lYZ
-vGI
-fGA
-fGA
-oFg
-oFg
-oFg
-oFg
 uoO
 uoO
 uoO
@@ -49971,8 +54160,20 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -49985,7 +54186,13 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -49998,11 +54205,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -50018,35 +54220,40 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+rex
+baE
+baE
+vag
+wtj
+ijq
+nGx
+wAX
+sFr
+caq
+unJ
+daW
+wtj
+ijq
+hRA
+lps
+nhq
+aqg
+nbx
+uKg
+fKv
+lGe
+rha
+fLU
+exF
+jwh
+uSi
+eQZ
+hGW
+afT
+fLU
+eLE
 uoO
 uoO
 aoj
@@ -50121,6 +54328,55 @@ uoO
 uoO
 uoO
 uoO
+eLE
+jmN
+aMg
+bsw
+bmj
+bmj
+bmj
+bmj
+eeT
+wfe
+wfe
+uAK
+eCE
+ePk
+jmN
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -50139,35 +54395,10 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
 aoj
 aoj
 uoO
@@ -50197,42 +54428,12 @@ uoO
 uoO
 uoO
 uoO
-oFg
-wry
-tKU
-tKU
-tKU
-nCD
-lYZ
-lYZ
-lYZ
-lYZ
-lYZ
-fJM
-qhW
-oFg
-cUk
-fGA
-bWY
-vTa
-mNM
-oFg
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 eLE
 eLE
 eLE
@@ -50245,6 +54446,12 @@ eLE
 eLE
 eLE
 eLE
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
 eLE
 "}
 (108,1,1) = {"
@@ -50255,15 +54462,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -50279,31 +54477,40 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+blc
+xFI
+baE
+aiI
+mfi
+wtj
+ijq
+wtj
+wtj
+ijq
+hoc
+fLU
+uSi
+acJ
+ijq
+ijq
+fLU
+fKv
+lhg
+tqF
+rjs
+jGd
+sxm
+fLU
+nfo
+dTO
+ioj
+oAm
+wnT
+wMa
+fLU
+eLE
 uoO
 uoO
 uoO
@@ -50378,11 +54585,30 @@ uoO
 uoO
 uoO
 uoO
+eLE
+jmN
+aNI
+bmj
+bWk
+cOn
+dyQ
+dLK
+jmN
+ekE
+wfe
+eug
+cOb
+uAK
+jmN
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
+azs
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -50399,6 +54625,8 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -50409,71 +54637,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-jvg
-tKU
-tKU
-jvg
-oFg
-oZJ
-oZJ
-oZJ
-oZJ
-jaY
-jaY
-jaY
-oFg
-lec
-fGA
-oFg
-mng
-ujx
-oFg
 uoO
 uoO
 uoO
@@ -50491,15 +54654,59 @@ uoO
 uoO
 aoj
 aoj
-uoO
-uoO
-uoO
+aoj
+aoj
 aoj
 aoj
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -50512,15 +54719,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -50536,31 +54734,40 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+blc
+uSi
+ijq
+wtj
+mbC
+rOZ
+sgL
+oSG
+btu
+oSG
+fLU
+fLU
+fLU
+sRL
+baX
+fLU
+fLU
+ibo
+fKv
+jvJ
+lhg
+ngv
+nvn
+fLU
+jew
+jwh
+xdM
+wJk
+wnT
+rde
+fLU
+eLE
 uoO
 uoO
 uoO
@@ -50635,113 +54842,113 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-tKU
-tKU
-tKU
-hMw
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
-lec
-fGA
-oFg
-oFg
-oFg
-oFg
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+azs
+azs
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 aoj
@@ -50769,11 +54976,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -50789,35 +54991,40 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+blc
+lue
+wAX
+ijq
+sWM
+tAO
+cLR
+wtj
+wmf
+tfi
+jcB
+nox
+sVV
+mNc
+wql
+yfm
+fLU
+fLU
+fLU
+fLU
+snF
+fLU
+fLU
+fLU
+qBn
+xyU
+ibv
+loe
+jLI
+vyt
+fLU
+eLE
 uoO
 uoO
 uoO
@@ -50892,11 +55099,29 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
+nBk
+nBk
 uoO
 uoO
 uoO
@@ -50915,6 +55140,58 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -50928,77 +55205,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-jvg
-ukI
-wyl
-jvg
-oFg
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-oFg
-lec
-fGA
-bWY
-vTa
-mNM
-oFg
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 aoj
@@ -51027,7 +55234,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -51042,39 +55248,40 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+blc
+kXo
+vag
+nGx
+sWM
+xFI
+ijq
+adf
+wtj
+ijq
+baX
+dUz
+pho
+pwR
+bxQ
+tcT
+uJt
+aNQ
+wql
+ylz
+ciS
+uYD
+esM
+aOz
+lOo
+ovF
+ahI
+rBa
+vyt
+urt
+fLU
+eLE
 uoO
 uoO
 uoO
@@ -51170,6 +55377,8 @@ tur
 tur
 tur
 tur
+nBk
+nBk
 tur
 tur
 tur
@@ -51177,6 +55386,7 @@ tur
 tur
 tur
 tur
+hkD
 uoO
 uoO
 uoO
@@ -51225,26 +55435,12 @@ uoO
 uoO
 uoO
 uoO
-oFg
-oFg
-oFg
-oFg
-oFg
-oFg
 uoO
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-oFg
-oFg
-oFg
-oFg
-mng
-ujx
-oFg
 uoO
 uoO
 uoO
@@ -51256,6 +55452,17 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
 uoO
 aoj
 aoj
@@ -51284,7 +55491,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -51299,39 +55505,40 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+blc
+rXA
+kHi
+ijq
+fLU
+fLU
+fLU
+lHn
+fLU
+fLU
+bHO
+blc
+blc
+tEv
+blc
+wLp
+bHO
+blc
+blc
+blc
+blc
+blc
+blc
+blc
+qLE
+blc
+blc
+blc
+yeT
+blc
+blc
+eLE
 uoO
 uoO
 uoO
@@ -51433,52 +55640,9 @@ nBk
 nBk
 nBk
 nBk
+nBk
+nBk
 tur
-tur
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 aoj
@@ -51489,19 +55653,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-oFg
-oFg
-oFg
-oFg
 uoO
 uoO
 uoO
@@ -51513,6 +55664,62 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
 uoO
 aoj
 aoj
@@ -51555,40 +55762,40 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
 uoO
+rXA
+fmB
+vag
+xFI
+wtj
+wtj
+bOv
+ijq
+aiI
+oQd
+wtj
+nEo
+tMn
+bUK
+nRh
+yjB
+wtj
+loe
+xOE
+tMn
+gfb
+ijq
+ugu
+nRh
+cGy
+eLE
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+fAl
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -51691,7 +55898,7 @@ nBk
 nBk
 nBk
 nBk
-tur
+nBk
 dXE
 uoO
 uoO
@@ -51738,25 +55945,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -51770,6 +55958,25 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
 uoO
 uoO
 uoO
@@ -51802,7 +56009,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -51813,39 +56019,40 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
 uoO
+rXA
+rXA
+jRu
+tfZ
+wtj
+sFr
+unJ
+gZL
+wtj
+hWB
+viS
+ijq
+ijq
+uUO
+ijq
+vag
+bUK
+yjB
+wtj
+mfb
+wtj
+wtj
+gui
+oUM
+baE
+eLE
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+uee
+eAL
+eLE
 uoO
 uoO
 uoO
@@ -51941,7 +56148,7 @@ tur
 tur
 tur
 tur
-tur
+lnr
 tur
 tur
 tur
@@ -51995,24 +56202,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -52027,6 +56216,24 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
 uoO
 uoO
 uoO
@@ -52069,40 +56276,40 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
 uoO
+rXA
+vyt
+urt
+xLN
+ijq
+nGx
+ijq
+wtj
+vcc
+oQd
+nRh
+fkm
+lsn
+ijq
+pFb
+fmB
+kHi
+ijq
+ugu
+rBa
+wtj
+fRU
+vag
+uHb
+rXA
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+onS
+cSY
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -52252,10 +56459,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -52284,6 +56487,10 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+eLE
 uoO
 uoO
 uoO
@@ -52315,7 +56522,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -52327,39 +56533,40 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+blc
+cFS
+bHO
+blc
+blc
+blc
+blc
+blc
+blc
+djM
+blc
+blc
+pZm
+nAM
+mgu
+vag
+mgu
+cnS
+pZm
+fLU
+fLU
+fLU
+rXA
+fLU
+fLU
+eLE
+gwD
+dNN
+cSY
+waj
+eLE
 uoO
 uoO
 uoO
@@ -52509,13 +56716,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -52541,6 +56741,13 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLE
 uoO
 uoO
 uoO
@@ -52580,43 +56787,43 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+eLE
+uoO
+eLE
+uoO
+iSV
+ksD
+buV
+pbu
+xVz
 uoO
 uoO
 uoO
 uoO
+hyd
+lzR
+lDm
+hDP
+any
+hyd
+lDm
+otJ
+lKW
+oUg
+fDI
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+eLE
+xuH
+cSY
+cSY
+vSD
+eLE
 uoO
 uoO
 uoO
@@ -52768,8 +56975,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -52798,6 +57003,8 @@ uoO
 uoO
 uoO
 uoO
+uoO
+eLE
 uoO
 uoO
 uoO
@@ -52827,18 +57034,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -52852,6 +57047,15 @@ uoO
 uoO
 uoO
 uoO
+eLE
+uoO
+azs
+hDP
+oUg
+eTb
+mjS
+oUg
+oUg
 uoO
 uoO
 uoO
@@ -52859,21 +57063,24 @@ uoO
 uoO
 uoO
 uoO
+xVz
+jbU
+lDm
+otJ
+hyd
+lDm
+azs
+fuX
+uoO
+eLE
+eLE
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+cSY
+eAL
+vSD
+eLE
 uoO
 uoO
 uoO
@@ -53054,7 +57261,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -53079,23 +57286,6 @@ eLE
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -53114,6 +57304,20 @@ uoO
 uoO
 uoO
 uoO
+eLE
+uoO
+lDm
+nyb
+lDm
+lDm
+lDm
+xUb
+uoO
+uoO
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -53122,15 +57326,18 @@ uoO
 uoO
 uoO
 uoO
+rmb
+uoO
+uoO
+eLE
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+cSY
+hyd
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -53226,7 +57433,7 @@ tur
 tur
 tur
 tur
-tur
+rzg
 tur
 tur
 tur
@@ -53336,23 +57543,6 @@ eLE
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -53371,23 +57561,40 @@ uoO
 uoO
 uoO
 uoO
+eLE
+uoO
+uoO
+uoO
+cjw
+lDm
+uoO
+uoO
+uoO
+eLE
 uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+uoO
+uoO
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
+eLE
+eLE
+eLE
+xVz
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eAL
+xVz
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -53601,16 +57808,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -53621,30 +57818,40 @@ uoO
 uoO
 uoO
 uoO
+eLE
+uoO
+eLE
+uoO
+uoO
+uio
+uoO
+uoO
+eLE
+uoO
+uoO
+jWG
+xVz
 uoO
 uoO
 uoO
+eLE
+eLE
 uoO
 uoO
 uoO
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
+hyd
+cSY
+cSY
+cSY
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -53857,17 +58064,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -53879,6 +58075,21 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+uoO
+eLE
+uoO
+uoO
+uoO
+uoO
+eLE
+xVz
+xVz
+hyd
+eAL
+cSY
+xVz
 uoO
 uoO
 uoO
@@ -53890,18 +58101,14 @@ uoO
 uoO
 uoO
 uoO
+xVz
+hyd
+tHM
+eAL
+cSY
+xVz
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -54045,8 +58252,8 @@ pBk
 wWF
 miI
 wWF
-miI
-miI
+weW
+weW
 miI
 bcM
 bcM
@@ -54122,43 +58329,43 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+eLE
+uoO
+uoO
+uoO
+eLE
+uoO
+uoO
+eLE
+uoO
+xVz
+hyd
+eAL
+cSY
+cSY
+eAL
+jVf
+cSY
+eAL
+hyd
+hyd
+xVz
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+cSY
+cSY
+hyd
+aWs
+hyd
+xVz
+eLE
 uoO
 uoO
 uoO
@@ -54266,18 +58473,8 @@ tur
 tur
 tur
 tur
-tur
-tur
-tur
-tur
-iRc
-mNE
-mNE
-iRc
-tur
-tur
-chW
-iRc
+miI
+miI
 tur
 tur
 tur
@@ -54288,9 +58485,19 @@ tur
 tur
 tur
 tur
-nKZ
-nKZ
-iRc
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
 tur
 tur
 tur
@@ -54364,24 +58571,6 @@ eLE
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -54400,22 +58589,40 @@ uoO
 uoO
 uoO
 uoO
+eLE
+uoO
+tCC
 uoO
 uoO
+eLE
+eLE
 uoO
+xVz
+hyd
+xVz
+xVz
+xVz
+xVz
+eAL
+cSY
+lrt
+cSY
+cSY
+cSY
+xVz
+xVz
+xVz
 uoO
+xVz
+eAL
+eAL
+cSY
+hyd
+uKW
+vja
+fbT
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -54522,32 +58729,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-wIM
-kPb
-weW
-wmT
-rOq
-tur
-miI
-wWF
-tur
-hkD
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
@@ -54565,6 +58749,29 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+uoO
+uoO
+uoO
+tur
+kvK
+lUq
+uMA
+vaf
+lOt
+nrO
+wgT
+rca
+rca
+wUi
+tur
 uoO
 uoO
 uoO
@@ -54623,22 +58830,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -54655,24 +58846,40 @@ uoO
 uoO
 uoO
 uoO
+eLE
+uoO
+cda
+aoD
 uoO
 uoO
 uoO
+xVz
+xVz
+hyd
+xVz
 uoO
 uoO
 uoO
+hsH
+jVf
+cSY
+eAL
+eAL
+cSY
+cSY
+cSY
+hyd
+xVz
+baF
+cSY
+xVz
+xVz
+aWs
+ijP
+aWs
+lAm
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -54779,49 +58986,49 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
 tur
-wIM
-weW
-weW
-wmT
-miI
+nBk
+nBk
 tur
-ttq
-sic
-tur
-hkD
 uoO
 uoO
-aoj
 aoj
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eoy
+eoy
+eoy
+eoy
+eoy
+eoy
+eoy
+eoy
+uoO
+uoO
+rrq
+rXg
+xVz
+uoO
+tZf
 tur
-nBk
-nBk
-miI
+rca
+uHt
+lUq
+lUq
+lOt
+lOt
+wjW
+nrO
+iuv
+wUo
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -54878,17 +59085,6 @@ eLE
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -54907,29 +59103,40 @@ uoO
 uoO
 uoO
 uoO
+eLE
 uoO
 uoO
+vUz
+wPo
+hyd
+hyd
+hyd
+ime
+xVz
 uoO
+vSD
+vSD
+vSD
+vSD
+vSD
+xVz
+nTY
+hyd
+xVz
+cSY
+cSY
+eAL
+cSY
+cSY
+hyd
+hyd
 uoO
+hyd
+fbT
+hyd
+vPN
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -55036,32 +59243,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-wmT
-miI
-tur
-tur
-tur
-tur
-hkD
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
@@ -55075,10 +59259,33 @@ uoO
 uoO
 uoO
 uoO
+eoy
+miw
+ncQ
+hEp
+hLd
+iYF
+pvI
+eoy
 uoO
 uoO
-uoO
-uoO
+rsf
+xVz
+rXg
+xVz
+xVz
+tur
+uAb
+rxG
+lOt
+hEp
+vii
+vTH
+hLd
+wuM
+wIb
+wUB
+tur
 uoO
 uoO
 uoO
@@ -55136,13 +59343,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -55160,33 +59360,40 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
 uoO
 uoO
+jVf
+xVz
+bxJ
+nWY
 uoO
 uoO
+eLE
+vSD
+vMc
+lgn
+kiY
+ixU
+bsQ
+kqK
+nZb
+xVz
+xVz
+cSY
+hyd
+xVz
+xVz
+xVz
 uoO
 uoO
+xVz
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -55293,32 +59500,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-wmT
-rOq
-tur
-hkD
-hkD
-hkD
-hkD
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
@@ -55332,10 +59516,33 @@ uoO
 uoO
 uoO
 uoO
+eoy
+miw
+miw
+hEp
+oaG
+hLd
+pCn
+eoy
 uoO
 uoO
 uoO
-uoO
+xVz
+srz
+xVz
+wuf
+lnr
+lnr
+hLd
+kvK
+kvK
+kvK
+vVz
+tur
+wyc
+tur
+tur
+tur
 uoO
 uoO
 uoO
@@ -55393,9 +59600,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -55413,6 +59617,9 @@ uoO
 uoO
 uoO
 uoO
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -55420,30 +59627,30 @@ uoO
 uoO
 uoO
 uoO
+eLE
+vSD
+aJc
+isI
+vSD
+eLE
+eLE
+uoO
+hsH
+uoO
+xVz
+xVz
+hyd
+uoO
+uoO
+uoO
+eLE
+eLE
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
 uoO
 uoO
 aoj
@@ -55550,32 +59757,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-wmT
-tur
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
@@ -55585,14 +59769,37 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
+eoy
+miw
+miw
+hEp
+hEp
+hEp
+pvI
+eoy
 uoO
 uoO
+uoO
+tiS
+sBm
+uoO
+uoO
+tur
+nrO
+uKB
+hEp
+hEp
+vkD
+kvK
+tur
+ghw
+wJm
+tur
+tur
 uoO
 uoO
 uoO
@@ -55650,9 +59857,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -55670,37 +59874,40 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 aoj
@@ -55807,42 +60014,15 @@ uoO
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-drV
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
 aoj
 uoO
 uoO
@@ -55850,6 +60030,33 @@ uoO
 uoO
 uoO
 uoO
+eoy
+miy
+miy
+nqA
+hLd
+hLd
+pGw
+eoy
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+tur
+tur
+uKP
+uNS
+pbp
+vkL
+vWg
+tur
+wDO
+wMy
+tur
+tur
 uoO
 uoO
 uoO
@@ -55911,50 +60118,50 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -56064,42 +60271,15 @@ uoO
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-wWF
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
 aoj
 uoO
 uoO
@@ -56107,6 +60287,33 @@ uoO
 uoO
 uoO
 uoO
+eoy
+eoy
+eoy
+nsa
+obT
+hEp
+pGw
+eoy
+uoO
+uoO
+uoO
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+wkN
+wFx
+wOg
+wXG
+tur
 uoO
 uoO
 uoO
@@ -56191,27 +60398,27 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -56321,49 +60528,49 @@ uoO
 uoO
 aoj
 uoO
-uoO
-uoO
-uoO
-uoO
 tur
-wIM
-weW
-weW
-wWF
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-mRT
 nBk
-miI
+nBk
 tur
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
 aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+hLd
+hEp
+hEp
+hLd
+tur
+tur
+tur
+tur
+tur
+tur
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+wpJ
+nuA
+wQC
+weW
+tur
 uoO
 uoO
 uoO
@@ -56426,20 +60633,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -56476,7 +60669,21 @@ aoj
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
 aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -56578,32 +60785,9 @@ uoO
 uoO
 aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
@@ -56611,16 +60795,39 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
+tur
+jcf
+weW
+weW
+kAp
+weW
+weW
+weW
+weW
+nue
+weW
+nue
+pMg
+qwV
+weW
+rbt
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+wpJ
+nuA
+wQC
+weW
+tur
 uoO
 uoO
 uoO
@@ -56680,49 +60887,49 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 aoj
 aoj
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
 aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -56835,49 +61042,49 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
+eLE
+eLE
+eLE
+tur
+tur
+tur
+tur
+tur
+tur
+eoy
+tur
+hLd
+hLd
+hEp
+hEp
+tur
+tur
+tur
+tur
+tur
+tur
+sCZ
+pBk
+pBk
+pBk
+wWF
+wWF
+uOE
+uOE
+uOE
+wWF
+wWF
+miI
+miI
+weW
+tur
 uoO
 uoO
 uoO
@@ -56937,49 +61144,49 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
 uoO
 uoO
 aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -57092,40 +61299,14 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -57133,8 +61314,34 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+eoy
+hEp
+ndi
+nxH
+hEp
+oAe
+hEp
+eoy
+hkD
+hkD
+hkD
+tur
+sHb
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+vWZ
+hLd
+hEp
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -57194,44 +61401,44 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -57349,49 +61556,49 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
+eLE
+eLE
 uoO
 uoO
 uoO
+nrO
+iKB
+nrO
+iuv
+iuv
+iuv
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
+eoy
+mzR
+hEp
+eoy
+hLd
+eoy
+pYA
+eoy
+hkD
+rca
+run
+nIP
+nuA
+nuA
+tZq
+nuA
+weW
+vuv
+lnr
+iuv
+vmm
+iuv
+rxG
+ozN
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -57451,44 +61658,44 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -57606,49 +61813,49 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
+eLE
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
+lnr
+hxM
+lnr
+hkD
+hkD
+nrO
+gWt
+kBD
+gWt
+eoy
+eoy
+eoy
+eoy
+odk
+eoy
+pZr
+eoy
+hkD
+hkD
+iuv
+iuv
+vuv
+tmM
+vuv
+tmM
+weW
+vuv
+rxG
+hkD
+hkD
+hkD
+hkD
+tur
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -57731,35 +61938,35 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
 uoO
 uoO
 aoj
+uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -57863,49 +62070,49 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
+eLE
 uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+lnr
+nrO
+gWt
+gWt
+gWt
+gWt
+gWt
+gWt
+iuv
+lev
+iuv
+nrO
+vuv
+vuv
+nrO
+oDY
+qcp
+vuv
+hkD
+rce
+rux
+rXS
+vuv
+vuv
+vuv
+vuv
+vuv
+vuv
+iuv
+vat
+vuv
+vuv
+vuv
+tur
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -57985,28 +62192,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-aoj
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -58017,6 +62202,28 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+qDR
+uoO
+uoO
+aoj
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -58120,49 +62327,49 @@ uoO
 uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
+eLE
 uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+iuv
+lnr
+gWt
+iuv
+iNY
+iuv
+nrO
+gWt
+iNY
+gWt
+iuv
+mAa
+vuv
+nrO
+nrO
+iuv
+iuv
+qyc
+nrO
+nrO
+nrO
+iuv
+iuv
+iuv
+nrO
+nrO
+iuv
+vuv
+iuv
+vuv
+urZ
+nrO
+rca
+tur
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -58241,39 +62448,39 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+qDR
+uoO
+adY
+uoO
+uoO
 aoj
 aoj
-uoO
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -58377,48 +62584,48 @@ uoO
 uoO
 aoj
 aoj
-aoj
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+iuv
+iuv
+gWt
+gWt
+iuv
+uJD
+iuv
+nrO
+iuv
+iuv
+jeM
+iuv
+nrO
+gWt
+nEr
+nrO
+iuv
+qcp
+vuv
+vuv
+hkD
+qyI
+qLf
+vuv
+vuv
+nrO
+nrO
+iuv
+urZ
+nrO
+nrO
+nrO
+nrO
+nrO
+tur
+fGO
+weW
 tur
 tur
 tur
@@ -58494,32 +62701,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -58529,6 +62710,32 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+abi
+qDR
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -58634,48 +62841,48 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+iuv
+iuv
+gWt
+hyj
+iuv
+uJD
+iuv
+iuv
+nrO
+iuv
+gWt
+iuv
+iuv
+ndk
+iuv
+ohv
+iuv
+iuv
+qyC
+vuv
+rca
+nrO
+nrO
+sMc
+toA
+vuv
+vuv
+iuv
+nrO
+nrO
+nrO
+nrO
+nrO
+iuv
+tur
+fGO
+weW
 tur
 ehc
 dxj
@@ -58736,60 +62943,60 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -58891,48 +63098,48 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-wmT
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
 tur
 nBk
 nBk
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+lnr
+iuv
+gWt
+hAT
+hYr
+uJD
+jdP
+nrO
+jSJ
+kDS
+gWt
+gWt
+gWt
+gWt
+nEz
+nrO
+oEi
+vuv
+vuv
+vuv
+nrO
+iuv
+iuv
+iuv
+iuv
+ubW
+vuv
+iuv
+nrO
+nrO
+nrO
+nrO
+nrO
+iuv
+tur
+fGO
+weW
 tur
 dxj
 dxj
@@ -58993,61 +63200,61 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -59148,48 +63355,48 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
 tur
+nBk
+nBk
 tur
-bIh
+eLE
+lnr
+lnr
+gWt
+hEp
+hLd
+uJD
+jej
+jFB
+jWC
+iuv
+lfb
+gWt
+gWt
+gWt
+nEH
+iuv
+vuv
+vuv
+vuv
+nrO
+nrO
+iuv
+rZZ
+sPK
+iuv
+iuv
+qyI
+iuv
+nrO
+nrO
+iuv
+iuv
+nrO
+iuv
+tur
+wIM
 weW
-nBk
-nKZ
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-mSD
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-cQc
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 hhQ
 dxj
@@ -59251,36 +63458,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -59299,7 +63476,37 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+lMI
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -59405,48 +63612,48 @@ uoO
 uoO
 uoO
 aoj
-aoj
-uoO
-uoO
-uoO
 tur
+nBk
+nBk
 tur
-jkb
-weW
-nBk
-nKZ
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-cWd
-nBk
+eLE
+uoO
+lnr
+gWt
+hIq
+ias
+uJD
+jeE
+jGy
+iuv
+kFg
+kFg
+gWt
+gWt
+gWt
+gWt
+oiy
+vuv
+vuv
+vuv
 nrO
+nrO
+iuv
+sdI
+sPK
+iuv
+udH
+vuv
+iuv
+vuv
+nrO
+tdY
+vnW
+nrO
+iuv
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+wIM
+weW
 tur
 vxm
 frm
@@ -59511,8 +63718,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -59522,25 +63727,15 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -59558,8 +63753,20 @@ uoO
 uoO
 aoj
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -59662,48 +63869,48 @@ uoO
 uoO
 uoO
 aoj
-aoj
-uoO
-uoO
-uoO
-tur
-tur
-weW
-weW
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-miI
-rOq
-tur
-tur
-tur
-tur
-tur
 tur
 nBk
 nBk
-miI
 tur
+eLE
+uoO
+lnr
+gWt
+gWt
+gWt
+gWt
+jeM
+gWt
+gWt
+gWt
+gWt
+gWt
+mBn
+nrO
+nrO
+iuv
+mBn
+qdZ
+qyI
+nrO
+nrO
+nrO
+nrO
+nrO
+nrO
+iuv
+vuv
+nrO
+nrO
+vuv
+vbI
+vpz
+vXh
+vuv
 tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
+wIM
+weW
 tur
 tur
 tur
@@ -59779,12 +63986,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -59795,9 +63996,7 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -59810,10 +64009,17 @@ uoO
 uoO
 uoO
 aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -59824,7 +64030,8 @@ uoO
 uoO
 uoO
 uoO
-eoy
+uoO
+dhi
 nBk
 nBk
 nBk
@@ -59919,55 +64126,55 @@ uoO
 uoO
 uoO
 aoj
-aoj
+tur
+nBk
+nBk
+tur
+eLE
 uoO
-uoO
-uoO
+rxG
+iuv
+rxG
+icj
+iuv
+iuv
+jHN
+iuv
+nrO
+iuv
+nrO
+iuv
+nrO
+iuv
+iuv
+vuv
+vuv
+vuv
+nrO
+iuv
+nrO
+sfm
+vuv
+vuv
+vuv
+vuv
+nrO
+kSa
+vuv
+vuv
+vuv
+vuv
+vuv
 tur
 miI
 weW
-weW
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-tur
-tur
-tur
-tur
-uoO
 uoO
 uoO
 uoO
 tur
 nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-dyv
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
+mSD
 cQc
 tur
 uoO
@@ -60058,30 +64265,30 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
 aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+acT
+xVz
+xVz
 uoO
 uoO
-eoy
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+gpM
+dhi
 mRT
 nBk
 nBk
@@ -60176,53 +64383,53 @@ uoO
 uoO
 uoO
 uoO
+tur
+nBk
+nBk
+tur
+eLE
 uoO
-uoO
-uoO
-uoO
+lnr
+gWG
+gWG
+jmN
+jmN
+hhi
+hhi
+jXe
+jXe
+gWG
+iuv
+nrO
+iuv
+nrO
+iuv
+oEi
+hkD
+vuv
+nrO
+iuv
+nrO
+vuv
+vuv
+vuv
+nrO
+upC
+nrO
+nrO
+uPu
+vuv
+vuv
+vuv
+vuv
 tur
 miI
 weW
-weW
-miI
 tur
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
-nBk
-nBk
-nBk
-pzX
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
-nBk
 nBk
 nBk
 miI
@@ -60315,30 +64522,30 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
 aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
-eoy
+uoO
+uoO
+xVz
+xVz
+afj
+dhi
 eoy
 eoy
 nBk
@@ -60433,52 +64640,52 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
 tur
-miI
+nBk
+nBk
+tur
+eLE
+nrO
+lnr
+gWG
+hIy
+igH
+iPs
+iuv
+jJT
+jYt
+kPb
+gWG
+iuv
+nrO
+nrO
+iuv
+nrO
+oFh
+hkD
+hkD
+vuv
+nrO
+nrO
+vuv
+nrO
+mBn
+nrO
+iuv
+nrO
+vuv
+uQO
+ghw
+vqb
+vuv
+vuv
+ozN
+wRj
 weW
-weW
-wWF
 tur
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-nBk
-kvK
-cRm
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-mRT
-nBk
-nBk
-nBk
-nBk
-mSD
-tur
-tur
-tur
 tur
 nBk
 nBk
@@ -60533,17 +64740,9 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -60581,20 +64780,28 @@ uoO
 uoO
 uoO
 aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+lMI
+xVz
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
+uoO
+xVz
+xVz
+xVz
 uoO
 uoO
 eoy
@@ -60690,50 +64897,50 @@ tur
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
 tur
-wIM
-kPb
+nBk
+nBk
+tur
+eLE
+iuv
+lnr
+gXR
+iuv
+iuv
+iuv
+iuv
+nrO
+nrO
+nrO
+gWG
+lJa
+mGg
+nfM
+nIP
+nrO
+iuv
+nrO
+hkD
+hkD
+vuv
+qyI
+vuv
+nrO
+iuv
+nrO
+iuv
+nrO
+vuv
+uRY
+ven
+vra
+vuv
+vuv
+ozN
+fGO
 weW
-wWF
 tur
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-nBk
-nBk
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
 uoO
 uoO
 tur
@@ -60790,17 +64997,8 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-aoj
-aoj
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -60841,9 +65039,6 @@ uoO
 aoj
 aoj
 aoj
-aoj
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -60851,6 +65046,18 @@ uoO
 uoO
 uoO
 uoO
+uoO
+aeS
+kjz
+xVz
+xVz
+xVz
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -60947,49 +65154,49 @@ tur
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+iuv
+lnr
+gWG
+hKG
+ihg
+iPH
+jfS
+jKY
+iuv
+nrO
+gWG
+lJa
+mHM
+nha
+nrO
+iuv
+nrO
+nrO
+nrO
+nrO
+mBn
+nrO
+nrO
+nrO
+nrO
+iuv
+iuv
+nrO
+vuv
+vuv
+veq
+vuv
+vuv
+vuv
+vuv
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -61047,17 +65254,8 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -61101,13 +65299,22 @@ aoj
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+bRX
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -61204,55 +65411,55 @@ tur
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
 tur
-wIM
+nBk
+nBk
+tur
+eLE
+uoO
+gTv
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+nrO
+jmN
+lJa
+mKh
+nhK
+hkD
+iuv
+iuv
+nIP
+nrO
+iuv
+nrO
+iuv
+nrO
+iuv
+tqH
+nrO
+nrO
+nrO
+vuv
+iuv
+iuv
+vuv
+hEp
+wrg
+wGy
+fGO
 weW
-weW
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
 tur
 nBk
-nBk
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-nBk
-nBk
+mRT
 miI
 tur
 aoj
@@ -61306,64 +65513,64 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
-aoj
 uoO
 uoO
 uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -61461,49 +65668,49 @@ tur
 tur
 uoO
 uoO
-uoO
-aoj
-uoO
-uoO
-tur
-miI
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+gQV
+gUm
+lnr
+hkD
+hkD
+hkD
+hkD
+gWG
+jmN
+kRu
+jmN
+lJa
+mKm
+njZ
+hkD
+iuv
+nrO
+nrO
+nrO
+nrO
+nIP
+nrO
+nrO
+iuv
+nrO
+iuv
+iuv
+teW
+vuv
+iuv
+iuv
+vuf
+hEp
+hEp
+wHf
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -61562,65 +65769,65 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 aoj
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+buV
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+mlz
 uoO
 uoO
 uoO
@@ -61718,49 +65925,49 @@ sBu
 tur
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+rxG
+jmN
+jmN
+jmN
+gWG
+gWG
+gWG
+gWG
+jmN
+nrO
+jmN
+iuv
+hkD
+hkD
+hkD
+iuv
+oIo
+iuv
+iuv
+iuv
+oIo
+nrO
+nrO
+iuv
+iuv
+nrO
+iuv
+vuv
+vuv
+nrO
+iuv
+nrO
+hLd
+hLd
+wGy
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -61827,57 +66034,57 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+acs
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 aoj
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -61975,49 +66182,49 @@ dYy
 tur
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+rxG
+jmN
+gYE
+hLd
+ikD
+iRE
+gZF
+iWE
+jZf
+nrO
+gWc
+lKT
+hkD
+nmN
+nmN
+nmN
+nmN
+nmN
+qyW
+nmN
+nmN
+nmN
+nmN
+nrO
+iuv
+nrO
+iuv
+oZF
+nrO
+nrO
+iuv
+vuv
+vXF
+wsv
+wGy
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -62077,31 +66284,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -62118,8 +66300,29 @@ uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+uoO
+qDR
+qDR
+qDR
+jPC
+uoO
+uoO
 aoj
 aoj
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -62135,6 +66338,10 @@ uoO
 uoO
 uoO
 uoO
+uoO
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -62232,49 +66439,49 @@ jhN
 tur
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+gRa
+jmN
+gZF
+hLd
+ikD
+hEp
+hEp
+iWE
+iuv
+nrO
+jmN
+rxG
+hkD
+nmN
+nJB
+omq
+oJc
+qez
+hEp
+hLd
+rcf
+rAx
+sfI
+sRw
+tqZ
+nrO
+urM
+vuv
+vuv
+uWl
+iuv
+vuv
+vYC
+wsK
+wHB
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -62334,23 +66541,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -62368,6 +66558,31 @@ aoj
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+xVz
+xVz
+qDR
+uoO
+aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+jPC
+xVz
+xVz
+xVz
+uoO
+uoO
+aoj
+aoj
+uoO
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -62379,19 +66594,11 @@ aoj
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
-uoO
-uoO
-uoO
-uoO
+aoj
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -62490,48 +66697,48 @@ tur
 tur
 tur
 tur
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
 nBk
 nBk
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+iuv
+jmN
+hev
+hNq
+imj
+iWE
+jgP
+iWE
+iuv
+kRE
+jmN
+lOt
+mMC
+nmN
+nLK
+org
+ghw
+ghw
+ghw
+qVG
+hLd
+qVG
+nmN
+sUl
+tqZ
+iuv
+iuv
+nrO
+vuv
+kvL
+sZJ
+mgQ
+vuv
+vuv
+vuv
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -62591,9 +66798,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -62604,15 +66808,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -62620,20 +66815,28 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
+lMI
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
 aoj
 aoj
+uoO
 aoj
+uoO
+uoO
+qDR
+xVz
+uoO
+uoO
+aoj
+aoj
+uoO
 aoj
 aoj
 uoO
@@ -62644,10 +66847,14 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
 aoj
-uoO
-uoO
-uoO
+aoj
+aoj
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -62747,48 +66954,48 @@ rOq
 rOq
 rOq
 tur
-tur
-tur
-tur
-tur
-wIM
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
 nBk
 nBk
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+gSQ
+gWc
+heR
+hOR
+ioO
+nrO
+nrO
+nrO
+iuv
+kSa
+gWG
+lPs
+mTq
+nmN
+nNR
+ghw
+oOm
+qgP
+qzG
+hLd
+hLd
+hLd
+nmN
+sXV
+tqZ
+iuv
+nrO
+nrO
+vuv
+vuv
+vuv
+vuv
+vuv
+hkD
+vWZ
+wWF
+weW
+tur
 uoO
 uoO
 uoO
@@ -62847,7 +67054,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -62861,24 +67067,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -62886,26 +67074,45 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+xVz
+xVz
 uoO
 uoO
 uoO
 uoO
 uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 uoO
 uoO
 uoO
 uoO
+uoO
+qDR
+uoO
+uoO
+aoj
+aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+aoj
+aoj
+aoj
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -63004,48 +67211,48 @@ nBk
 nBk
 nBk
 nBk
-nxH
-nxH
-nxH
-ryY
+nBk
+nBk
+tur
+eLE
 iuv
-weW
-weW
+jmN
+hfb
 etN
+hAT
+hAT
+jkb
+hAT
+nrO
+nrO
+gWG
+lUq
+mUw
+nmN
+nRP
+ghw
+hEp
+hEp
+qAK
+hLd
+hLd
+rBn
+nmN
+sZJ
+nrO
+nrO
+teW
+iuv
+gWt
+gWt
+gWt
+gWt
+gWt
+gWt
 tur
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
+wWF
+weW
 tur
-nBk
-nBk
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -63117,36 +67324,15 @@ uoO
 uoO
 uoO
 uoO
-uoO
 aoj
 aoj
 aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -63157,12 +67343,33 @@ aoj
 uoO
 uoO
 uoO
+qDR
+uoO
+jPC
 uoO
 uoO
 aoj
 aoj
+uoO
+aoj
 aoj
 uoO
+uoO
+uoO
+aoj
+aoj
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -63263,46 +67470,46 @@ nBk
 nBk
 nBk
 nBk
-nBk
-nBk
-nBk
+tur
+eLE
+iuv
+jmN
+hgP
+hQG
+hAT
+ias
+hLd
+hAT
+nrO
+kTJ
+gWG
+iuv
+mVa
+nmN
+nTt
+ghw
+oOR
+qhk
+oOR
+hLd
+hLd
+rCv
+nmN
+sfI
+nmN
+nmN
+sfI
+nrO
+uKU
+iuv
+vfh
+vzL
+vZW
+gWt
+tur
+fGO
 weW
-weW
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-nBk
-nBk
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
 uoO
 uoO
 uoO
@@ -63374,26 +67581,15 @@ uoO
 uoO
 uoO
 uoO
-uoO
 aoj
 aoj
 aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -63404,12 +67600,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+abi
+qDR
 uoO
 uoO
 uoO
@@ -63418,8 +67610,23 @@ uoO
 uoO
 aoj
 aoj
-aoj
 uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+xVz
+mlz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -63518,48 +67725,48 @@ tur
 tur
 tur
 tur
+nBk
+nBk
 tur
+eLE
+iuv
+jmN
+hhe
+hWZ
+ipw
+iWH
+jmA
+hAT
+nrO
+kVD
+gWG
+lUI
+hkD
+nmN
+nmN
+otk
+hLd
+hEp
+hLd
+hEp
+hLd
+rHL
+nmN
+tau
+tAr
+ufo
+sfI
+nrO
+oZF
+iuv
+vfi
+vzR
+wcm
+gWt
 tur
-tur
-tur
-tur
-bIh
+fGO
 weW
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-nBk
-nBk
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
 uoO
 uoO
 uoO
@@ -63628,37 +67835,32 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
 uoO
 uoO
 uoO
 aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 aoj
 uoO
 uoO
 uoO
-uoO
+xVz
+buV
+xVz
 uoO
 uoO
 aoj
-aoj
+uoO
+uoO
+uoO
+jPC
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -63667,16 +67869,21 @@ uoO
 uoO
 uoO
 aoj
-aoj
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+xVz
+xVz
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+buV
 uoO
 uoO
 uoO
@@ -63774,49 +67981,49 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+rxG
+jmN
+hhi
+hhi
+hhi
+jmN
+jmN
+gWG
+gWG
+gWG
+gWG
+gWG
+hkD
+nnz
+nmN
+nmN
+oQa
+qjs
+qDo
+qWm
+hEp
+hLd
+shF
+hEp
+hEp
+hLd
+sfI
+iuv
+gWt
+iuv
+iuv
+nrO
+nrO
+nrO
+wHB
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -63878,24 +68085,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-aoj
-uoO
-uoO
-aoj
-uoO
-aoj
-uoO
-aoj
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -63908,7 +68097,25 @@ uoO
 aoj
 aoj
 aoj
+aoj
 uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -63921,10 +68128,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-uoO
+xVz
 uoO
 uoO
 uoO
@@ -63933,7 +68137,10 @@ uoO
 uoO
 uoO
 uoO
-uoO
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -64031,49 +68238,49 @@ aoj
 uoO
 aoj
 aoj
-aoj
-aoj
-uoO
-uoO
-tur
-miI
-weW
-weW
-wmT
-tur
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+lnr
+lnr
+lnr
+rxG
+ipx
+ipx
+jok
+jNe
+kfQ
+kWK
+hEp
+jwp
+hEp
+hEp
+hEp
+nmN
+oRb
+nmN
+nmN
+nmN
+qyW
+nmN
+nmN
+tbE
+tDl
+ufQ
+nmN
+nrO
+gWt
+iuv
+iuv
+iuv
+nrO
+nrO
+wHB
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -64134,29 +68341,12 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -64167,6 +68357,23 @@ aoj
 aoj
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+xVz
+xVz
+xVz
+lMI
 uoO
 uoO
 uoO
@@ -64178,19 +68385,19 @@ uoO
 uoO
 uoO
 uoO
+xVz
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+iwL
 uoO
 uoO
 uoO
@@ -64288,49 +68495,49 @@ aoj
 uoO
 aoj
 aoj
-aoj
-aoj
-uoO
-uoO
 tur
-miI
-weW
-weW
-wmT
-tur
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-bqO
 nBk
-miI
+nBk
 tur
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+lnr
+hor
+gWG
+gWG
+jmN
+jmN
+jmN
+jmN
+jmN
+jwp
+jmN
+jmN
+jmN
+nZI
+nmN
+hEp
+qju
+qFn
+nmN
+hEp
+rMp
+sfI
+nmN
+nmN
+nmN
+nmN
+nrO
+gWt
+gWt
+nrO
+iuv
+iuv
+nrO
+wHB
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -64384,20 +68591,10 @@ eLE
 "}
 (163,1,1) = {"
 eLE
-aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -64417,37 +68614,47 @@ aoj
 aoj
 uoO
 uoO
+xVz
+xVz
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+qDR
+qDR
+qDR
+jPC
+uoO
 uoO
 uoO
 aoj
-aoj
-aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
+jPC
+qrc
+mlz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -64545,49 +68752,49 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-rOq
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
+lnr
+lnr
+gWG
+ivm
+iYF
+jqX
+hEp
+hLd
+hLd
+hLd
+lVr
+mVo
+jmN
+hEp
+ouz
+hEp
+hLd
+qJL
+nmN
+rfH
+rMp
+nmN
+tcC
+tqZ
+iuv
+urZ
+nrO
+vuv
+gWt
+mgQ
+nrO
+uWl
+gWt
+tur
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -64641,70 +68848,70 @@ eLE
 "}
 (164,1,1) = {"
 eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+aoj
+aoj
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+qDR
+uoO
+uoO
+uoO
+uoO
 aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -64802,49 +69009,49 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
+lnr
+hpe
+gWG
+hEp
+hEp
+jrm
+hEp
+kjW
+hLd
+llV
+hLd
+mYV
+jmN
+hEp
+nmN
+oXs
+oXs
+qJM
+nmN
+riT
+rMG
+nmN
+tdY
+tDW
+umG
+iuv
+iuv
+vuv
+gWt
+gWt
+gWt
+gWt
+gWt
+tur
+wIM
+weW
+tur
 uoO
 uoO
 uoO
@@ -64900,32 +69107,6 @@ eLE
 eLE
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -64946,6 +69127,15 @@ aoj
 aoj
 aoj
 uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+xVz
+aoj
+aoj
+xVz
 uoO
 uoO
 uoO
@@ -64953,6 +69143,21 @@ uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+acT
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+lMI
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -64960,7 +69165,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -65053,55 +69260,55 @@ uoO
 uoO
 uoO
 uoO
-uoO
-tur
+dXE
 tur
 tur
 oeb
 tur
 tur
 tur
+nBk
+nBk
+tur
+eLE
 uoO
-uoO
+lnr
+lnr
+gWG
+hEp
+hEp
+jro
+hEp
+kkm
+hLd
+lnt
+hEp
+naY
+jmN
+hLd
+nmN
+nmN
+nmN
+nmN
+nmN
+nmN
+nmN
+nmN
+nrO
+nrO
+nrO
+nrO
+nrO
+vuv
+hkD
+hkD
+hkD
+hkD
+hkD
 tur
 wIM
 weW
-weW
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-nBk
-nBk
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -65157,32 +69364,6 @@ eLE
 eLE
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -65204,6 +69385,34 @@ aoj
 aoj
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+lMI
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -65212,11 +69421,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -65299,66 +69506,66 @@ uoO
 uoO
 uoO
 uoO
-uoO
+eWV
 pYd
 pYd
 pYd
-pYd
+rXA
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-tur
+dXE
+gsQ
 pEF
 fGZ
 vnJ
 twy
-qpI
-oeb
+tur
+nBk
+nBk
+tur
+eLE
 uoO
 uoO
+lnr
+gXR
+iwx
+hEp
+jrV
+hEp
+kkU
+hLd
+loc
+hEp
+naY
+gWc
+hLd
+oyo
+iuv
+nrO
+nrO
+iuv
+rjq
+iuv
+iuv
+nrO
+nrO
+nrO
+nrO
+nrO
+vuv
+vuv
+vuv
+hkD
+hkD
+hkD
 tur
 wIM
 weW
-weW
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-nBk
-nBk
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -65414,22 +69621,11 @@ eLE
 eLE
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -65457,23 +69653,34 @@ uoO
 uoO
 uoO
 aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+lMI
+xVz
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+xVz
+xVz
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+jPC
+qrc
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -65555,67 +69762,67 @@ tur
 uoO
 uoO
 uoO
-uoO
-rXA
+eUp
 pYd
+frh
 irB
-nIP
 pYd
 pYd
+rXA
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-oeb
+gev
 jZT
 jZT
 jZT
 jZT
-vqb
-oeb
-uoO
-uoO
-tur
-wIM
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
+gFV
 tur
 nBk
 nBk
-miI
 tur
+eLE
+eLE
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
+gWG
+iDt
+hEp
+jug
+hEp
+kpk
+hEp
+lsk
+hEp
+naY
+jmN
+hLd
+hLd
+nrO
+iuv
+nrO
+nrO
+nrO
+nrO
+nrO
+teW
+tEu
+nrO
+teW
+nrO
+uLn
+hLd
+vuv
+vuv
+vuv
+vuv
+tur
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -65671,9 +69878,7 @@ eLE
 eLE
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -65713,9 +69918,15 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+adx
+kjz
+xVz
+xVz
+uoO
+uoO
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -65723,14 +69934,10 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -65812,67 +70019,67 @@ tur
 uoO
 uoO
 uoO
-uoO
-pYd
+eWV
+fgW
 ptQ
 ctu
 bgV
-jJT
 pYd
 pYd
 pYd
 pYd
+rXA
 uoO
 uoO
-uoO
-oeb
+gev
 jZT
 jZT
 jZT
 jZT
-bJG
-tur
-uoO
-uoO
-tur
-miI
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-tur
+gJz
 tur
 nBk
 nBk
-miI
 tur
 uoO
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
+hqg
+gWG
+iER
+hLd
+juP
+hLd
+krt
+hEp
+lzW
+hEp
+ncx
+jmN
+hLd
+hEp
+nrO
+iuv
+iuv
+iuv
+iuv
+iuv
+iuv
+gWc
+jmN
+unV
+jmN
+gWc
+vuv
+hLd
+hEp
+vBA
+wcF
+vuv
+ozN
+fGO
+weW
+tur
 uoO
 uoO
 uoO
@@ -65928,19 +70135,6 @@ eLE
 eLE
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -65964,18 +70158,7 @@ uoO
 uoO
 uoO
 aoj
-uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -65988,6 +70171,30 @@ aoj
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+bRX
+uoO
+uoO
+buV
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+jPC
+qDR
+adY
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -66069,67 +70276,67 @@ tur
 uoO
 uoO
 uoO
-uoO
-pYd
-bGf
+eWV
+fjU
+cfL
 nqV
 iox
-kIS
-ctu
+ptQ
 sgn
 eBg
 pYd
+rXA
 uoO
 uoO
-uoO
-oeb
+gev
+gxq
 dJF
 twj
-qyW
 jZT
-jfS
+gNZ
 tur
-uoO
-uoO
-tur
-miI
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-tur
-mRT
 nBk
 nBk
-miI
 tur
 uoO
+eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
+hsH
+gWG
+iHB
+jak
+jwm
+hEp
+hEp
+hEp
+lAW
+lYE
+ncK
+jmN
+hLd
+vuv
+vuv
+qmV
+qLf
+vuv
+vuv
+vuv
+sic
+jmN
+tEH
+hLd
+utr
+jmN
+vuv
+hEp
+hEp
+hEp
+hEp
+wus
+wHV
+miI
+weW
+tur
 uoO
 uoO
 uoO
@@ -66185,17 +70392,6 @@ eLE
 eLE
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -66223,27 +70419,38 @@ aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-aoj
 aoj
 aoj
 uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+qDR
 uoO
 uoO
 uoO
@@ -66326,67 +70533,67 @@ tur
 uoO
 aoj
 aoj
-uoO
-pYd
+eWV
+iox
 kIS
 fLK
 fJS
 cfL
-nqV
 fLU
-fSV
+pkL
 pYd
 pYd
 pYd
-uoO
+rXA
+dXE
 tur
 tur
 tur
-tur
-uzc
+gFu
 oeb
-oeb
-uoO
-uoO
 tur
+nBk
+nBk
+tur
+uoO
+eLE
+eLE
+hvw
+gWG
+jmN
+jmN
+hLd
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+nnL
+hLd
+oZF
+nrO
+nrO
+nrO
+nrO
+nrO
+vuv
+jmN
+tEW
+hLd
+hLd
+jmN
+vuv
+hEp
+vfL
+vfL
+hEp
+vuv
+ozN
 miI
 weW
-weW
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-tur
-nBk
-nBk
-nBk
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -66454,31 +70661,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -66496,17 +70678,42 @@ uoO
 uoO
 uoO
 aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
 uoO
 aoj
 aoj
 aoj
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
-aoj
 uoO
-aoj
+uoO
+xVz
+xVz
+xVz
+jPC
+jPC
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
@@ -66583,67 +70790,67 @@ tur
 uoO
 aoj
 aoj
-uoO
+eWV
 pYd
-pYd
+ftV
 iVi
 mSs
-iKB
 gyf
 fLU
-fSV
+pkL
+pAK
 oFi
-hWZ
 pYd
 pYd
+giA
+gyB
+jZT
+gza
+jZT
+jZT
 tur
-aWF
-jZT
-hKG
-jZT
-jZT
-oeb
+nBk
+nBk
+tur
 uoO
 uoO
+uoO
+eLE
+eLE
+hvw
+jmN
+jwp
+jmN
+hEp
+hEp
+hEp
+mba
+hEp
+hLd
+hLd
+vuv
+pab
+iuv
+nrO
+nrO
+iuv
+rOO
+vuv
+jmN
+nRP
+hLd
+rBn
+jmN
+vuv
+hEp
+vgo
+vDl
+wdT
+vuv
 tur
 miI
 weW
-weW
-miI
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-tur
-nBk
-nBk
-nBk
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -66711,40 +70918,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -66755,7 +70928,41 @@ uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+xVz
+xVz
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -66841,66 +71048,66 @@ uoO
 aoj
 aoj
 uoO
-uoO
-pYd
+eWV
 gyf
 gyf
 gyf
 gyf
 fLU
-nEz
+fPj
 eBg
+fXm
 pAK
-oFi
 pYd
-oeb
-bSL
+gmL
+gyZ
 jZT
-vmm
+gBq
 jZT
-hev
-oeb
-uoO
-uoO
-tur
-miI
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-tur
+gPe
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
+eLE
+jmN
+hLd
+jmN
+vuv
+kZR
+vuv
+vuv
+hLd
+hLd
+hLd
+vuv
+pbp
+qpG
+qRG
+qXr
+rjG
+iuv
+vuv
+jmN
+hLd
+hLd
+hLd
+jmN
+vuv
+hEp
+vuv
+vuv
+vuv
+vuv
+tur
+wWF
+weW
+tur
 uoO
 uoO
 uoO
@@ -66968,34 +71175,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-aoj
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -67015,8 +71194,36 @@ uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+xVz
+xVz
+oKH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -67098,66 +71305,66 @@ uoO
 uoO
 uoO
 uoO
-uoO
-pYd
+eWV
 gyf
 gyf
 gyf
 xSY
 fLU
+fPB
 sgd
 tfw
 cfP
-uLn
 pYd
-oeb
+gmL
 oeb
 tur
 oeb
 oeb
 oeb
-oeb
-uoO
-uoO
-tur
-miI
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
+eLE
+jmN
+hEp
+jmN
+vuv
+laT
+lCd
+vuv
+hEp
+hLd
+hLd
+vuv
+vuv
+vuv
+vuv
+vuv
+vuv
+vuv
+siK
+jmN
+tII
+hAT
+uwt
+jmN
+vuv
+hEp
+vuv
+vDq
+uQO
+vuv
+tur
+wWF
+weW
+tur
 uoO
 uoO
 uoO
@@ -67223,26 +71430,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -67261,18 +71448,38 @@ aoj
 uoO
 uoO
 uoO
-uoO
-uoO
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+xVz
+xVz
+oKH
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -67355,40 +71562,18 @@ uoO
 uoO
 uoO
 uoO
-uoO
-pYd
+eWV
 uaL
 eBg
+fBi
 pkL
-fSV
 fLU
 eBg
 eBg
 eBg
-fSV
+pkL
 pYd
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+rXA
 uoO
 uoO
 uoO
@@ -67397,24 +71582,46 @@ uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
+eLE
+jmN
+hEp
+jmN
+vuv
+nrO
+nrO
+vuv
+hEp
+hLd
+hLd
+oyo
+hLd
+hLd
+hLd
+oyo
+hLd
+hLd
+hLd
+jmN
+jmN
+jmN
+jmN
+jmN
+vuv
+hEp
+veq
+ven
+wfE
+vuv
+tur
+wWF
+weW
+tur
 uoO
 uoO
 uoO
@@ -67471,35 +71678,6 @@ eLE
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -67530,6 +71708,35 @@ uoO
 aoj
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+lMI
+xVz
+uoO
+xVz
+xVz
+oKH
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -67567,11 +71774,11 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -67612,40 +71819,18 @@ tur
 tur
 tur
 tur
-uoO
-pYd
+eWV
 hzg
 eBg
 eBg
+pkL
 fSV
-tmM
 eBg
-kKB
+fXa
+lKk
 elU
-mYV
 pYd
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+rXA
 uoO
 uoO
 uoO
@@ -67654,24 +71839,46 @@ uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+jmN
+hEp
+jmN
+vuv
+ldZ
+lED
+vuv
+hYr
+hLd
+kZR
+vuv
+vuv
+vuv
+vuv
+vuv
+vuv
+vuv
+vuv
+vuv
+vuv
+vuv
+vuv
+vuv
+vuv
+uXs
+vuv
+vuv
+vuv
+vuv
+tur
+wWF
+weW
+tur
 uoO
 uoO
 uoO
@@ -67725,28 +71932,10 @@ eLE
 "}
 (176,1,1) = {"
 eLE
-aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -67781,27 +71970,6 @@ uoO
 uoO
 aoj
 aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -67818,6 +71986,26 @@ uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+oKH
+uoO
+uoO
+xVz
+lMI
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -67829,6 +72017,25 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -67869,40 +72076,18 @@ tur
 ggH
 xJE
 tur
-uoO
-pYd
+eWV
 eBg
-azr
+fxN
 xSY
-tqH
+fMg
 fLU
 eBg
-mYV
+elU
 eBg
-qju
+fTt
 pYd
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+rXA
 uoO
 uoO
 uoO
@@ -67911,24 +72096,46 @@ uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+jmN
+hEp
+jmN
+vuv
+vuv
+vuv
+vuv
+hEp
+nnL
+hLd
+oyr
+pdh
+qpI
+hLd
+hLd
+oyo
+rTh
+siP
+thH
+iuv
+uoo
+uyz
+uDS
+vuv
+rxG
+rxG
+vKh
+rxG
+cqT
+tur
+miI
+weW
+tur
 uoO
 uoO
 uoO
@@ -67984,26 +72191,6 @@ eLE
 eLE
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -68018,7 +72205,9 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -68038,6 +72227,15 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 uoO
 uoO
@@ -68045,10 +72243,19 @@ uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+sNT
+xGO
+buV
+xVz
+kjz
+xVz
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
@@ -68126,66 +72333,66 @@ fvp
 fvp
 fvp
 tur
-uoO
-rXA
+eUp
 pYd
 pYd
+fBU
 jMT
-juP
 fLU
-qju
+fTt
 eBg
-sgd
+fPB
 eBg
 pYd
-aoj
+gni
 uoO
 uoO
 aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-tur
-wIM
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
+eLE
+jmN
+jBv
+jmN
+kvK
+kvK
+kvK
+mbX
+hLd
+hLd
+vuv
+vuv
+phP
+phP
+hLd
+phP
+phP
+mGg
+vuv
+nrO
+tJD
+vuv
+nrO
+iuv
+vuv
+lnr
+weW
+weW
+weW
+cqT
+tur
+miI
+weW
+tur
 uoO
 uoO
 tur
@@ -68241,27 +72448,6 @@ eLE
 eLE
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -68275,10 +72461,22 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -68294,18 +72492,27 @@ uoO
 uoO
 uoO
 aoj
+uoO
 aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+oKH
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 scG
 uoO
@@ -68333,16 +72540,16 @@ uoO
 uoO
 aoj
 aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -68385,64 +72592,64 @@ fvp
 tur
 uoO
 uoO
-uoO
-pYd
+eWV
 fLU
-kDS
+fNr
 fLU
+fTW
 wiz
-iPH
 eBg
 eBg
 pYd
-uoO
+rXA
 aoj
 aoj
 aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+jmN
+hLd
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+kvK
+vuv
+ozp
+pip
+qpY
+qUx
+rbg
+rqc
+hEp
+ska
+iuv
+tPY
+vuv
+nrO
+iuv
+vuv
+cqT
+weW
+cqT
+weW
+cqT
+tur
+wIM
+weW
+tur
 uoO
 uoO
 tur
@@ -68498,9 +72705,6 @@ eLE
 eLE
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -68516,9 +72720,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -68528,21 +72729,17 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -68553,16 +72750,26 @@ uoO
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+sNT
+wum
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
 xVz
 xVz
 uoO
@@ -68588,10 +72795,10 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -68642,64 +72849,64 @@ tOY
 tur
 uoO
 uoO
-uoO
-pYd
+eWV
+fEB
 lkt
-vkL
 fLU
+fWr
 dLP
-kRu
 eBg
-mYV
+elU
 pYd
-uoO
+rXA
 aoj
 aoj
 aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+jmN
+hLd
+jOe
+nrO
+nrO
+nrO
+mgg
+jmN
+kvK
+vuv
+hEp
+pjj
+qsg
+qUx
+rbo
+rqF
+hEp
+smm
+tjd
+tTm
+vuv
+mgQ
+uFj
+vuv
+cqT
+weW
+cqT
+weW
+cqT
+tur
+wRj
+weW
+tur
 uoO
 uoO
 tur
@@ -68755,58 +72962,49 @@ eLE
 eLE
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 aoj
@@ -68818,10 +73016,19 @@ uoO
 uoO
 uoO
 uoO
-aoj
+xVz
+xoU
 xVz
 xVz
 xVz
+xVz
+xVz
+buV
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -68845,19 +73052,19 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -68899,64 +73106,64 @@ tur
 tur
 uoO
 uoO
-uoO
-pYd
-dLK
+eWV
+fKi
 fLU
 fLU
 fLU
 fLU
+fZO
 lKk
-elU
 pYd
-uoO
+rXA
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+jmN
+hLd
+jmN
+kvL
+nrO
+lIw
+mgQ
+jmN
+kvK
+vuv
+vuv
+pkH
+qvI
+hEp
+qvI
+rrm
+vuv
+vuv
+tjA
+vuv
+vuv
+vuv
+vuv
+vuv
+cqT
+vgS
+cqT
+wfG
+cqT
+tur
+wIM
+weW
+tur
 uoO
 uoO
 tur
@@ -69012,9 +73219,6 @@ eLE
 eLE
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -69024,15 +73228,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -69042,23 +73237,8 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -69076,9 +73256,36 @@ uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 xVz
 xVz
 xVz
+xVz
+oTR
+xVz
+xVz
+lMI
+xVz
+xVz
+xVz
+xVz
+xVz
 aoj
 aoj
 uoO
@@ -69091,22 +73298,22 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -69156,38 +73363,16 @@ uoO
 uoO
 uoO
 uoO
-uoO
-pYd
-gTv
+eWV
+fKq
 tgC
 tgC
-hpe
+fWY
 fLU
+gaf
 sMr
-vXF
 pYd
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-miI
-weW
-weW
-wmT
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+rXA
 uoO
 uoO
 uoO
@@ -69196,24 +73381,46 @@ uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+eLE
+jmN
+jFx
+jmN
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+ozN
+plF
+qwP
+qwP
+qwP
+qwP
+ozN
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+wIM
+weW
+tur
 uoO
 uoO
 tur
@@ -69269,9 +73476,6 @@ eLE
 eLE
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -69281,15 +73485,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -69299,23 +73494,9 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -69333,8 +73514,34 @@ uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+buV
+xVz
+xVz
+xVz
+qjT
+xVz
+bRX
+uoO
+xVz
+xVz
+xVz
+xVz
 xVz
 aoj
 aoj
@@ -69348,22 +73555,22 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
 uoO
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -69413,38 +73620,16 @@ uoO
 uoO
 uoO
 uoO
-uoO
+eUp
+pYd
+pYd
+pYd
+fKi
+pYd
+pYd
+pYd
+gbH
 rXA
-pYd
-pYd
-pYd
-dLK
-pYd
-pYd
-pYd
-rXA
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-tur
-acs
-weW
-weW
-miI
-tur
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -69453,7 +73638,6 @@ uoO
 tur
 nBk
 nBk
-miI
 tur
 uoO
 uoO
@@ -69461,16 +73645,39 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+tur
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+tur
 uoO
 uoO
 uoO
@@ -69539,7 +73746,23 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -69562,35 +73785,19 @@ aoj
 aoj
 aoj
 uoO
-aoj
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
+xoU
+xVz
+xVz
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-aoj
-aoj
 aoj
 xVz
 aoj
@@ -69605,10 +73812,10 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
-aoj
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -69673,10 +73880,21 @@ tur
 tur
 tur
 tur
-tur
-rBS
 phA
 rBS
+phA
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+nBk
+nBk
 tur
 tur
 tur
@@ -69691,8 +73909,6 @@ tur
 tur
 tur
 tur
-mNE
-mNE
 tur
 tur
 tur
@@ -69702,15 +73918,6 @@ tur
 tur
 tur
 tur
-tur
-tur
-tur
-tur
-tur
-tur
-nKZ
-nKZ
-iRc
 tur
 tur
 tur
@@ -69814,24 +74021,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -69846,25 +74035,27 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 xVz
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
 uoO
 uoO
 aoj
-aoj
-uoO
 aoj
 aoj
 uoO
@@ -69873,8 +74064,24 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -69945,16 +74152,21 @@ vbV
 vfj
 miI
 miI
-wWF
+miI
+miI
+miI
+miI
+miI
+miI
+miI
+miI
 vfj
 vfj
-tjt
-tjt
-vfj
-vfj
-vfj
-wWF
-wWF
+miI
+miI
+miI
+miI
+miI
 vfj
 vfj
 vfj
@@ -69963,25 +74175,20 @@ miI
 miI
 miI
 miI
-vbV
-vbV
-vfj
-vfj
-miI
-miI
-vfj
-vbV
-wWF
 miI
 miI
 miI
 miI
-vfj
-oiy
 miI
 miI
-wWF
-wWF
+miI
+miI
+miI
+miI
+miI
+miI
+miI
+miI
 wWF
 miI
 miI
@@ -70079,32 +74286,32 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 xVz
+xVz
+xVz
+xVz
+buV
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uiV
 aoj
 uoO
@@ -70119,19 +74326,19 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-aoj
-aoj
-uoO
-uoO
 uoO
 uoO
 uoO
 uoO
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -70206,22 +74413,6 @@ weW
 weW
 weW
 weW
-lYx
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-lYx
 weW
 weW
 weW
@@ -70238,7 +74429,23 @@ weW
 weW
 weW
 weW
-qaX
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+weW
+wpJ
+nuA
 nuA
 hsR
 weW
@@ -70322,10 +74529,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -70344,24 +74547,28 @@ aoj
 aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 aoj
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
 xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 xVz
 rZw
 uoO
@@ -70371,24 +74578,24 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -70556,30 +74763,9 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -70614,11 +74800,32 @@ uoO
 aoj
 aoj
 aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
-rZw
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 xVz
 xVz
 uoO
@@ -70636,23 +74843,23 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -70752,7 +74959,7 @@ uoO
 uoO
 uoO
 mkY
-cvb
+nXj
 nXj
 nXj
 mkY
@@ -70813,9 +75020,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -70823,24 +75027,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -70871,10 +75057,22 @@ uoO
 aoj
 aoj
 aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
 xVz
 xVz
 uoO
@@ -70885,31 +75083,40 @@ uoO
 uoO
 uoO
 uoO
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -71009,8 +75216,8 @@ uoO
 uoO
 uoO
 mkY
-vKh
-cvb
+nXj
+nXj
 nXj
 mkY
 uoO
@@ -71069,7 +75276,6 @@ eLE
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -71087,26 +75293,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -71128,12 +75314,23 @@ uoO
 aoj
 aoj
 aoj
+aoj
+aoj
 uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
 xVz
-uoO
+xVz
+xVz
 xVz
 uoO
 uoO
@@ -71142,8 +75339,9 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+xVz
 uoO
 uoO
 uoO
@@ -71151,22 +75349,31 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -71337,33 +75544,12 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -71385,10 +75571,22 @@ uoO
 aoj
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+xVz
+xVz
 xVz
 xVz
 xVz
@@ -71399,33 +75597,42 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
+xVz
+xVz
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -71594,7 +75801,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -71606,21 +75812,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -71645,9 +75836,15 @@ aoj
 uoO
 uoO
 uoO
+uoO
+uoO
 aoj
 aoj
-aoj
+uoO
+uoO
+uoO
+xVz
+xVz
 xVz
 xVz
 uoO
@@ -71658,14 +75855,8 @@ uoO
 uoO
 uoO
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -71681,8 +75872,24 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -71868,35 +76075,35 @@ aoj
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -71914,19 +76121,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -71939,8 +76133,21 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -72144,17 +76351,17 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+lMI
 uoO
 uoO
 uoO
@@ -72171,6 +76378,24 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 uoO
 uoO
@@ -72180,24 +76405,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -72383,15 +76590,10 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -72405,13 +76607,18 @@ uoO
 uoO
 uoO
 aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+lMI
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -72439,8 +76646,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -72453,8 +76658,10 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -72640,20 +76847,24 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 uoO
 uoO
@@ -72661,14 +76872,10 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -72688,15 +76895,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -72704,16 +76902,25 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
@@ -72813,7 +77020,7 @@ cvb
 cvb
 coX
 cIF
-wrJ
+qUn
 xkh
 iIu
 tnp
@@ -72897,21 +77104,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -72926,6 +77118,21 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+vOo
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -72944,27 +77151,27 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -73153,12 +77360,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -73168,13 +77369,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -73188,6 +77382,19 @@ uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -73202,14 +77409,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -73221,22 +77420,30 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -73430,21 +77637,21 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -73459,22 +77666,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -73483,17 +77674,33 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -73576,7 +77783,7 @@ jSu
 wrJ
 eGn
 wrJ
-coX
+ndr
 cvb
 cvb
 cvb
@@ -73687,21 +77894,21 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
 uoO
 uoO
 uoO
 aoj
 uoO
 uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
-aoj
+uoO
 uoO
 uoO
 aoj
@@ -73717,8 +77924,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -73749,8 +77954,10 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -73946,19 +78153,19 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
-uoO
-aoj
 uoO
 uoO
 aoj
@@ -73975,20 +78182,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -74006,8 +78199,22 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -74184,17 +78391,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -74203,16 +78399,27 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -74246,25 +78453,25 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -74442,15 +78649,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -74467,12 +78665,21 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -74499,24 +78706,24 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -74609,7 +78816,7 @@ cvb
 cvb
 cvb
 cvb
-coX
+ndr
 wrJ
 kkq
 cAf
@@ -74695,17 +78902,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -74723,14 +78919,25 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+fou
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 xVz
@@ -74751,8 +78958,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -74760,9 +78965,11 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -74840,9 +79047,9 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -74952,7 +79159,6 @@ uoO
 uoO
 aoj
 aoj
-aoj
 uoO
 uoO
 uoO
@@ -74980,16 +79186,17 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
+xVz
 xVz
 xVz
 aoj
@@ -75008,24 +79215,24 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -75097,9 +79304,9 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -75212,8 +79419,6 @@ aoj
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -75234,20 +79439,22 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
 xVz
+qjT
+qoi
+lMI
 xVz
 uoO
 uoO
@@ -75260,28 +79467,28 @@ rEl
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -75340,7 +79547,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -75351,12 +79557,13 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
@@ -75467,21 +79674,6 @@ aoj
 aoj
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -75491,19 +79683,34 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
-aoj
-aoj
-uoO
-aoj
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
 xVz
 xVz
 uoO
@@ -75517,31 +79724,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -75554,8 +79736,33 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -75597,7 +79804,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -75608,12 +79814,13 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
@@ -75627,7 +79834,7 @@ abg
 cvb
 dyC
 cvb
-cvb
+uPv
 cvb
 cvb
 cvb
@@ -75748,65 +79955,31 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
-aoj
-aoj
+xVz
+xVz
+qDR
 uoO
 uoO
+uoO
+uoO
+xVz
 xVz
 uoO
 uoO
 uoO
 uoO
-xVz
-xVz
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -75851,7 +80024,40 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
@@ -75865,12 +80071,13 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
@@ -75888,7 +80095,7 @@ tnp
 tnp
 tnp
 tnp
-coX
+ndr
 tnp
 tnp
 cvb
@@ -76005,40 +80212,30 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
-aoj
-aoj
+qDR
+qDR
+egP
 uoO
 uoO
+uoO
+xVz
+xVz
 xVz
 uoO
 uoO
 uoO
-xVz
-xVz
-xVz
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -76046,7 +80243,6 @@ uoO
 uoO
 uoO
 aoj
-aoj
 uoO
 uoO
 uoO
@@ -76056,9 +80252,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -76068,8 +80261,22 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -76111,7 +80318,6 @@ uoO
 aoj
 aoj
 aoj
-aoj
 uoO
 uoO
 uoO
@@ -76122,12 +80328,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -76135,8 +80335,15 @@ uoO
 uoO
 uoO
 uoO
-skG
-tnp
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+sdN
+hba
 deT
 cvb
 syq
@@ -76274,8 +80481,8 @@ uoO
 uoO
 uoO
 aoj
-uoO
-uoO
+ahe
+egP
 xVz
 uoO
 uoO
@@ -76289,44 +80496,8 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 aoj
-aoj
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -76337,8 +80508,16 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -76367,24 +80546,34 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
 aoj
 uoO
 uoO
@@ -76392,9 +80581,27 @@ uoO
 uoO
 uoO
 uoO
-skG
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+eLF
 tnp
-tnp
+hba
 cvb
 cvb
 cvb
@@ -76531,13 +80738,16 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+xVz
+xVz
+xoU
+xVz
+xVz
+xVz
 xVz
 uoO
 uoO
 uoO
-xVz
 uoO
 uoO
 uoO
@@ -76559,14 +80769,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -76577,10 +80779,15 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -76625,7 +80832,6 @@ uoO
 aoj
 aoj
 aoj
-aoj
 uoO
 uoO
 uoO
@@ -76636,13 +80842,14 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -76788,13 +80995,13 @@ lEl
 uoO
 uoO
 uoO
-uoO
-uoO
 xVz
 xVz
 xVz
 xVz
 xVz
+xVz
+xVz
 uoO
 aoj
 aoj
@@ -76811,31 +81018,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -76851,8 +81033,7 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -76879,25 +81060,51 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -77067,29 +81274,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -77105,11 +81289,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -77138,22 +81317,50 @@ uoO
 uoO
 aoj
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -77299,7 +81506,7 @@ uoO
 uoO
 uoO
 lEl
-xVz
+qoi
 xVz
 xVz
 xVz
@@ -77324,38 +81531,6 @@ rEl
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -77365,8 +81540,12 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -77395,22 +81574,50 @@ uoO
 uoO
 aoj
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -77559,8 +81766,8 @@ lEl
 xVz
 xVz
 xVz
-xVz
-xVz
+qjT
+qoi
 xVz
 xVz
 xVz
@@ -77581,28 +81788,6 @@ rEl
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -77612,18 +81797,11 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -77664,13 +81842,42 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -77837,41 +82044,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -77905,11 +82077,26 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -77928,6 +82115,26 @@ uoO
 aoj
 aoj
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -78081,9 +82288,9 @@ xVz
 xVz
 xVz
 xVz
+qjT
 xVz
 xVz
-xVz
 uoO
 cSY
 cSY
@@ -78093,29 +82300,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -78127,8 +82311,31 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -78351,17 +82558,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -78371,21 +82567,32 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -78590,7 +82797,7 @@ qjT
 qjT
 sdJ
 seJ
-qpe
+sjA
 qoi
 rZw
 xVz
@@ -78604,15 +82811,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -78628,15 +82826,24 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -78868,17 +83075,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -78889,11 +83085,22 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79100,7 +83307,7 @@ xVz
 xVz
 xVz
 fou
-fAJ
+hOj
 byA
 vZr
 cSY
@@ -79116,47 +83323,6 @@ cSY
 cSY
 uoO
 aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -79176,12 +83342,36 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79195,6 +83385,15 @@ uoO
 uoO
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79202,6 +83401,14 @@ uoO
 uoO
 uoO
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79358,7 +83565,7 @@ xVz
 xVz
 cSY
 cSY
-xVz
+cSY
 mTj
 cSY
 cSY
@@ -79373,30 +83580,6 @@ rOp
 aoj
 uoO
 aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -79411,18 +83594,27 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79438,8 +83630,6 @@ aoj
 aoj
 aoj
 aoj
-aoj
-uoO
 uoO
 uoO
 uoO
@@ -79452,12 +83642,29 @@ uoO
 uoO
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
 aoj
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79615,7 +83822,7 @@ xVz
 xVz
 cSY
 cSY
-rEl
+nmo
 mTj
 cSY
 cSY
@@ -79630,53 +83837,6 @@ uoO
 aoj
 uoO
 aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -79690,12 +83850,27 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79712,9 +83887,41 @@ aoj
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79868,11 +84075,11 @@ uAc
 iZQ
 rEj
 xVz
-xVz
+qoi
 xVz
 cSY
 cSY
-xVz
+cSY
 cSY
 cSY
 cSY
@@ -79887,34 +84094,6 @@ uoO
 aoj
 uoO
 aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -79932,8 +84111,21 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79949,10 +84141,7 @@ uoO
 uoO
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -79966,12 +84155,30 @@ uoO
 uoO
 uoO
 aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
 aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80129,7 +84336,7 @@ xVz
 xoU
 saz
 cSY
-xVz
+cSY
 cSY
 nqE
 cSY
@@ -80157,20 +84364,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -80187,29 +84380,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -80227,6 +84397,12 @@ uoO
 uoO
 uoO
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80237,6 +84413,37 @@ uoO
 uoO
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80384,9 +84591,9 @@ yhT
 uoO
 xVz
 rXl
-xVz
+cSY
 fAJ
-pNT
+vZr
 vZr
 cSY
 cSY
@@ -80413,8 +84620,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -80422,36 +84627,23 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80476,24 +84668,39 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80662,42 +84869,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -80729,9 +84900,34 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80741,16 +84937,27 @@ uoO
 uoO
 uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80913,20 +85120,15 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -80954,8 +85156,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -80982,15 +85182,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -81005,9 +85196,25 @@ uoO
 uoO
 aoj
 aoj
+aoj
+aoj
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -81169,14 +85376,9 @@ xoU
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -81186,13 +85388,10 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
-aoj
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -81211,8 +85410,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -81244,11 +85441,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -81264,7 +85456,22 @@ aoj
 aoj
 aoj
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -81428,30 +85635,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -81468,8 +85651,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -81484,10 +85665,17 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -81504,6 +85692,25 @@ uoO
 uoO
 uoO
 aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 aoj
 aoj
 aoj
@@ -81516,12 +85723,12 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -81688,45 +85895,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -81740,11 +85908,29 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -81773,12 +85959,33 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
 aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -81946,45 +86153,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -81997,10 +86165,28 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -82022,6 +86208,25 @@ aoj
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 aoj
 aoj
 uoO
@@ -82030,12 +86235,14 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -82202,37 +86409,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -82276,11 +86452,29 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -82292,7 +86486,20 @@ uoO
 aoj
 aoj
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -82455,18 +86662,13 @@ uoO
 uoO
 uoO
 aoj
-aoj
-aoj
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -82485,10 +86687,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -82534,10 +86732,7 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -82548,8 +86743,20 @@ uoO
 uoO
 aoj
 aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -82712,40 +86919,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -82777,15 +86950,33 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -82796,6 +86987,22 @@ uoO
 aoj
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -82984,25 +87191,25 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -83241,19 +87448,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -83263,7 +87457,20 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -83480,7 +87687,6 @@ xoU
 uoO
 uoO
 aoj
-aoj
 uoO
 uoO
 uoO
@@ -83507,12 +87713,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -83520,11 +87720,18 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -83737,40 +87944,6 @@ xoU
 uoO
 uoO
 aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -83781,8 +87954,42 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -84000,15 +88207,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -84019,16 +88217,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -84038,8 +88226,27 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -84257,15 +88464,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -84276,27 +88474,36 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -84484,7 +88691,7 @@ dVj
 xjE
 xhA
 fwX
-xjE
+dSx
 hac
 xjE
 sUs
@@ -84514,16 +88721,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -84533,15 +88730,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -84549,15 +88737,34 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
@@ -84775,29 +88982,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -84810,11 +88994,34 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
@@ -85032,8 +89239,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -85067,8 +89272,10 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -85286,21 +89493,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -85316,7 +89508,22 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -85542,12 +89749,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -85573,7 +89774,13 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -85798,12 +90005,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -85824,8 +90025,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -85837,7 +90036,15 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -86055,15 +90262,6 @@ uoO
 uoO
 uoO
 aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -86075,14 +90273,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -86094,7 +90284,24 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -86249,7 +90456,7 @@ tsm
 ejQ
 tsm
 xxn
-xxn
+vUs
 xxn
 gEZ
 xSi
@@ -86312,17 +90519,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -86332,19 +90528,30 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -86575,33 +90782,33 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -86834,20 +91041,20 @@ uoO
 uoO
 uoO
 aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -87099,8 +91306,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -87120,11 +91325,13 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -87354,10 +91561,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -87379,9 +91582,13 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -87610,9 +91817,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -87637,7 +91841,10 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -15245,6 +15245,10 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
+"mUZ" = (
+/obj/effect/landmark/map_load_mark/dungeons/northsewer,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "mVa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -22801,11 +22805,8 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
-/obj/item/clothing/suit/armor/f13/power_armor/t45d{
-	color = "#C1C1C1";
-	desc = "(IX) Originally developed and manufactured for the United States Army by American defense contractor West Tek, the T-45d power armor was the first version of power armor to be successfully deployed in battle. This set looks somewhat bashed up and worn";
-	item_color = "#C1C1C1"
-	},
+/obj/item/clothing/suit/armor/f13/power_armor/t45d/gunslinger,
+/obj/item/clothing/head/helmet/f13/power_armor/t45d/gunslinger,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "tDc" = (
@@ -23003,6 +23004,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/effect/landmark/start/f13/ncrcaptain,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "tLd" = (
@@ -33180,13 +33182,13 @@ uoO
 uoO
 uoO
 uoO
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 eLE
 eLE
 eLE
@@ -44746,7 +44748,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+mUZ
 uoO
 uoO
 uoO
@@ -45259,8 +45261,8 @@ uoO
 uoO
 uoO
 uoO
-eLE
-eLE
+uoO
+uoO
 eLE
 eLE
 eLE
@@ -45516,7 +45518,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -45772,8 +45774,8 @@ eLE
 eLE
 eLE
 eLE
-eLE
-eLE
+uoO
+uoO
 uoO
 gpM
 gpM
@@ -46032,7 +46034,7 @@ uoO
 uoO
 uoO
 uoO
-xVz
+uoO
 lnr
 uoO
 lnr
@@ -46286,10 +46288,10 @@ uoO
 uoO
 xVz
 xVz
-xVz
 uoO
-xVz
-xVz
+uoO
+uoO
+uoO
 lnr
 lnr
 lnr
@@ -46543,10 +46545,10 @@ xVz
 xVz
 pmU
 xVz
-xVz
-xVz
-xVz
-xVz
+uoO
+uoO
+uoO
+uoO
 lnr
 lnr
 lnr
@@ -47058,8 +47060,8 @@ uoO
 uoO
 uoO
 uoO
-eLE
-eLE
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -47314,8 +47316,8 @@ eLE
 eLE
 eLE
 eLE
-eLE
-eLE
+uoO
+uoO
 uoO
 eLE
 eLE


### PR DESCRIPTION
## About The Pull Request:
This PR is an overhaul of Pahrump. Mainly focusing on adding old content back and moving Oasis further to the center of the map.

## Why It's Good For The Game

Moving Oasis further into the center instead of the corner will make it easier for people to use it as a hub to roleplay in. Legion might be closer to it and have more incentive to enslave the population of Oasis, creating conflict where the NCR would be able to step in and do their job.
The followers clinic has been merged into the Oasis doctor , since nobody even plays Oasis doctor and it’s basically the same role.Kinda retarded they were right next to eachother anyway.
More bunkers because it’s fun.

## Changelog
:cl:
add: 3 old bunkers in second z-level 
add: new independent church south to oasis
add: new oasis
balance: loot has lesser tier the less risk it requires
balance: shopkeeper only has tier 7-8 instead of 9-10
del: oasis church 
del: nuked oasis doctor
del: followers clinic
del: old oasis

## Notes:
Might need more testing in regards to balance.

## Screenshots:
( Zoom in for Original size )

https://i.ibb.co/hLJ8kZJ/1.png

https://i.ibb.co/jgKN6vq/2.png


