### PR TITLE
Obliterates ranged melee once and for all

### DIFF
--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -115,7 +115,6 @@
 	icon_state = "halberd"
 	w_class = WEIGHT_CLASS_HUGE
 	overlay_state = "spearhandle"
-	reach = 2 
 	slot_flags = ITEM_SLOT_BACK
 	wielded_mult = 1.8
 
@@ -141,7 +140,6 @@
 	name = "glaive"
 	icon_state = "glaive"
 	overlay_state = "longhandle"
-	reach = 2 
 	slot_flags = ITEM_SLOT_BACK
 	wielded_mult = 1.5
 
@@ -154,7 +152,6 @@
 	name = "pike"
 	icon_state = "pike"
 	overlay_state = "longhandle"
-	reach = 2 //yeah ok
 	wielded_mult = 1.3
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = SHARP_POINTY

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -17,6 +17,7 @@
 	var/mutable_appearance/overlay
 	var/wielded_mult = 1
 	var/wield_force = 15
+
 /obj/item/melee/smith/Initialize()
 	..()
 	if(desc == "cringe")
@@ -26,6 +27,8 @@
 	add_overlay(overlay)
 	if(force < 0)
 		force = 0
+
+
 /obj/item/melee/smith/twohand
 	item_flags = NEEDS_PERMIT //it's a bigass sword/spear. beepsky is going to give you shit for it.
 	sharpness = SHARP_EDGED
@@ -33,10 +36,14 @@
 	force = 10
 	wielded_mult = 1.75
 	w_class = WEIGHT_CLASS_BULKY
+
 /obj/item/melee/smith/twohand/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 100, 70) //decent in a pinch, but pretty bad.
 	AddElement(/datum/element/sword_point)
+
+
+
 ///////////////////////////
 //        Mining         //
 ///////////////////////////
@@ -47,6 +54,7 @@
 	icon = 'icons/obj/smith.dmi'
 	icon_state = "minipick" //todo:sprite
 	sharpness = SHARP_POINTY//it doesnt have a blade it has a point
+
 /obj/item/mining_scanner/prospector/Initialize()
 	..()
 	var/mutable_appearance/overlay
@@ -56,6 +64,7 @@
 	add_overlay(overlay)
 	if(force < 0)
 		force = 0
+
 /obj/item/pickaxe/smithed
 	name = "pickaxe"
 	desc = "A pickaxe."
@@ -63,6 +72,7 @@
 	icon = 'icons/obj/smith.dmi'
 	icon_state = "pickaxe"
 	sharpness = SHARP_POINTY
+
 /obj/item/pickaxe/smithed/Initialize()
 	..()
 	desc = "A handmade [name]."
@@ -72,8 +82,10 @@
 	add_overlay(overlay)
 	if(force < 0)
 		force = 0
+
 /obj/item/pickaxe/smithed/attack_self(mob/user)
 		to_chat(user, "<span class='notice'>Tool does not have a configureable dig range.</span>")
+
 /obj/item/shovel/smithed
 	name = "shovel"
 	desc = "A shovel."
@@ -81,6 +93,7 @@
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	icon_state = "shovel"
 	sharpness = SHARP_EDGED //it cuts through the earth
+
 /obj/item/shovel/smithed/Initialize()
 	..()
 	desc = "A handmade [name]."
@@ -90,9 +103,13 @@
 	add_overlay(overlay)
 	if(force < 0)
 		force = 0
+
+
 ///////////////////////////
 //        Spears         //
 ///////////////////////////
+
+
 /obj/item/melee/smith/twohand/halberd
 	name = "halberd"
 	icon_state = "halberd"
@@ -102,20 +119,11 @@
 	slot_flags = ITEM_SLOT_BACK
 	wielded_mult = 1.8
 
-
-    
-        
-          
-    
-
-        
-    
-    @@ -141,7 +140,6 @@
-  
 /obj/item/melee/smith/twohand/halberd/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/jousting)
 	AddComponent(/datum/component/two_handed, require_twohands=TRUE)
