### PR TITLE
Makes Service Rifle more expensive

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -580,9 +580,9 @@
 	name = "Service Rifle 5.56mm"
 	result = /obj/item/gun/ballistic/automatic/service
 	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/crafting/metalparts = 5,
+				/obj/item/stack/crafting/metalparts = 8,
 				/obj/item/stack/sheet/mineral/wood = 5,
-				/obj/item/stack/crafting/goodparts = 2
+				/obj/item/stack/crafting/goodparts = 4
 				)
 	tools = list(TOOL_WORKBENCH)
 	time = 120


### PR DESCRIPTION
After the NCR changes it turns out that the service rifle is a little bit too easy to craft, which means the NCR doesn't need to spend that much time out of base to equip everyone with Improved Service Rifles. This PR will make it more expensive but still a little bit below the burst fire scout carbine. It should force the NCR to get out and scavenge more before they all run SRs.