### PR TITLE
Ports shutter fixes from TG, adds window shutters, tweaks values

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -121,7 +121,7 @@
 /datum/crafting_recipe/rip
 	category = CAT_MISC
 	subcategory = CAT_FURNITURE
-	
+
 /datum/crafting_recipe/rip/gravemarker
 	name = "Gravemarker"
 	result = /obj/structure/statue/wood/headstonewood
@@ -182,7 +182,7 @@
 	tools = list(TOOL_SCREWDRIVER, TOOL_WRENCH, TOOL_WELDER)
 
 
-/datum/crafting_recipe/shutters
+/datum/crafting_recipe/shutters/old
 	name = "Shutters"
 	reqs = list(/obj/item/stack/sheet/plasteel = 10, //5x as expensive as a reinforced wall, can be destroyed by mid-tier guns or high-tier melee. More useful to townies/comfy roles then for NCR/Legion.
 				/obj/item/stack/cable_coil = 10,
@@ -203,6 +203,19 @@
 	result = /obj/machinery/door/poddoor/preopen
 	tools = list(TOOL_SCREWDRIVER, TOOL_MULTITOOL, TOOL_WIRECUTTER, TOOL_WELDER)
 	time = 30 SECONDS
+	subcategory = CAT_MISCELLANEOUS
+	category = CAT_MISC
+
+/datum/crafting_recipe/shutters/window
+	name = "Windowed Shutters"
+	reqs = list(/obj/item/stack/sheet/plasteel = 5,
+				/obj/item/stack/sheet/rglass = 10,
+				/obj/item/stack/cable_coil = 10,
+				/obj/item/electronics/airlock = 1
+				)
+	result = /obj/machinery/door/poddoor/shutters/window/preopen
+	tools = list(TOOL_SCREWDRIVER, TOOL_MULTITOOL, TOOL_WIRECUTTER, TOOL_WELDER)
+	time = 15 SECONDS
 	subcategory = CAT_MISCELLANEOUS
 	category = CAT_MISC
 

--- a/code/game/machinery/doors/city_gate.dm
+++ b/code/game/machinery/doors/city_gate.dm
@@ -7,6 +7,7 @@
 	id = 333
 	bound_width = 96
 	var/list/opacity_objects = list() //FUCK BYOND
+	ertblast = TRUE
 
 /obj/machinery/door/poddoor/gate/preopen
 	icon_state = "open"

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -1,3 +1,9 @@
+
+//blast door (de)construction states
+#define BLASTDOOR_NEEDS_WIRES 0
+#define BLASTDOOR_NEEDS_ELECTRONICS 1
+#define BLASTDOOR_FINISHED 2
+
 /obj/machinery/door/poddoor
 	name = "blast door"
 	desc = "A heavy duty blast door that opens mechanically."
@@ -13,17 +19,18 @@
 	max_integrity = 600
 	armor = list("melee" = 50, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 65, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF
-	damage_deflection = 73 // nothing short of an explosive/energy axe is getting through
+	damage_deflection = 73
 	proj_resist = 100
-	poddoor = TRUE
 
-var/ertblast = FALSE //If this is true the blast door cannot be deconstructed
-var/deconstruction = INTACT //For the deconstruction steps
+	var/datum/crafting_recipe/recipe_type = /datum/crafting_recipe/blast_doors
+	var/deconstruction = BLASTDOOR_FINISHED // deconstruction step
+	var/ertblast = FALSE
 
 /obj/machinery/door/poddoor/attackby(obj/item/W, mob/user, params)
 	. = ..()
-	if(ertblast && W.tool_behaviour == TOOL_SCREWDRIVER) // This makes it so ERT members cannot cheese by opening their blast doors.
-		to_chat(user, "<span class='warning'>This shutter has a different kind of screw, you cannot unscrew the panel open.</span>")
+
+	if(ertblast && W.tool_behaviour == TOOL_SCREWDRIVER)
+		to_chat(user, "<span class='warning'>[src] lacks a maintenance hatch, it cannot be modified!</span")
 		return
 
 	if(W.tool_behaviour == TOOL_SCREWDRIVER)
@@ -34,48 +41,62 @@ var/deconstruction = INTACT //For the deconstruction steps
 			to_chat(user, "<span class='notice'>You [panel_open ? "open" : "close"] the maintenance hatch of [src].</span>")
 			return TRUE
 
-	if(panel_open)
-		if(W.tool_behaviour == TOOL_MULTITOOL)
+	if(panel_open && density == FALSE)
+		if(W.tool_behaviour == TOOL_MULTITOOL && deconstruction == BLASTDOOR_FINISHED)
 			var/change_id = input("Set the shutters/blast door/blast door controllers ID. It must be a number between 1 and 100.", "ID", id) as num|null
 			if(change_id)
 				id = clamp(round(change_id, 1), 1, 100)
 				to_chat(user, "<span class='notice'>You change the ID to [id].</span>")
 
-		if(W.tool_behaviour == TOOL_CROWBAR && deconstruction == INTACT)
+		else if(W.tool_behaviour == TOOL_CROWBAR && deconstruction == BLASTDOOR_FINISHED)
 			to_chat(user, "<span class='notice'>You start to remove the airlock electronics.</span>")
 			if(do_after(user, 10 SECONDS, target = src))
 				new /obj/item/electronics/airlock(loc)
 				id = null
-				deconstruction = FALSE
+				deconstruction = BLASTDOOR_NEEDS_ELECTRONICS
 
-		if(W.tool_behaviour == TOOL_WIRECUTTER && deconstruction == FALSE)
+		else if(W.tool_behaviour == TOOL_WIRECUTTER && deconstruction == BLASTDOOR_NEEDS_ELECTRONICS)
 			to_chat(user, "<span class='notice'>You start to remove the internal cables.</span>")
 			if(do_after(user, 10 SECONDS, target = src))
-				deconstruction = TRUE
+				var/datum/crafting_recipe/recipe = locate(recipe_type) in GLOB.crafting_recipes
+				var/amount = recipe.reqs[/obj/item/stack/cable_coil]
+				new /obj/item/stack/cable_coil(loc, amount)
+				deconstruction = BLASTDOOR_NEEDS_WIRES
 
-		if(W.tool_behaviour == TOOL_WELDER && deconstruction == TRUE)
+		else if(W.tool_behaviour == TOOL_WELDER && deconstruction == BLASTDOOR_NEEDS_WIRES)
+			if(!W.tool_start_check(user, amount=0))
+				return
+
 			to_chat(user, "<span class='notice'>You start tearing apart the [src].</span>")
 			playsound(src.loc, 'sound/items/welder.ogg', 50, 1)
 			if(do_after(user, 15 SECONDS, target = src))
-				new /obj/item/stack/sheet/plasteel(loc, 5)
+				var/datum/crafting_recipe/recipe = locate(recipe_type) in GLOB.crafting_recipes
+				var/amount = recipe.reqs[/obj/item/stack/sheet/plasteel]
+				new /obj/item/stack/sheet/plasteel(loc, amount - rand(1,4))
 				qdel(src)
 
 /obj/machinery/door/poddoor/examine(mob/user)
 	. = ..()
 	if(panel_open)
-		. += "<span class='<span class='notice'>The maintenance panel is [panel_open ? "opened" : "closed"].</span>"
+		if(deconstruction == BLASTDOOR_FINISHED)
+			. += "<span class='notice'>The maintenance panel is opened and the electronics could be <b>pried</b> out.</span>"
+		else if(deconstruction == BLASTDOOR_NEEDS_ELECTRONICS)
+			. += "<span class='notice'>The <i>electronics</i> are missing and there are some <b>wires</b> sticking out.</span>"
+		else if(deconstruction == BLASTDOOR_NEEDS_WIRES)
+			. += "<span class='notice'>The <i>wires</i> have been removed and it's ready to be <b>sliced apart</b>.</span>"
 
-
-/obj/machinery/door/poddoor/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
-	id = "[idnum][id]"
+/obj/machinery/door/poddoor/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
+	id = "[port.id]_[id]"
 
 /obj/machinery/door/poddoor/preopen
 	icon_state = "open"
 	density = FALSE
-	opacity = 0
+	opacity = FALSE
 
 /obj/machinery/door/poddoor/ert
+	name = "hardened blast door"
 	desc = "A heavy duty blast door that only opens for dire emergencies."
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 //special poddoors that open when emergency shuttle docks at centcom
 /obj/machinery/door/poddoor/shuttledock

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -9,6 +9,7 @@
 	damage_deflection = 26 //fragile, but will block weak melee weapons
 	max_integrity = 200
 	proj_resist = 16 //fragile, blocks .22s
+	recipe_type = /datum/crafting_recipe/shutters
 
 /obj/machinery/door/poddoor/shutters/preopen
 	icon_state = "open"
@@ -22,10 +23,10 @@
 
 /obj/machinery/door/poddoor/shutters/old //"old" only in code and sprite. In-game these should be brand new.
 	name = "strong shutters"
-	desc = "A plan grey security shutter, it looks to be moderately reinforced. Mag-locks keep the shutter securely in place."
+	desc = "A plain grey security shutter, it looks to be moderately reinforced. Mag-locks keep the shutter securely in place."
 	icon = 'icons/obj/doors/shutters_old.dmi'
 	icon_state = "closed"
-	armor = list("melee" = 40, "bullet" = 45, "laser" = 45, "energy" = 75, "bomb" = 40, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70)
+	armor = list("melee" = 40, "bullet" = 50, "laser" = 50, "energy" = 75, "bomb" = 40, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70)
 	max_integrity = 350
 	damage_deflection = 36 //stronger, will block most one-handed melee weapons
 	proj_resist = 30 // will block weaker pistol/scattershot projectiles, though most faction weapons will get through
@@ -62,11 +63,16 @@
 
 /obj/machinery/door/poddoor/shutters/window
 	name = "windowed shutters"
-	desc = "Mechanical shutters that have some form of plastic window in them, allowing you to see through the shutters at all times."
+	desc = "Mechanical shutters that have a thick piece of ballistic glass in the middle, allowing you to see through the shutters at all times."
 	icon = 'icons/obj/doors/shutters_window.dmi'
 	icon_state = "closed"
+	armor = list("melee" = 25, "bullet" = 50, "laser" = 60, "energy" = 80, "bomb" = 30, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70)
+	max_integrity = 300
+	damage_deflection = 26 // weaker against melee
+	proj_resist = 28
 	opacity = 0
 	glass = 1
+	recipe_type = /datum/crafting_recipe/shutters/window
 
 /obj/machinery/door/poddoor/shutters/window/preopen
 	icon_state = "open"


### PR DESCRIPTION
## Description: 

A few things were broken/misplaced from #88, this ports [this PR from TG here](https://github.com/tgstation/tgstation/pull/58231)

## Why It's Good For The Game

Shutters can't be deconstructed whilst closed, or without completing their deconstruction steps, also adds TG's window-shutter into the crafting menu for all your quartermaster gimmickry. I'm not a coder, though, so there might be issues.

## Changelog
:cl:
add: Adds a recipe for a transparent 'window shutter', credits to TG for the sprite and animation
tweak: Slightly changed a few armor values
/:cl:


