### PR TITLE
Captain loadout change

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -132,7 +132,7 @@ Captain
 	name = "Armored Officer"
 	suit 		= /obj/item/clothing/suit/armor/f13/ncrarmor/captain
 	belt 		= /obj/item/storage/belt/military/assault/ncr
-	l_hand 		= /obj/item/gun/ballistic/automatic/service/automatic
+	l_hand 		= /obj/item/gun/ballistic/automatic/assault_rifle
 	backpack_contents = list(
 	/obj/item/ammo_box/magazine/m556/rifle/assault=3,
 	/obj/item/gun/ballistic/automatic/pistol/deagle=1,


### PR DESCRIPTION
Both have the R91 now

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

M16 was not planned with the tinkering system in mind, mistakes were made, this should balance it a bit now.

## Why It's Good For The Game

The M16 in the captain loadout combined with the tinkering made a great gun insanely OP... and Captains would lose it mostly and then NCR would get very mad. This fixes the problem by now making the M16 an admin only spawn.

## Changelog
:cl:
tweak: tweaked NCR Captain loadouts to both have R91s instead of one having an M16

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