+
 /obj/item/melee/smith/twohand/javelin
 	name = "javelin"
 	icon_state = "javelin"
@@ -123,9 +131,12 @@
 	wielded_mult = 1.5
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = SHARP_POINTY
+
+
 /obj/item/melee/smith/twohand/javelin/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/jousting)
+
 /obj/item/melee/smith/twohand/glaive
 	name = "glaive"
 	icon_state = "glaive"
@@ -134,19 +145,11 @@
 	slot_flags = ITEM_SLOT_BACK
 	wielded_mult = 1.5
 
-
-    
-        
-          
-    
-
-        
-    
-    @@ -154,7 +152,6 @@
-  
 /obj/item/melee/smith/twohand/glaive/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/jousting)
+
+
 /obj/item/melee/smith/twohand/pike
 	name = "pike"
 	icon_state = "pike"
@@ -156,30 +159,27 @@
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = SHARP_POINTY
 
-    
-          
-            
-    
-
-          
-    
-    
-  
 //////////////////////////
 //      Other Melee     //
 ///////////////////////////
+
+
 /obj/item/melee/smith/hammer//blacksmithing, not warhammer.
 	name = "hammer"
 	icon_state = "hammer"
 	overlay_state = "hammerhandle"
 	var/qualitymod = 0
+
 /obj/item/scythe/smithed //we need to inherit scythecode, but that's about it.
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
+
+
 /obj/item/melee/smith/cogheadclub
 	name = "coghead club"
 	icon_state = "coghead"
 	item_flags = NEEDS_PERMIT
 	overlay_state = "stick"
+
 /obj/item/melee/smith/shortsword
 	name = "gladius"
 	force = 9
@@ -187,11 +187,13 @@
 	sharpness = SHARP_EDGED
 	icon_state = "gladius"
 	overlay_state = "gladiushilt"
+
 /obj/item/melee/smith/shortsword/scimitar
 	name = "scimitar"
 	sharpness = SHARP_EDGED
 	icon_state = "scimitar"
 	overlay_state = "scimitarhilt"
+
 /obj/item/melee/smith/wakizashi
 	name = "wakizashi"
 	sharpness = SHARP_EDGED
@@ -201,6 +203,7 @@
 	icon_state = "waki"
 	overlay_state = "wakihilt"
 	block_parry_data = /datum/block_parry_data/waki
+
 /datum/block_parry_data/waki //like longbokken but worse reflect
 	parry_stamina_cost = 6
 	parry_time_windup = 0
@@ -214,11 +217,13 @@
 	parry_efficiency_perfect = 120
 	parry_failed_stagger_duration = 3 SECONDS
 	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 1.9)
+
 /obj/item/melee/smith/twohand/broadsword
 	name = "broadsword"
 	icon_state = "broadsword"
 	overlay_state = "broadhilt"
 	wielded_mult = 1.8
+
 /obj/item/melee/smith/twohand/zweihander
 	name = "zweihander"
 	icon_state = "zwei"
@@ -226,6 +231,7 @@
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON * 2
 	force = 4
 	wielded_mult = 2 //affected more by quality. a -1 is 25% less damage, a +1 is 25% more. These bonuses are tripled when wielded.
+
 /obj/item/melee/smith/twohand/katana
 	name = "katana"
 	icon_state = "katana"
@@ -235,6 +241,7 @@
 	item_flags = ITEM_CAN_PARRY | NEEDS_PERMIT //want to name your katana "DEMON BLADE" or some shit? go ahead, idiot.
 	obj_flags = UNIQUE_RENAME
 	block_parry_data = /datum/block_parry_data/captain_saber //todo
+
 /obj/item/melee/smith/sabre
 	name = "sabre"
 	icon_state = "sabre"
@@ -245,6 +252,7 @@
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	item_flags = NEEDS_PERMIT | ITEM_CAN_PARRY
 	block_parry_data = /datum/block_parry_data/captain_saber //yeah this is fine i guess
+
 /obj/item/melee/smith/sabre/rapier
 	name = "rapier"
 	icon_state = "rapier"
