### PR TITLE
BoS village booth fix

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -918,14 +918,14 @@
 /turf/closed/wall/f13/wood,
 /area/f13/city)
 "aDw" = (
-/obj/structure/chair/left{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 8;
 	pixel_x = -6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_east_middle"
+	},
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "aDX" = (
@@ -1076,15 +1076,13 @@
 /turf/open/floor/wood/f13/stage_tl,
 /area/f13/legion)
 "aKD" = (
-/obj/structure/chair/left{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4;
 	pixel_x = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/west_middle,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "aLg" = (
@@ -2254,9 +2252,6 @@
 	},
 /area/f13/caves)
 "bxG" = (
-/obj/structure/chair/left{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1;
 	pixel_y = 6
@@ -2267,6 +2262,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "byv" = (
@@ -7123,9 +7121,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "eWH" = (
-/obj/structure/chair/left{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/line{
 	pixel_y = -6
 	},
@@ -7134,6 +7129,9 @@
 	pixel_x = -6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
+	},
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "eXa" = (
@@ -10383,9 +10381,6 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "hab" = (
-/obj/structure/chair/left{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 8;
 	pixel_x = -6
@@ -10394,6 +10389,9 @@
 /obj/item/radio/intercom{
 	frequency = 1891;
 	pixel_x = -33
+	},
+/obj/structure/chair/booth{
+	icon_state = "booth_east_middle"
 	},
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
@@ -15644,9 +15642,6 @@
 	},
 /area/f13/wasteland)
 "koZ" = (
-/obj/structure/chair/left{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1;
 	pixel_y = 6
@@ -15656,6 +15651,9 @@
 	pixel_x = 6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "kpd" = (
@@ -17307,9 +17305,6 @@
 	},
 /area/f13/followers)
 "luc" = (
-/obj/structure/chair/left{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4;
 	pixel_x = 6
@@ -17319,6 +17314,7 @@
 	frequency = 1891;
 	pixel_x = 33
 	},
+/obj/structure/chair/west_middle,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "lun" = (
@@ -19453,14 +19449,12 @@
 	},
 /area/f13/wasteland)
 "mTm" = (
-/obj/structure/chair/left{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4;
 	pixel_x = 6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/west_middle,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "mTy" = (
@@ -24387,7 +24381,9 @@
 /turf/closed/wall/f13/wood,
 /area/f13/village)
 "qiU" = (
-/obj/structure/chair/stool/retro,
+/obj/structure/chair/stool/retro/backed{
+	dir = 8
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "qiV" = (
@@ -28740,9 +28736,6 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "thO" = (
-/obj/structure/chair/left{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 8;
 	pixel_x = -6
@@ -28751,6 +28744,9 @@
 	pixel_y = -6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
+	},
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "thW" = (
@@ -33213,8 +33209,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "wbi" = (
-/obj/structure/chair/stool/retro,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/retro/backed{
+	dir = 8
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "wcu" = (

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -720,6 +720,30 @@
 /obj/structure/chair/left/proc/GetOverlay()
 	return mutable_appearance('icons/obj/chairs.dmi', "booth_leftend_overlay")
 
+/obj/structure/chair/west_middle
+	name = "booth"
+	desc = "A diner-styled end booth."
+	icon_state = "booth_west_middle"
+	resistance_flags = FLAMMABLE
+	max_integrity = 70
+	item_chair = null
+	var/mutable_appearance/overlay
+
+/obj/structure/chair/left/proc/update_overlay()
+		add_overlay(overlay)
+
+/obj/structure/chair/left/Initialize()
+	overlay = GetOverlay()
+	overlay.layer = ABOVE_ALL_MOB_LAYER
+	return ..()
+
+/obj/structure/chair/left/Destroy()
+	QDEL_NULL(overlay)
+	return ..()
+
+/obj/structure/chair/left/proc/GetOverlay()
+	return mutable_appearance('icons/obj/chairs.dmi', "booth_leftend_overlay")
+
 /obj/structure/chair/middle
 	name = "booth"
 	desc = "A diner-styled middle booth."

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -729,9 +729,6 @@
 	item_chair = null
 	var/mutable_appearance/overlay
 
-/obj/structure/chair/left/proc/update_overlay()
-		add_overlay(overlay)
-
 /obj/structure/chair/left/Initialize()
 	overlay = GetOverlay()
 	overlay.layer = ABOVE_ALL_MOB_LAYER
@@ -740,9 +737,6 @@
 /obj/structure/chair/left/Destroy()
 	QDEL_NULL(overlay)
 	return ..()
-
-/obj/structure/chair/left/proc/GetOverlay()
-	return mutable_appearance('icons/obj/chairs.dmi', "booth_leftend_overlay")
 
 /obj/structure/chair/middle
 	name = "booth"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For anyone who's been inside the BoS village, you've likely seen the booths there. What even. They are fixed now to look like one long piece of furniture.

## Why It's Good For The Game

Oh my goodness it was so ugly just having the end pieces lined up, if I had OCD I would have been very upset. The east facing booth is now in game and ready for placement by all map makers.

## Changelog
:cl:
add: Added east facing middle booth, added them to BoS Village
del: Deleted old ugly booths in BoS Village, yuck.
add: Added bar stools to Oasis bar, because we have them and it's a bar.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
