### PR TITLE
BoS Hallway of death, plasmiglass, emitters, all gone

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -1182,17 +1182,9 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "bbV" = (
@@ -2207,18 +2199,22 @@
 	},
 /area/f13/tunnel)
 "bMe" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9
+	},
+/obj/machinery/recharger,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/machinery/camera/autoname{
-	dir = 8;
-	name = "Mess Hall Camera";
-	network = list("BoS");
-	pixel_x = -1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/operations)
 "bMq" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -3099,7 +3095,12 @@
 	},
 /area/f13/sewer)
 "cAB" = (
-/obj/structure/sign/poster/prewar/poster90,
+/obj/machinery/button/door{
+	id = "bosdoors";
+	name = "Bunker Lockdown Button";
+	pixel_x = -22;
+	req_access_txt = "120"
+	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "cBb" = (
@@ -4604,6 +4605,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/vehicle/ridden/janicart/upgraded,
+/obj/item/key/janitor,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dLK" = (
@@ -5419,6 +5422,12 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
 	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Mess Hall Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -5969,11 +5978,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "eJh" = (
-/obj/structure/chair/right{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/item/flag/bos,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/leisure)
 "eJi" = (
 /obj/structure/chair/office/dark,
@@ -6251,12 +6260,13 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
 "eVA" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "eWN" = (
@@ -6458,7 +6468,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood/operations)
 "feB" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowhorizontal"
@@ -6715,14 +6725,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "fnD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "fnS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -6772,8 +6785,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "fqK" = (
@@ -7192,24 +7205,13 @@
 	},
 /area/f13/clinic)
 "fIN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"fIV" = (
-/obj/effect/landmark/start/f13/Knight,
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
+/obj/structure/chair/f13foldupchair,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/effect/landmark/start/f13/Knight,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "fJt" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/sentrybot/nsb,
@@ -7732,10 +7734,7 @@
 /area/f13/bunker)
 "ggm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -7913,13 +7912,10 @@
 /area/f13/tunnel)
 "glq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -8286,7 +8282,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "gFv" = (
-/obj/structure/sign/warning/securearea,
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "gFP" = (
@@ -8319,9 +8315,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gHi" = (
-/obj/item/flag/bos,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
 "gId" = (
 /obj/structure/sign/warning/securearea{
@@ -8349,6 +8350,7 @@
 /area/f13/tunnel)
 "gKJ" = (
 /obj/effect/turf_decal/caution/stand_clear/white,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -8391,6 +8393,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -17601,6 +17604,12 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/machinery/button/door{
+	id = "bosdoors";
+	name = "Bunker Lockdown Button";
+	pixel_x = -22;
+	req_access_txt = "120"
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -17835,14 +17844,14 @@
 	},
 /area/f13/bunker)
 "oyk" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "oyG" = (
@@ -21709,19 +21718,10 @@
 	},
 /area/f13/followers)
 "rHV" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/pen/fountain,
-/obj/machinery/button/door{
-	id = "bosdoors";
-	name = "Bunker Lockdown Button";
-	pixel_x = -22;
-	req_access_txt = "120"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "rIl" = (
@@ -22688,19 +22688,11 @@
 	},
 /area/f13/bunker)
 "szW" = (
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/obj/machinery/recharger,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flag/bos,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "sAa" = (
@@ -24467,12 +24459,15 @@
 	},
 /area/f13/brotherhood/reactor)
 "urc" = (
-/obj/structure/chair/left{
-	dir = 8
+/obj/structure/table{
+	layer = 2.9
 	},
+/obj/item/storage/box/lights/tubes,
+/obj/item/storage/box/lights/bulbs,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/soap/homemade,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/operations)
 "urM" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -84679,7 +84674,7 @@ xrz
 xrz
 xrz
 xrz
-nWg
+fIN
 rAo
 rAo
 sDK
@@ -85446,7 +85441,7 @@ dSf
 xGp
 xGp
 epe
-xGp
+fnD
 xGp
 xGp
 xGp
@@ -85705,11 +85700,11 @@ gEZ
 gEZ
 gEZ
 eJh
-urc
-bMe
-eJh
-urc
-gHh
+xrz
+xrz
+cfA
+xrz
+xSi
 xSi
 yhd
 xSi
@@ -85961,12 +85956,12 @@ uoI
 ehz
 erF
 dSd
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gHi
+xSi
+xSi
+hhn
+gFv
+vgW
+xSi
 xSi
 yhd
 xSi
@@ -86218,10 +86213,10 @@ dBy
 ehT
 rSw
 xAn
-jJM
-fnD
-jJM
-jJM
+xSi
+xSi
+xSi
+gHi
 ggm
 gKJ
 xSi
@@ -86475,10 +86470,10 @@ dSr
 dMm
 esP
 eOx
+wOp
+wOp
 eVA
-eVA
-eVA
-eVA
+oyk
 glq
 gMX
 wOp
@@ -86731,14 +86726,14 @@ rSw
 rSw
 eiN
 exH
-gEZ
-gEZ
-gEZ
-gEZ
-fIN
-gEZ
-gEZ
+cAB
 vgW
+xSi
+xSi
+xSi
+xSi
+xSi
+xSi
 yhd
 xSi
 hpI
@@ -86991,10 +86986,10 @@ gEZ
 cAB
 szW
 bbO
-oyk
-fIV
+xSi
 rHV
-gFv
+rHV
+xSi
 xSi
 azD
 xSi
@@ -87246,12 +87241,12 @@ dTR
 xSi
 xSi
 slX
-xxn
-rFJ
-xxn
-xxn
-xxn
-slX
+xSi
+xSi
+xSi
+xSi
+xSi
+xSi
 xSi
 haW
 wOp
@@ -87503,12 +87498,12 @@ yhd
 xSi
 xSi
 slX
-xxn
+xSi
 fqz
-xxn
+bbs
 fqz
-xxn
-slX
+xSi
+xSi
 xSi
 yhd
 xSi
@@ -87755,7 +87750,7 @@ pXq
 pXq
 pXq
 pXq
-xSi
+bMe
 azD
 xSi
 xSi
@@ -91884,7 +91879,7 @@ xSi
 gEZ
 qpd
 dLF
-iAs
+urc
 iAs
 hPn
 oSq

--- a/_maps/map_files/Pahrump/old/Pahrump.dmm
+++ b/_maps/map_files/Pahrump/old/Pahrump.dmm
@@ -24130,10 +24130,6 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "bFb" = (
-/obj/item/circuitboard/machine/emitter/siege,
-/obj/item/circuitboard/machine/emitter/siege,
-/obj/item/circuitboard/machine/emitter/siege,
-/obj/item/circuitboard/machine/emitter/siege,
 /obj/structure/closet/crate/secure/weapon,
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel/dark,

--- a/code/datums/wires/emitter.dm
+++ b/code/datums/wires/emitter.dm
@@ -1,4 +1,4 @@
-
+/** Commented out to avoid BoS cheesing
 /datum/wires/emitter
 	holder_type = /obj/machinery/power/emitter
 	req_knowledge = JOB_SKILL_TRAINED
@@ -17,3 +17,4 @@
 			E.mode = !E.mode
 			E.set_projectile()
 	..()
+*/

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -1,11 +1,8 @@
 /* Glass stack types
  * Contains:
  *		Glass sheets
- *		Plasma glass
  *		Reinforced glass sheets
- *		Reinforced plasma glass
  *		Titanium glass
- *		Plastitanium glass
  *		Glass shards - TODO: Move this into code/game/object/item/weapons
  */
 
@@ -94,7 +91,7 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 		return ..()
 
 
-
+/**
 GLOBAL_LIST_INIT(pglass_recipes, list ( \
 	new/datum/stack_recipe("directional window", /obj/structure/window/plasma/unanchored, time = 0, on_floor = TRUE, window_checks = TRUE), \
 	new/datum/stack_recipe("fulltile window", /obj/structure/window/plasma/fulltile/unanchored, 2, time = 0, on_floor = TRUE, window_checks = TRUE) \
@@ -143,6 +140,8 @@ GLOBAL_LIST_INIT(pglass_recipes, list ( \
 /obj/item/stack/sheet/plasmaglass/on_solar_construction(obj/machinery/power/solar/S)
 	S.max_integrity *= 1.2
 	S.efficiency *= 1.2
+*/
+
 
 /*
  * Reinforced glass sheets
@@ -196,7 +195,7 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list ( \
 /obj/item/stack/sheet/rglass/get_main_recipes()
 	. = ..()
 	. += GLOB.reinforced_glass_recipes
-
+/**
 GLOBAL_LIST_INIT(prglass_recipes, list ( \
 	new/datum/stack_recipe("directional reinforced window", /obj/structure/window/plasma/reinforced/unanchored, time = 0, on_floor = TRUE, window_checks = TRUE), \
 	new/datum/stack_recipe("fulltile reinforced window", /obj/structure/window/plasma/reinforced/fulltile/unanchored, 2, time = 0, on_floor = TRUE, window_checks = TRUE) \
@@ -223,7 +222,7 @@ GLOBAL_LIST_INIT(prglass_recipes, list ( \
 /obj/item/stack/sheet/plasmarglass/on_solar_construction(obj/machinery/power/solar/S)
 	S.max_integrity *= 2.2
 	S.efficiency *= 1.2
-
+*/
 GLOBAL_LIST_INIT(titaniumglass_recipes, list(
 	new/datum/stack_recipe("shuttle window", /obj/structure/window/shuttle/unanchored, 2, time = 0, on_floor = TRUE, window_checks = TRUE)
 	))
@@ -247,7 +246,7 @@ GLOBAL_LIST_INIT(titaniumglass_recipes, list(
 /obj/item/stack/sheet/titaniumglass/on_solar_construction(obj/machinery/power/solar/S)
 	S.max_integrity *= 2.5
 	S.efficiency *= 1.5
-
+/**
 GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	new/datum/stack_recipe("plastitanium window", /obj/structure/window/plastitanium/unanchored, 2, time = 0, on_floor = TRUE, window_checks = TRUE)
 	))
@@ -270,7 +269,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 /obj/item/stack/sheet/plastitaniumglass/get_main_recipes()
 	. = ..()
 	. += GLOB.plastitaniumglass_recipes
-
+*/
 /obj/item/stack/sheet/titaniumglass/on_solar_construction(obj/machinery/power/solar/S)
 	S.max_integrity *= 2
 	S.efficiency *= 2
@@ -379,7 +378,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 		else
 			playsound(loc, 'sound/effects/glass_step.ogg', 50, 1)
 	return ..()
-
+/**
 /obj/item/shard/plasma
 	name = "purple shard"
 	desc = "A nasty looking shard of plasma glass."
@@ -392,3 +391,4 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 /obj/item/shard/plasma/alien
 	name = "alien shard"
 	desc = "A nasty looking shard of advanced alloy glass."
+*/	


### PR DESCRIPTION
They all go bye bye

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR is meant to change the layout of the BoS Bunker to be FAR less defendable, it was stupidly defendable before. Now, BoS have to WORK to defend their base. In addition, the cheese tactics of plasmaglass and emitters have been removed, their codes set to not work. No one used these but the BoS anyhow usually.

Map changes: https://i.imgur.com/hsKBH7U.png

## Why It's Good For The Game

BoS is hard enough to fight currently with the Power armor and extra strong weapons. Giving them a hallway of death they can camp forever doesn't work so well for interesting raids. So far, raiding them from behind by meta'ing their bunker location is the only viable tactic. This changes that, BoS still have a ladder they can defend, but no hallway of death giving them the chance to just go BRRRRR and mow down anyone coming down the ladder with stacks of plasmiglass and emitters.

## Changelog
:cl:
add: Added new ladder area to BoS bunker
del: BoS bunker hallway of death to their ladders
del: Commented out code for plasmiglass (and that titanium plasmiglass mix) and emitters, ready to be re-enabled however.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