@@ -254,6 +262,7 @@
 	sharpness = SHARP_POINTY
 	armour_penetration = 0.6
 	block_parry_data = /datum/block_parry_data/smithrapier
+
 /datum/block_parry_data/smithrapier //parry into riposte. i am pretty sure this is going to be nearly fucking impossible to land.
 	parry_stamina_cost = 12 //dont miss
 	parry_time_active = 4
@@ -268,6 +277,7 @@
 	parry_efficiency_considered_successful = 120
 	parry_efficiency_perfect = 120
 	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 4)
+
 //unique hammers
 /obj/item/melee/smith/hammer/toolbox
 	name = "toolbox hammer"
@@ -276,11 +286,13 @@
 	icon_state = "toolbox"
 	overlay_state = "hammerhandle"
 	qualitymod = 0
+
 /obj/item/melee/smith/hammer/narsie
 	name = "runemetal hammer"
 	custom_materials = list(/datum/material/runedmetal = 12000)
 	desc = "A metal hammer inscribed with geometeric runes."
 	qualitymod = 1
+
 /obj/item/melee/smith/hammer/narsie/attack(mob/living/target, mob/living/carbon/human/user)
 	if(!iscultist(user))
 		user.DefaultCombatKnockdown(100)
@@ -294,11 +306,13 @@
 			user.adjustBruteLoss(rand(force/2,force))
 		return
 	..()
+
 /obj/item/melee/smith/hammer/ratvar
 	name = "brass hammer"
 	custom_materials = list(/datum/material/bronze = 12000)
 	desc = "A brass hammer inscribed with... writing? You can't read it."
 	qualitymod = 1
+
 /obj/item/melee/smith/hammer/ratvar/attack(mob/living/target, mob/living/carbon/human/user)
 	if(!is_servant_of_ratvar(user))
 		user.DefaultCombatKnockdown(100)
@@ -311,6 +325,7 @@
 			user.adjustBruteLoss(rand(force/2,force))
 		return
 	..()
+
 /obj/item/melee/smith/hammer/debug
 	name = "debugging hammer"
 	desc = "A DEBUGGING HAMMER!! EPIC!!."

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -17,7 +17,6 @@
 	var/mutable_appearance/overlay
 	var/wielded_mult = 1
 	var/wield_force = 15
-
 /obj/item/melee/smith/Initialize()
 	..()
 	if(desc == "cringe")
@@ -27,8 +26,6 @@
 	add_overlay(overlay)
 	if(force < 0)
 		force = 0
-
-
 /obj/item/melee/smith/twohand
 	item_flags = NEEDS_PERMIT //it's a bigass sword/spear. beepsky is going to give you shit for it.
 	sharpness = SHARP_EDGED
@@ -36,14 +33,10 @@
 	force = 10
 	wielded_mult = 1.75
 	w_class = WEIGHT_CLASS_BULKY
-
 /obj/item/melee/smith/twohand/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 100, 70) //decent in a pinch, but pretty bad.
 	AddElement(/datum/element/sword_point)
-
-
-
 ///////////////////////////
 //        Mining         //
 ///////////////////////////
@@ -54,7 +47,6 @@
 	icon = 'icons/obj/smith.dmi'
 	icon_state = "minipick" //todo:sprite
 	sharpness = SHARP_POINTY//it doesnt have a blade it has a point
-
 /obj/item/mining_scanner/prospector/Initialize()
 	..()
 	var/mutable_appearance/overlay
@@ -64,7 +56,6 @@
 	add_overlay(overlay)
 	if(force < 0)
 		force = 0
-
 /obj/item/pickaxe/smithed
 	name = "pickaxe"
 	desc = "A pickaxe."
@@ -72,7 +63,6 @@
 	icon = 'icons/obj/smith.dmi'
 	icon_state = "pickaxe"
 	sharpness = SHARP_POINTY
-
 /obj/item/pickaxe/smithed/Initialize()
 	..()
 	desc = "A handmade [name]."
