### PR TITLE
Followers RnD addition

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -136,7 +136,7 @@
 /turf/open/water,
 /area/f13/tunnel)
 "aeS" = (
-/obj/structure/frame/machine,
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -15036,6 +15036,14 @@
 "mps" = (
 /turf/closed/wall,
 /area/f13/bunker)
+"mpt" = (
+/obj/machinery/computer/rdconsole/core/followers{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "mpA" = (
 /mob/living/simple_animal/hostile/raider/firefighter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -20987,6 +20995,12 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"rkV" = (
+/obj/machinery/rnd/production/protolathe,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "rkW" = (
 /obj/structure/wreck/trash/five_tires,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24501,6 +24515,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"uCT" = (
+/obj/machinery/rnd/server/followers,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "uDa" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line,
@@ -49990,12 +50010,12 @@ jlt
 cuB
 tFc
 oFg
-tKU
+uCT
 tKU
 tKU
 aeS
-aeS
-aeS
+mpt
+rkV
 vCM
 tKU
 tKU

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -136,7 +136,8 @@
 /turf/open/water,
 /area/f13/tunnel)
 "aeS" = (
-/obj/machinery/rnd/production/circuit_imprinter,
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/circuit_imprinter,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -20996,7 +20997,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "rkV" = (
-/obj/machinery/rnd/production/protolathe,
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/techfab/department/medical,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -28,6 +28,7 @@ SUBSYSTEM_DEF(research)
 	var/list/obj/machinery/rnd/server/servers = list()
 	var/list/obj/machinery/rnd/server/VAULTservers = list()
 	var/list/obj/machinery/rnd/server/BOSservers = list()
+	var/list/obj/machinery/rnd/server/FOLLOWERSservers = list()
 
 
 	var/list/techweb_nodes_starting = list()	//associative id = TRUE
@@ -300,6 +301,7 @@ SUBSYSTEM_DEF(research)
 	//----------------------------------------------
 	var/list/BOSsingle_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 7)	//citadel edit - techwebs nerf
 	var/list/VAULTsingle_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 35)
+	var/list/FOLLOWERSsingle_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 7)
 	var/multiserver_calculation = FALSE
 	var/last_income
 	//^^^^^^^^ ALL OF THESE ARE PER SECOND! ^^^^^^^^
@@ -350,6 +352,7 @@ SUBSYSTEM_DEF(research)
 	var/list/bitcoins = list()
 	var/list/BOSbitcoins = list()
 	var/list/VAULTbitcoins = list()
+	var/list/FOLLOWERSbitcoins = list()
 	if(multiserver_calculation)
 		var/eff = calculate_server_coefficient()
 		for(var/obj/machinery/rnd/server/miner in servers)
@@ -365,9 +368,14 @@ SUBSYSTEM_DEF(research)
 		for(var/obj/machinery/rnd/server/miner in VAULTservers)
 			if(miner.working)
 				VAULTbitcoins = VAULTsingle_server_income.Copy()
-				break	
+				break
+
+		for(var/obj/machinery/rnd/server/miner in FOLLOWERSservers)
+			if(miner.working)
+				FOLLOWERSbitcoins = FOLLOWERSsingle_server_income.Copy()
+				break
 	var/income_time_difference = world.time - last_income
-		
+
 	science_tech.last_bitcoins = VAULTbitcoins  // Doesn't take tick drift into account
 	bos_tech.last_bitcoins = BOSbitcoins
 	unknown_tech.last_bitcoins = bitcoins
@@ -380,10 +388,13 @@ SUBSYSTEM_DEF(research)
 	for(var/i in VAULTbitcoins)
 		VAULTbitcoins[i] *= income_time_difference / 10
 
+	for(var/i in FOLLOWERSbitcoins)
+		FOLLOWERSbitcoins[i] *= income_time_difference / 10
+
 	science_tech.add_point_list(VAULTbitcoins)
 	bos_tech.add_point_list(BOSbitcoins)
 	unknown_tech.add_point_list(bitcoins) //tbh these guys can get a fuckton of points, because it isn't even being used
-	followers_tech.add_point_list(bitcoins)
+	followers_tech.add_point_list(FOLLOWERSbitcoins)
 
 	last_income = world.time
 

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -180,7 +180,7 @@
 
 /obj/machinery/rnd/server/followers/Initialize()
 	. = ..()
-	SSresearch.VAULTservers |= src
+	SSresearch.FOLLOWERSservers |= src
 	stored_research = SSresearch.followers_tech
 	var/obj/item/circuitboard/machine/B = new /obj/item/circuitboard/machine/rdserver(null)
 	B.apply_default_parts(src)


### PR DESCRIPTION
## About The Pull Request

Adds Research to the Follower's Underground area.

## Why It's Good For The Game
It simply allows the Followers to treat their patients more efficiently and allows them to do what they are supposed to do - research for the betterment of the wasteland.  :) 

## Commit Update
Disallows the Followers to use the ores from the BoS and others and also replaces the lathe with a medical board to prevent printing of nonmedical stuff 😔 

## Changelog
:cl:
add: Put the RnD stuff in the followers.
add: The ability for the Follower's RnD set to create points.
/:cl: