### PR TITLE
Tribal Language and clothing fixes.

### DIFF
--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -26,6 +26,7 @@
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	ADD_TRAIT(H, TRAIT_TRAPPER, src)
 	ADD_TRAIT(H, TRAIT_MACHINE_SPIRITS, src)
+	H.grant_language(/datum/language/tribal)
 
 /*
 Tribal Chief

--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -56,18 +56,19 @@ Tribal Chief
 	..()
 	if(visualsOnly)
 		return
+	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
 	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
 
 /datum/outfit/job/tribal/f13chief
 	name = "Chief"
 	jobtype = /datum/job/tribal/f13chief
 	head = 			/obj/item/clothing/head/helmet/f13/wayfarer/chief/green
-	uniform = 		/obj/item/clothing/under/f13/tribe_chief
+	uniform = 		/obj/item/clothing/under/f13/wayfarer
 	belt = 			/obj/item/storage/backpack/spearquiver
 	neck =			/obj/item/clothing/neck/cloak/chiefcloak
 	id = 			/obj/item/card/id/tribetattoo
-	suit =			/obj/item/clothing/suit/armor/f13/tribe_armor
-	suit_store =	/obj/item/twohanded/spear/bonespear/deathclaw
+	suit =			/obj/item/clothing/suit/hooded/cloak/hhunter
+	suit_store =	/obj/item/melee/transforming/cleaving_saw
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola=1,
 		/obj/item/reagent_containers/pill/patch/healingpowder=2,
@@ -337,6 +338,7 @@ Hunter
 	if(visualsOnly)
 		return
 	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
+	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
 
 /datum/outfit/job/tribal/f13hunter
 	name = "Hunter"
@@ -391,5 +393,5 @@ Spirit-Pledged
 /datum/outfit/job/tribal/f13spiritpledged
 	name = "Spirit-Pledged"
 	jobtype = /datum/job/tribal/f13spiritpledged
-	uniform =	/obj/item/clothing/under/f13/tribe
+	uniform =	/obj/item/clothing/under/f13/wayfarer
 	id = 		/obj/item/card/id/tribetattoo

--- a/code/modules/language/wayfarer.dm
+++ b/code/modules/language/wayfarer.dm
@@ -1,6 +1,6 @@
-/datum/language/wayfarer
-	name = "Wayfarer"
-	desc = "The language spoken by members of the Wayfarer tribe, boasting a complex system of phonemes and alien grammar. An expert ear of a researcher may notice the vague resemblance to the Indo-European language family."
+/datum/language/tribal
+	name = "Tribal"
+	desc = "The language spoken by members of the local tribe, boasting a complex system of phonemes and mixed grammar."
 	key = "w"
 	syllables = list(
 	"pa", "pe", "pi","pa", "pe", "pi","pr", "bm",

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -25,6 +25,7 @@
 		/datum/language/slime,
 		/datum/language/vampiric,
 		/datum/language/dwarf,
+		/datum/language/tribal,
 	))
 	healing_factor = STANDARD_ORGAN_HEALING*5 //Fast!!
 	decay_factor = STANDARD_ORGAN_DECAY/2


### PR DESCRIPTION
ports tribe talk from DR

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Essentially ports over the tribal language from DR as well as balances some loadouts in the Tribe, mostly just Chief.

## Why It's Good For The Game

Gives tribals their own personal language to communicate with each other, as well as adding a bit more character toward the faction from an RP standpoint. The ability to talk will be in the language option menu for all tribals on round start, and it can toggle on or off with the click of a button or simple ",w" that will speak the message. 

Also changes out some of the old tribal apparel that really needed to go with some of the newer sprites we got to keep everyone in proper uniform, as well as giving the head honcho of the faction (Chief) an actual fucking weapon to use in PvE situations, or in general, as current state glavies were supposed to be reverted but have yet (ill get around to fixing that soon.)

## Changelog
:cl:
add: Tribal language
tweak: tribal apperals
balance: chief loadout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