@@ -82,10 +72,8 @@
 	add_overlay(overlay)
 	if(force < 0)
 		force = 0
-
 /obj/item/pickaxe/smithed/attack_self(mob/user)
 		to_chat(user, "<span class='notice'>Tool does not have a configureable dig range.</span>")
-
 /obj/item/shovel/smithed
 	name = "shovel"
 	desc = "A shovel."
@@ -93,7 +81,6 @@
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	icon_state = "shovel"
 	sharpness = SHARP_EDGED //it cuts through the earth
-
 /obj/item/shovel/smithed/Initialize()
 	..()
 	desc = "A handmade [name]."
@@ -103,26 +90,32 @@
 	add_overlay(overlay)
 	if(force < 0)
 		force = 0
-
-
 ///////////////////////////
 //        Spears         //
 ///////////////////////////
-
-
 /obj/item/melee/smith/twohand/halberd
 	name = "halberd"
 	icon_state = "halberd"
 	w_class = WEIGHT_CLASS_HUGE
 	overlay_state = "spearhandle"
+	reach = 1 
 	slot_flags = ITEM_SLOT_BACK
 	wielded_mult = 1.8
 
+
+    
+        
+          
+    
+
+        
+    
+    @@ -141,7 +140,6 @@
+  
 /obj/item/melee/smith/twohand/halberd/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/jousting)
 	AddComponent(/datum/component/two_handed, require_twohands=TRUE)
-
 /obj/item/melee/smith/twohand/javelin
 	name = "javelin"
 	icon_state = "javelin"
@@ -130,53 +123,63 @@
 	wielded_mult = 1.5
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = SHARP_POINTY
-
-
 /obj/item/melee/smith/twohand/javelin/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/jousting)
-
 /obj/item/melee/smith/twohand/glaive
 	name = "glaive"
 	icon_state = "glaive"
 	overlay_state = "longhandle"
+	reach = 1 
 	slot_flags = ITEM_SLOT_BACK
 	wielded_mult = 1.5
 
+
+    
+        
+          
+    
+
+        
+    
+    @@ -154,7 +152,6 @@
+  
 /obj/item/melee/smith/twohand/glaive/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/jousting)
-
-
 /obj/item/melee/smith/twohand/pike
 	name = "pike"
 	icon_state = "pike"
 	overlay_state = "longhandle"
+	reach = 1 
 	wielded_mult = 1.3
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = SHARP_POINTY
 
+    
+          
+            
+    
+
+          
+    
+    
+  
 //////////////////////////
 //      Other Melee     //
 ///////////////////////////
-
-
 /obj/item/melee/smith/hammer//blacksmithing, not warhammer.
 	name = "hammer"
 	icon_state = "hammer"
 	overlay_state = "hammerhandle"
 	var/qualitymod = 0
-
 /obj/item/scythe/smithed //we need to inherit scythecode, but that's about it.
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
-
-
 /obj/item/melee/smith/cogheadclub
 	name = "coghead club"
 	icon_state = "coghead"
 	item_flags = NEEDS_PERMIT
 	overlay_state = "stick"
-
 /obj/item/melee/smith/shortsword
 	name = "gladius"
 	force = 9
@@ -184,13 +187,11 @@
 	sharpness = SHARP_EDGED
 	icon_state = "gladius"
 	overlay_state = "gladiushilt"
-
 /obj/item/melee/smith/shortsword/scimitar
 	name = "scimitar"
 	sharpness = SHARP_EDGED
 	icon_state = "scimitar"
 	overlay_state = "scimitarhilt"
-
 /obj/item/melee/smith/wakizashi
 	name = "wakizashi"
 	sharpness = SHARP_EDGED
@@ -200,7 +201,6 @@
 	icon_state = "waki"
 	overlay_state = "wakihilt"
 	block_parry_data = /datum/block_parry_data/waki
-
 /datum/block_parry_data/waki //like longbokken but worse reflect
 	parry_stamina_cost = 6
 	parry_time_windup = 0
@@ -214,13 +214,11 @@
 	parry_efficiency_perfect = 120
 	parry_failed_stagger_duration = 3 SECONDS
 	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 1.9)
