### PR TITLE
[DRAFT: Still needs more work & help] Smelling salt bugfix

### DIFF
--- a/code/modules/fallout/obj/smelling_salts.dm
+++ b/code/modules/fallout/obj/smelling_salts.dm
@@ -5,7 +5,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	icon = 'icons/obj/fallout/smelling_salts.dmi'
 	icon_state = "smelling_salts_legion"
-	var/charges = 8 // a bit lower than a normal defib's 10
+	var/charges = 20
 	var/in_use = FALSE
 	var/time_to_use = 10 SECONDS // a defib is 5 seconds
 
@@ -23,7 +23,7 @@
 	w_class = WEIGHT_CLASS_SMALL // unsure about this balance-wise, given that defibs are bulky
 	desc = "A stoppered glass phial of pungent smelling salts, used to revive those who have fainted."
 	icon_state = "smelling_salts_crafted"
-	charges = 2 // quarter of the premade smelling salts
+	charges = 10
 
 /obj/item/smelling_salts/attack(mob/target, mob/user)
 	if(in_use)

--- a/code/modules/fallout/obj/smelling_salts.dm
+++ b/code/modules/fallout/obj/smelling_salts.dm
@@ -26,9 +26,6 @@
 	charges = 2 // quarter of the premade smelling salts
 
 /obj/item/smelling_salts/attack(mob/target, mob/user)
-	if(in_use == TRUE)
-		to_chat(user, "<span class='warning'>I can't do that right now, they are already recieving smelling salts.</span>")
-		return
 	if(world.time < time_to_use)
 		to_chat(user, "<span class='warning'>They are not ready smell something so pungent yet, I should wait a moment.</span>")
 		return
@@ -74,7 +71,6 @@
 	return TRUE
 
 /obj/item/smelling_salts/proc/do_revive(mob/living/carbon/revived_mob, mob/living/user)
-	in_use = TRUE
 	if(!do_after(user, time_to_use, target = revived_mob))
 		return
 	user.visible_message(SPAN_NOTICE("[user] starts waving [src] under [revived_mob]'s nose."), SPAN_WARNING("You wave [src] under [revived_mob]'s nose."))
@@ -137,4 +133,3 @@
 		to_chat(revived_mob, policy)
 	revived_mob.log_message("revived using strange reagent, [time_since_death / 10] seconds from time of death, considered [late? "late" : "memory-intact"] revival under configured policy limits.", LOG_GAME)
 	//add_logs(user, revived_mob, "revived (smelling salts)", src)
-	in_use = FALSE

--- a/code/modules/fallout/obj/smelling_salts.dm
+++ b/code/modules/fallout/obj/smelling_salts.dm
@@ -26,6 +26,8 @@
 	charges = 2 // quarter of the premade smelling salts
 
 /obj/item/smelling_salts/attack(mob/target, mob/user)
+	if(in_use)
+		return
 	if(world.time < time_to_use)
 		to_chat(user, "<span class='warning'>They are not ready smell something so pungent yet, I should wait a moment.</span>")
 		return
@@ -71,7 +73,9 @@
 	return TRUE
 
 /obj/item/smelling_salts/proc/do_revive(mob/living/carbon/revived_mob, mob/living/user)
+	in_use = TRUE
 	if(!do_after(user, time_to_use, target = revived_mob))
+		in_use = FALSE
 		return
 	user.visible_message(SPAN_NOTICE("[user] starts waving [src] under [revived_mob]'s nose."), SPAN_WARNING("You wave [src] under [revived_mob]'s nose."))
 	var/time_since_death = world.time - revived_mob.timeofdeath
@@ -133,3 +137,4 @@
 		to_chat(revived_mob, policy)
 	revived_mob.log_message("revived using strange reagent, [time_since_death / 10] seconds from time of death, considered [late? "late" : "memory-intact"] revival under configured policy limits.", LOG_GAME)
 	//add_logs(user, revived_mob, "revived (smelling salts)", src)
+	in_use = FALSE


### PR DESCRIPTION
Ill forgoe a usual setup because this is a unusually presented WIP PR.

## Problem

When used, smelling salts would break on a interruption, then remain on IN_USE = TRUE continously blocking additional attempts to use it.

## What i have attempted already

Generally multiple attempts to try and keep the changes already here (which i've simplified in the commit) with the IN_USE = TRUE offending code variables removed in my personal debugging sessions (which is part of the solution)

## Other notes

Im generally expended on poking this any more and am out of options of what to do within my technical capability. Kelo can still flip this into a PR and merge if they want and can take hold of the problem the code has.

- The effect of this commit is that the interruption bug is fixed, but the cooldowns are inactive and un-functional, you can click people multiple times to do a defib.

- This is a problem because every time you activate it, it removes charges-- leading to eventual qdeletion, it could also be used to spam ghosts.

- Some of the personal unpublished debug attempts would excasperbate this even more with effects like smelling salts reviving people while you walked away from them.