### PR TITLE
Removes elder slots

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -56,8 +56,8 @@ Elder
 
 	exp_requirements = 3000
 
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 
 	outfit = /datum/outfit/job/bos/f13elder
 


### PR DESCRIPTION
The BoS elder slot is not a role that should always be present or is really even needed outside of certain situations, so I put it back to zero. The current leadership roles the BoS has is more than sufficient to effectively lead the faction and having another one always around is just kinda unnecessary and will mess things up.