-
 /obj/item/melee/smith/twohand/broadsword
 	name = "broadsword"
 	icon_state = "broadsword"
 	overlay_state = "broadhilt"
 	wielded_mult = 1.8
-
 /obj/item/melee/smith/twohand/zweihander
 	name = "zweihander"
 	icon_state = "zwei"
@@ -228,7 +226,6 @@
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON * 2
 	force = 4
 	wielded_mult = 2 //affected more by quality. a -1 is 25% less damage, a +1 is 25% more. These bonuses are tripled when wielded.
-
 /obj/item/melee/smith/twohand/katana
 	name = "katana"
 	icon_state = "katana"
@@ -238,7 +235,6 @@
 	item_flags = ITEM_CAN_PARRY | NEEDS_PERMIT //want to name your katana "DEMON BLADE" or some shit? go ahead, idiot.
 	obj_flags = UNIQUE_RENAME
 	block_parry_data = /datum/block_parry_data/captain_saber //todo
-
 /obj/item/melee/smith/sabre
 	name = "sabre"
 	icon_state = "sabre"
@@ -249,7 +245,6 @@
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	item_flags = NEEDS_PERMIT | ITEM_CAN_PARRY
 	block_parry_data = /datum/block_parry_data/captain_saber //yeah this is fine i guess
-
 /obj/item/melee/smith/sabre/rapier
 	name = "rapier"
 	icon_state = "rapier"
@@ -259,7 +254,6 @@
 	sharpness = SHARP_POINTY
 	armour_penetration = 0.6
 	block_parry_data = /datum/block_parry_data/smithrapier
-
 /datum/block_parry_data/smithrapier //parry into riposte. i am pretty sure this is going to be nearly fucking impossible to land.
 	parry_stamina_cost = 12 //dont miss
 	parry_time_active = 4
@@ -274,7 +268,6 @@
 	parry_efficiency_considered_successful = 120
 	parry_efficiency_perfect = 120
 	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 4)
-
 //unique hammers
 /obj/item/melee/smith/hammer/toolbox
 	name = "toolbox hammer"
@@ -283,13 +276,11 @@
 	icon_state = "toolbox"
 	overlay_state = "hammerhandle"
 	qualitymod = 0
-
 /obj/item/melee/smith/hammer/narsie
 	name = "runemetal hammer"
 	custom_materials = list(/datum/material/runedmetal = 12000)
 	desc = "A metal hammer inscribed with geometeric runes."
 	qualitymod = 1
-
 /obj/item/melee/smith/hammer/narsie/attack(mob/living/target, mob/living/carbon/human/user)
 	if(!iscultist(user))
 		user.DefaultCombatKnockdown(100)
@@ -303,13 +294,11 @@
 			user.adjustBruteLoss(rand(force/2,force))
 		return
 	..()
-
 /obj/item/melee/smith/hammer/ratvar
 	name = "brass hammer"
 	custom_materials = list(/datum/material/bronze = 12000)
 	desc = "A brass hammer inscribed with... writing? You can't read it."
 	qualitymod = 1
-
 /obj/item/melee/smith/hammer/ratvar/attack(mob/living/target, mob/living/carbon/human/user)
 	if(!is_servant_of_ratvar(user))
 		user.DefaultCombatKnockdown(100)
@@ -322,7 +311,6 @@
 			user.adjustBruteLoss(rand(force/2,force))
 		return
 	..()
-
 /obj/item/melee/smith/hammer/debug
 	name = "debugging hammer"
 	desc = "A DEBUGGING HAMMER!! EPIC!!."


### PR DESCRIPTION
## About The Pull Request

no smithing weapons have 2 tile reach anymore

## Why It's Good For The Game

corner stabs, dungeon cheese, bodies strapped to chairs and more were all spurred forth by this stuff. the glaive's range is already removed, but this cements it by removing 2 tile reach from all smithing weapons as well.

## Changelog
:cl:
del: no more 2 tile reach on any melee weapons
/:cl: